### PR TITLE
Update openSUSE base image

### DIFF
--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -1,4 +1,4 @@
-FROM opensuse:42.3
+FROM opensuse/leap:42.3
 
 ENV OS_IDENTIFIER opensuse-42
 


### PR DESCRIPTION
Switch from the deprecated `opensuse:42.3` to `opensuse/leap:42.3`