### PR TITLE
Enables output of Linux OS packages for CentOS 7

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -30,6 +30,9 @@ RUN yum -y update \
     pcre-devel \
     pcre2-devel \
     readline-devel \
+    rpm-build \
+    ruby \
+    ruby-devel \
     tcl-devel \
     tex \
     texinfo-tex \
@@ -50,6 +53,8 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 RUN pip install awscli --upgrade --user && \
     ln -s /root/.local/bin/aws /usr/bin/aws
 
+RUN gem install fpm
+
 RUN chmod 0777 /opt
 
 # Configure flags for CentOS 7 that don't use the defaults in build.sh
@@ -66,5 +71,6 @@ ENV CONFIGURE_OPTIONS="\
 # RHEL 7 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"
 
+COPY package.centos-7 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -38,12 +38,10 @@ fpm \
   -d pcre-devel \
   -d pcre2-devel \
   -d perl-Digest-MD5 \
-  -d sudo \
   -d tcl \
   -d tk \
   -d tre \
-  -d vim \
-  -d wget \
+  -d which \
   -d xz-devel \
   -d zlib-devel \
   /opt/R/${R_VERSION}

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -2,6 +2,12 @@ if [[ ! -d /tmp/output/centos-7 ]]; then
   mkdir -p /tmp/output/centos-7
 fi
 
+# create post-install script required for openblas
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep 
+ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
 fpm \
   -s dir \
   -t rpm \
@@ -14,6 +20,7 @@ fpm \
   --description "GNU R statistical computation and graphics system" \
   --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
   --license "GPL-2" \
+  --after-install /post-install.sh \
   -p /tmp/output/centos-7/ \
   -d bzip2-devel \
   -d gcc \

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -1,0 +1,46 @@
+if [[ ! -d /tmp/output/centos-7 ]]; then
+  mkdir -p /tmp/output/centos-7
+fi
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "R Project" \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  -p /tmp/output/centos-7/ \
+  -d bzip2-devel \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-gfortran \
+  -d libcurl-devel \
+  -d libicu-devel \
+  -d libSM \
+  -d libtiff \
+  -d libXmu \
+  -d libXt \
+  -d make \
+  -d openblas-devel \
+  -d pango \
+  -d pcre-devel \
+  -d pcre2-devel \
+  -d perl-Digest-MD5 \
+  -d sudo \
+  -d tcl \
+  -d tk \
+  -d tre \
+  -d vim \
+  -d wget \
+  -d xz-devel \
+  -d zlib-devel \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/centos-7/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -8,6 +8,13 @@ mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRb
 ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
 EOF
 
+# create after-remove script to remove internal blas
+cat <<EOF >> /before-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
 fpm \
   -s dir \
   -t rpm \
@@ -21,6 +28,7 @@ fpm \
   --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
   --license "GPL-2" \
   --after-install /post-install.sh \
+  --after-remove /before-remove.sh \
   -p /tmp/output/centos-7/ \
   -d bzip2-devel \
   -d gcc \


### PR DESCRIPTION
Builds on earlier work and provides the tooling required to create Linux OS packages (deb in this case).

**Modifies**: Dockerfile.centos-7

So that it includes the fpm package build tool and also copies in the packaging script

**Adds**: package.centos-7

which is the packaging script which runs fpm with the required parameters and dependencies