### PR TITLE
removed dependency xdg-utils

### DIFF
--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -41,7 +41,6 @@ fpm \
   -d make \
   -d ucf \
   -d unzip \
-  -d xdg-utils \
   -d zip \
   -d zlib1g \
   /opt/R/${R_VERSION}


### PR DESCRIPTION
One of the original set of dependencies for the resulting packaged version of R, xdg-utils, is not required in most server installations.

It provides some X windows related tools which are only needed in specific circumstances. Should these circumstances arise we would anticipate that the admin would be familiar enough with the situation to install manually.