### PR TITLE
Added 'vendor' to the package config

### DIFF
--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -7,7 +7,7 @@ fpm \
   -t deb \
   -v 1 \
   -n R-${R_VERSION} \
-  --vendor "R Project" \
+  --vendor "RStudio Inc." \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
   --url "http://www.r-project.org/" \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -7,6 +7,7 @@ fpm \
   -t deb \
   -v 1 \
   -n R-${R_VERSION} \
+  --vendor "R Project" \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
   --url "http://www.r-project.org/" \


### PR DESCRIPTION
The original version of the the package script does not correctly specify the vendor, which results in a weird default (it appears to be the hostname of the container the package is created in).

This PR adds the '--vendor' option to the fpm command and sets the value to 'R Project'.