### PR TITLE
Update BLAS libraries

### DIFF
--- a/builder/Dockerfile.centos-6
+++ b/builder/Dockerfile.centos-6
@@ -4,8 +4,6 @@ ENV OS_IDENTIFIER centos-6
 
 RUN yum -y update \
     && yum -y install \
-    atlas-devel \
-    blas-devel \
     bzip2-devel \
     cairo-devel \
     gcc-c++ \
@@ -16,7 +14,6 @@ RUN yum -y update \
     java-1.8.0-openjdk-devel \
     krb5-devel \
     krb5-libs \
-    lapack-devel \
     libICE-devel \
     libSM-devel \
     libX11-devel \
@@ -184,7 +181,6 @@ ENV CONFIGURE_OPTIONS="\
     --with-system-valgrind-headers \
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
-    --enable-BLAS-shlib \
     --enable-prebuilt-html"
 
 # RHEL 6 doesn't have texi2any, so use makeinfo.

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -4,10 +4,8 @@ ENV OS_IDENTIFIER centos-7
 
 RUN yum -y update \
     && yum -y install \
-    atlas-devel \
     autoconf \
     automake \
-    blas-devel \
     bzip2-devel \
     cairo-devel \
     gcc-c++ \
@@ -15,7 +13,6 @@ RUN yum -y update \
     gcc-objc \
     java-1.8.0-openjdk-devel \
     java-1.8.0-openjdk-headless \
-    lapack-devel \
     libICE-devel \
     libSM-devel \
     libX11-devel \
@@ -64,7 +61,6 @@ ENV CONFIGURE_OPTIONS="\
     --with-system-valgrind-headers \
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
-    --enable-BLAS-shlib \
     --enable-prebuilt-html"
 
 # RHEL 7 doesn't have the inconsolata font, so override the defaults.

--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -6,7 +6,7 @@ RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list \
   && apt-get update \
-  && apt-get install -y libatlas3-base libcurl4-openssl-dev libicu-dev wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev wget python-pip \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli

--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -6,7 +6,7 @@ RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli

--- a/builder/Dockerfile.opensuse-15
+++ b/builder/Dockerfile.opensuse-15
@@ -8,8 +8,6 @@ ENV OS_IDENTIFIER opensuse-15
 
 RUN zypper --non-interactive update
 RUN zypper --non-interactive --gpg-auto-import-keys -n install \
-    atlascpp-devel \
-    blas-devel \
     bzip2 \
     cairo-devel \
     fdupes \
@@ -20,7 +18,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     glibc-locale \
     help2man \
     java-1_8_0-openjdk-devel \
-    lapack-devel \
     libX11-devel \
     libXScrnSaver-devel \
     libXmu-devel \
@@ -70,8 +67,6 @@ RUN chmod 0777 /opt
 # Configure flags for SUSE that don't use the defaults in build.sh
 ENV CONFIGURE_OPTIONS="\
     --enable-R-shlib \
-    --with-blas \
-    --with-lapack \
     --with-tcltk \
     --with-x \
     --enable-memory-profiling \

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -8,8 +8,6 @@ ENV OS_IDENTIFIER opensuse-42
 
 RUN zypper --non-interactive update
 RUN zypper --non-interactive --gpg-auto-import-keys -n install \
-    atlascpp-devel \
-    blas-devel \
     bzip2 \
     cairo-devel \
     fdupes \
@@ -20,7 +18,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     glibc-locale \
     help2man \
     java-1_8_0-openjdk-devel \
-    lapack-devel \
     libX11-devel \
     libXScrnSaver-devel \
     libXmu-devel \
@@ -73,8 +70,6 @@ ENV MAKEINFO=makeinfo
 # Configure flags for SUSE that don't use the defaults in build.sh
 ENV CONFIGURE_OPTIONS="\
     --enable-R-shlib \
-    --with-blas \
-    --with-lapack \
     --with-tcltk \
     --with-x \
     --enable-memory-profiling \

--- a/builder/Dockerfile.ubuntu-1604
+++ b/builder/Dockerfile.ubuntu-1604
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libatlas3-base libcurl4-openssl-dev libicu-dev wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev wget python-pip \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli

--- a/builder/Dockerfile.ubuntu-1604
+++ b/builder/Dockerfile.ubuntu-1604
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libatlas3-base libcurl4-openssl-dev libicu-dev wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev wget python-pip \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli


### PR DESCRIPTION
Updates to build R with a generic BLAS library that can be swapped out for OpenBLAS (or other library).

**CentOS**
Use shared BLAS to match the CentOS/EPEL default R. The CentOS builds were already using shared BLAS before, so I just removed unused libraries and a redundant config flag.

**openSUSE**
Use shared BLAS to match the openSUSE default R. The openSUSE builds were using an external reference BLAS before.

**Ubuntu and Debian**
Continue using the generic external BLAS since the Ubuntu/Debian convention is to use the alternatives system to switch BLAS. I just replaced ATLAS with OpenBLAS to be safe, but either way, R links against the generic libblas.so.3 and liblapack.so.3.

---

To test this, I built R 3.1, 3.5, and 3.6 on each distro and checked that R was using either shared BLAS (libRblas.so) or generic external BLAS (libblas.so.3):

Test output:

```bash
# Debian 9
root@56a0c6520da1:/# ldd /opt/R/3.1.3/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007f15bf504000)
	libopenblas.so.0 => /usr/lib/libopenblas.so.0 (0x00007f15bb2b6000)
root@56a0c6520da1:/# ldd /opt/R/3.5.3/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007fe4a2956000)
	libopenblas.so.0 => /usr/lib/libopenblas.so.0 (0x00007fe49e06b000)
root@56a0c6520da1:/# ldd /opt/R/3.6.0/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007ff070ebb000)
	libopenblas.so.0 => /usr/lib/libopenblas.so.0 (0x00007ff06c5d0000)

# Ubuntu 16
root@71e84b8248ae:/# ldd /opt/R/3.1.3/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007fbfdd83c000)
	libopenblas.so.0 => /usr/lib/libopenblas.so.0 (0x00007fbfd9c2c000)
root@71e84b8248ae:/# ldd /opt/R/3.5.3/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007f9a5d0ea000)
	libopenblas.so.0 => /usr/lib/libopenblas.so.0 (0x00007f9a58e40000)
root@71e84b8248ae:/# ldd /opt/R/3.6.0/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007f078e5cd000)
	libopenblas.so.0 => /usr/lib/libopenblas.so.0 (0x00007f078a323000)

# Ubuntu 18
root@8e032c468a86:/# ldd /opt/R/3.1.3/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/x86_64-linux-gnu/libblas.so.3 (0x00007fa82c31f000)
	libopenblas.so.0 => /usr/lib/x86_64-linux-gnu/libopenblas.so.0 (0x00007fa8283c9000)
root@8e032c468a86:/# ldd /opt/R/3.5.3/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/x86_64-linux-gnu/libblas.so.3 (0x00007f5f0e95e000)
	libopenblas.so.0 => /usr/lib/x86_64-linux-gnu/libopenblas.so.0 (0x00007f5f0a369000)
root@8e032c468a86:/# ldd /opt/R/3.6.0/lib/R/lib/libR.so | grep blas
	libblas.so.3 => /usr/lib/x86_64-linux-gnu/libblas.so.3 (0x00007f6962cc2000)
	libopenblas.so.0 => /usr/lib/x86_64-linux-gnu/libopenblas.so.0 (0x00007f695e6cd000)

# CentOS 6
[root@5146d0cb0202 /]# LD_LIBRARY_PATH=/opt/R/3.1.3/lib/R/lib ldd /opt/R/3.1.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.1.3/lib/R/lib/libRblas.so (0x00007fbb7d366000)
[root@5146d0cb0202 /]# LD_LIBRARY_PATH=/opt/R/3.5.3/lib/R/lib ldd /opt/R/3.5.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.5.3/lib/R/lib/libRblas.so (0x00007f6bbe8c6000)
[root@5146d0cb0202 /]# LD_LIBRARY_PATH=/opt/R/3.6.0/lib/R/lib ldd /opt/R/3.6.0/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.6.0/lib/R/lib/libRblas.so (0x00007f3f4e529000)

# CentOS 7
[root@5e0d329a90a3 /]# LD_LIBRARY_PATH=/opt/R/3.1.3/lib/R/lib ldd /opt/R/3.1.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.1.3/lib/R/lib/libRblas.so (0x00007f8456eeb000)
[root@5e0d329a90a3 /]# LD_LIBRARY_PATH=/opt/R/3.5.3/lib/R/lib ldd /opt/R/3.5.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.5.3/lib/R/lib/libRblas.so (0x00007f33ebd1e000)
[root@5e0d329a90a3 /]# LD_LIBRARY_PATH=/opt/R/3.6.0/lib/R/lib ldd /opt/R/3.6.0/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.6.0/lib/R/lib/libRblas.so (0x00007f600d3e2000)

# openSUSE 42
be72ed7b97a9:/ # LD_LIBRARY_PATH=/opt/R/3.1.3/lib/R/lib ldd /opt/R/3.1.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.1.3/lib/R/lib/libRblas.so (0x00007f051a7ea000)
be72ed7b97a9:/ # LD_LIBRARY_PATH=/opt/R/3.5.3/lib/R/lib ldd /opt/R/3.5.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.5.3/lib/R/lib/libRblas.so (0x00007fee885e2000)
be72ed7b97a9:/ # LD_LIBRARY_PATH=/opt/R/3.6.0/lib/R/lib ldd /opt/R/3.6.0/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.6.0/lib/R/lib/libRblas.so (0x00007f6a96966000)

# openSUSE 15
01b04fac92bf:/ # LD_LIBRARY_PATH=/opt/R/3.1.3/lib/R/lib ldd /opt/R/3.1.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.1.3/lib/R/lib/libRblas.so (0x00007fce5d65d000)
01b04fac92bf:/ # LD_LIBRARY_PATH=/opt/R/3.5.3/lib/R/lib ldd /opt/R/3.5.3/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.5.3/lib/R/lib/libRblas.so (0x00007fa853a38000)
01b04fac92bf:/ # LD_LIBRARY_PATH=/opt/R/3.6.0/lib/R/lib ldd /opt/R/3.6.0/lib/R/lib/libR.so | grep blas
	libRblas.so => /opt/R/3.6.0/lib/R/lib/libRblas.so (0x00007f9aa0eb0000)
```
