### PR TITLE
Allows building deb packages for R on ubuntu-1804

### DIFF
--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -11,10 +11,15 @@ RUN set -x \
 
 RUN pip install awscli
 
+RUN apt-get install -y gcc make ruby ruby-dev wget
+
+RUN gem install fpm
+
 RUN chmod 0777 /opt
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 
+COPY package.ubuntu-1804 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -6,12 +6,10 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli
-
-RUN apt-get install -y gcc make ruby ruby-dev wget
 
 RUN gem install fpm
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -117,7 +117,7 @@ _version_is_greater_than() {
 set_up_environment
 fetch_r_source $R_VERSION
 compile_r $R_VERSION
-package_r $R_VERSION
 clean_r
+package_r $R_VERSION
 archive_r $R_VERSION
 upload_r $R_VERSION

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   ubuntu-1604:
     command: ./build.sh
     environment:
-      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -16,7 +15,6 @@ services:
   ubuntu-1804:
     command: ./build.sh
     environment:
-      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -28,7 +26,6 @@ services:
   debian-9:
     command: ./build.sh
     environment:
-      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -40,7 +37,6 @@ services:
   centos-6:
     command: ./build.sh
     environment:
-      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -52,7 +48,6 @@ services:
   centos-7:
     command: ./build.sh
     environment:
-      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -64,7 +59,6 @@ services:
   opensuse-42:
     command: ./build.sh
     environment:
-      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -76,7 +70,6 @@ services:
   opensuse-15:
     command: ./build.sh
     environment:
-      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   ubuntu-1604:
     command: ./build.sh
     environment:
-      - BUILD_NO=${BUILD_NUMBER}
+      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -16,7 +16,7 @@ services:
   ubuntu-1804:
     command: ./build.sh
     environment:
-      - BUILD_NO=${BUILD_NUMBER}
+      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -28,7 +28,7 @@ services:
   debian-9:
     command: ./build.sh
     environment:
-      - BUILD_NO=${BUILD_NUMBER}
+      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -40,7 +40,7 @@ services:
   centos-6:
     command: ./build.sh
     environment:
-      - BUILD_NO=${BUILD_NUMBER}
+      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -52,7 +52,7 @@ services:
   centos-7:
     command: ./build.sh
     environment:
-      - BUILD_NO=${BUILD_NUMBER}
+      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -64,7 +64,7 @@ services:
   opensuse-42:
     command: ./build.sh
     environment:
-      - BUILD_NO=${BUILD_NUMBER}
+      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -76,7 +76,7 @@ services:
   opensuse-15:
     command: ./build.sh
     environment:
-      - BUILD_NO=${BUILD_NUMBER}
+      - BUILD_NUMBER=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   ubuntu-1604:
     command: ./build.sh
     environment:
+      - BUILD_NO=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -15,6 +16,7 @@ services:
   ubuntu-1804:
     command: ./build.sh
     environment:
+      - BUILD_NO=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -26,6 +28,7 @@ services:
   debian-9:
     command: ./build.sh
     environment:
+      - BUILD_NO=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -37,6 +40,7 @@ services:
   centos-6:
     command: ./build.sh
     environment:
+      - BUILD_NO=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -48,6 +52,7 @@ services:
   centos-7:
     command: ./build.sh
     environment:
+      - BUILD_NO=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -59,6 +64,7 @@ services:
   opensuse-42:
     command: ./build.sh
     environment:
+      - BUILD_NO=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:
@@ -70,6 +76,7 @@ services:
   opensuse-15:
     command: ./build.sh
     environment:
+      - BUILD_NO=${BUILD_NUMBER}
       - R_VERSION=${R_VERSION}
       - LOCAL_STORE=/tmp/output
     build:

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -27,7 +27,6 @@ fpm \
   -d libjpeg8 \
   -d liblapack-dev \
   -d liblzma5 \
-  -d libopenblas-base \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -27,7 +27,6 @@ fpm \
   -d libgomp1 \
   -d libicu60 \
   -d libjpeg8 \
-  -d liblapack3 \
   -d liblzma5 \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -1,5 +1,5 @@
 if [[ ! -d /tmp/output/ubuntu-1804 ]]; then
-  mkdir /tmp/output/ubuntu-1804
+  mkdir -p /tmp/output/ubuntu-1804
 fi
 
 fpm \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -7,6 +7,7 @@ fpm \
   -t deb \
   -v ${BUILD_NO} \
   -n R-${R_VERSION} \
+  --deb-priority "optional" \
   -p /tmp/output/ubuntu-1804/ \ # --prefix=/opt/R \
   -d zip \
   -d unzip \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -14,11 +14,6 @@ fpm \
   --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
   --license "GPL-2" \
   -p /tmp/output/ubuntu-1804/ \
-  -d zip \
-  -d unzip \
-  -d libpaper-utils \
-  -d xdg-utils \
-  -d libopenblas-base \
   -d libbz2-1.0 \
   -d libc6 \
   -d libcairo2 \
@@ -28,8 +23,10 @@ fpm \
   -d libicu60 \
   -d libjpeg8 \
   -d liblzma5 \
+  -d libopenblas-base \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
+  -d libpaper-utils \
   -d libpcre3 \
   -d libpng16-16 \
   -d libreadline7 \
@@ -38,9 +35,11 @@ fpm \
   -d libtk8.6 \
   -d libx11-6 \
   -d libxt6 \
-  -d zlib1g \
   -d ucf \
-  -d ca-certificates \
+  -d unzip \
+  -d xdg-utils \
+  -d zip \
+  -d zlib1g \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -5,7 +5,7 @@ fi
 fpm \
   -s dir \
   -t deb \
-  -v ${BUILD_NUMBER} \
+  -v 1 \
   -n R-${R_VERSION} \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -25,8 +25,8 @@ fpm \
   -d libgomp1 \
   -d libicu60 \
   -d libjpeg8 \
-  -d liblapack-dev \
   -d liblzma5 \
+  -d libopenblas-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -8,7 +8,12 @@ fpm \
   -v ${BUILD_NO} \
   -n R-${R_VERSION} \
   --deb-priority "optional" \
-  -p /tmp/output/ubuntu-1804/ \ # --prefix=/opt/R \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio" \
+  --license "GPL-2" \
+  -p /tmp/output/ubuntu-1804/ \
   -d zip \
   -d unzip \
   -d libpaper-utils \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -7,15 +7,11 @@ fpm \
   -t deb \
   -v ${BUILD_NO} \
   -n R-${R_VERSION} \
-  -p /tmp/output/ubuntu-1804/ \
-  --prefix=/opt/R \
+  -p /tmp/output/ubuntu-1804/ \ # --prefix=/opt/R \
   -d zip \
   -d unzip \
   -d libpaper-utils \
   -d xdg-utils \
-  -d libblas3 \
-  -d libatlas3-base \
-  -d libblas3 \
   -d libopenblas-base \
   -d libbz2-1.0 \
   -d libc6 \
@@ -26,9 +22,6 @@ fpm \
   -d libicu60 \
   -d libjpeg8 \
   -d liblapack3 \
-  -d libatlas3-base \
-  -d liblapack3 \
-  -d libopenblas-base \
   -d liblzma5 \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -1,0 +1,50 @@
+if [[ ! -d /tmp/output/ubuntu-1804 ]]; then
+  mkdir /tmp/output/ubuntu-1804
+fi
+
+fpm \
+  -s dir \
+  -t deb \
+  -v ${BUILD_NO} \
+  -n R-${R_VERSION} \
+  -p /tmp/output/ubuntu-1804/ \
+  --prefix=/opt/R \
+  -d zip \
+  -d unzip \
+  -d libpaper-utils \
+  -d xdg-utils \
+  -d libblas3 \
+  -d libatlas3-base \
+  -d libblas3 \
+  -d libopenblas-base \
+  -d libbz2-1.0 \
+  -d libc6 \
+  -d libcairo2 \
+  -d libcurl4 \
+  -d libglib2.0-0 \
+  -d libgomp1 \
+  -d libicu60 \
+  -d libjpeg8 \
+  -d liblapack3 \
+  -d libatlas3-base \
+  -d liblapack3 \
+  -d libopenblas-base \
+  -d liblzma5 \
+  -d libpango-1.0-0 \
+  -d libpangocairo-1.0-0 \
+  -d libpcre3 \
+  -d libpng16-16 \
+  -d libreadline7 \
+  -d libtcl8.6 \
+  -d libtiff5 \
+  -d libtk8.6 \
+  -d libx11-6 \
+  -d libxt6 \
+  -d zlib1g \
+  -d ucf \
+  -d ca-certificates \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/ubuntu-1804/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -11,7 +11,7 @@ fpm \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
   --url "http://www.r-project.org/" \
   --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio Inc https://github.com/rstudio" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
   --license "GPL-2" \
   -p /tmp/output/ubuntu-1804/ \
   -d zip \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -14,6 +14,9 @@ fpm \
   --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
   --license "GPL-2" \
   -p /tmp/output/ubuntu-1804/ \
+  -d g++ \
+  -d gcc \
+  -d gfortran \
   -d libbz2-1.0 \
   -d libc6 \
   -d libcairo2 \
@@ -22,6 +25,7 @@ fpm \
   -d libgomp1 \
   -d libicu60 \
   -d libjpeg8 \
+  -d liblapack-dev \
   -d liblzma5 \
   -d libopenblas-base \
   -d libpango-1.0-0 \
@@ -35,6 +39,7 @@ fpm \
   -d libtk8.6 \
   -d libx11-6 \
   -d libxt6 \
+  -d make \
   -d ucf \
   -d unzip \
   -d xdg-utils \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -5,7 +5,7 @@ fi
 fpm \
   -s dir \
   -t deb \
-  -v ${BUILD_NO} \
+  -v ${BUILD_NUMBER} \
   -n R-${R_VERSION} \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \


### PR DESCRIPTION
This update provides a mechanism for building deb packages on Ubuntu
1804. Several changes have been necessary to facilitate this:

* Dockerfile has been updated. It now includes:
    - fpm - a tool tool to create OS specific packages
    - copying the package script into the image
* the OS specific package.ubuntu-1804 packaging script
    - this is the script that uses fpm to build the package
* Updates to build.sh. It now includes:
    - runs the package script if it exists
    - stores the resultant package to s3


*Note:* upload to s3 has not been tested.