### PR TITLE
Fix default pager for CentOS and openSUSE builds

### DIFF
--- a/builder/Dockerfile.centos-6
+++ b/builder/Dockerfile.centos-6
@@ -17,7 +17,6 @@ RUN yum -y update \
     krb5-devel \
     krb5-libs \
     lapack-devel \
-    less \
     libICE-devel \
     libSM-devel \
     libX11-devel \

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -16,7 +16,6 @@ RUN yum -y update \
     java-1.8.0-openjdk-devel \
     java-1.8.0-openjdk-headless \
     lapack-devel \
-    less \
     libICE-devel \
     libSM-devel \
     libX11-devel \

--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -13,5 +13,8 @@ RUN pip install awscli
 
 RUN chmod 0777 /opt
 
+# Override the default pager used by R
+ENV PAGER /usr/bin/pager
+
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/Dockerfile.ubuntu-1604
+++ b/builder/Dockerfile.ubuntu-1604
@@ -13,5 +13,8 @@ RUN pip install awscli
 
 RUN chmod 0777 /opt
 
+# Override the default pager used by R
+ENV PAGER /usr/bin/pager
+
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -13,5 +13,8 @@ RUN pip install awscli
 
 RUN chmod 0777 /opt
 
+# Override the default pager used by R
+ENV PAGER /usr/bin/pager
+
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -73,7 +73,6 @@ compile_r() {
   # set some common environment variables for the configure step
   AWK=/usr/bin/awk \
   LIBnn=lib \
-  PAGER=/usr/bin/pager \
   PERL=/usr/bin/perl \
   R_PDFVIEWER=xdg-open \
   R_BROWSER=xdg-open \


### PR DESCRIPTION
Fixes #3

This makes the `PAGER` override apply to Ubuntu/Debian builds only. The configure script should now pick up valid pagers for the other OSs, which will either be `less` or `more`.

I also removed the `less` dependency for CentOS so it doesn't become a requirement to use R.