### PR TITLE
Enables output of Linux OS packages for Debian 9

### DIFF
--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -6,15 +6,19 @@ RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip \
+  && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
+     libopenblas-base make python-pip ruby ruby-dev wget \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli
 
 RUN chmod 0777 /opt
 
+RUN gem install fpm
+
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 
+COPY package.debian-9 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -7,7 +7,7 @@ fpm \
   -t deb \
   -v 1 \
   -n R-${R_VERSION} \
-  --vendor "R Project" \
+  --vendor "RStudio Inc." \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
   --url "http://www.r-project.org/" \

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -7,6 +7,7 @@ fpm \
   -t deb \
   -v 1 \
   -n R-${R_VERSION} \
+  --vendor "R Project" \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
   --url "http://www.r-project.org/" \

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -1,0 +1,50 @@
+if [[ ! -d /tmp/output/debian-9 ]]; then
+  mkdir -p /tmp/output/debian-9
+fi
+
+fpm \
+  -s dir \
+  -t deb \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  -p /tmp/output/debian-9/ \
+  -d ca-certificates \
+  -d g++ \
+  -d gcc \
+  -d gfortran \
+  -d libbz2-1.0 \
+  -d libc6 \
+  -d libcairo2 \
+  -d libcurl4-openssl-dev \
+  -d libglib2.0-0 \
+  -d libgomp1 \
+  -d libicu57 \
+  -d liblzma5 \
+  -d libopenblas-dev \
+  -d libpango-1.0-0 \
+  -d libpangocairo-1.0-0 \
+  -d libpaper-utils \
+  -d libpcre3 \
+  -d libpng16-16 \
+  -d libreadline7 \
+  -d libtcl8.6 \
+  -d libtiff5 \
+  -d libtk8.6 \
+  -d libx11-6 \
+  -d libxt6 \
+  -d make \
+  -d ucf \
+  -d unzip \
+  -d zip \
+  -d zlib1g \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/debian-9/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+


### PR DESCRIPTION
Builds on earlier work and provides the tooling required to create Linux OS packages (deb in this case).

**Modifies**: Dockerfile.debian-9

So that it includes the fpm package build tool and also copies in the packaging script

**Adds**: package.debian-9

which runs fpm with the required parameters and dependencies 