### PR TITLE
Enables ouput of Linux packages for ubuntu 1604

### DIFF
--- a/builder/Dockerfile.ubuntu-1604
+++ b/builder/Dockerfile.ubuntu-1604
@@ -6,15 +6,18 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base wget python-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli
+
+RUN gem install fpm
 
 RUN chmod 0777 /opt
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 
+COPY package.ubuntu-1604 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/package.ubuntu-1604
+++ b/builder/package.ubuntu-1604
@@ -1,0 +1,51 @@
+if [[ ! -d /tmp/output/ubuntu-1604 ]]; then
+  mkdir -p /tmp/output/ubuntu-1604
+fi
+
+fpm \
+  -s dir \
+  -t deb \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "RStudio Inc." \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  -p /tmp/output/ubuntu-1604/ \
+  -d g++ \
+  -d gcc \
+  -d gfortran \
+  -d libbz2-1.0 \
+  -d libc6 \
+  -d libcairo2 \
+  -d libcurl3 \
+  -d libglib2.0-0 \
+  -d libgomp1 \
+  -d libicu55 \
+  -d libjpeg8 \
+  -d liblzma5 \
+  -d libopenblas-dev \
+  -d libpango-1.0-0 \
+  -d libpangocairo-1.0-0 \
+  -d libpaper-utils \
+  -d libpcre3 \
+  -d libpng16-16 \
+  -d libreadline6 \
+  -d libtcl8.6 \
+  -d libtiff5 \
+  -d libtk8.6 \
+  -d libx11-6 \
+  -d libxt6 \
+  -d make \
+  -d ucf \
+  -d unzip \
+  -d zip \
+  -d zlib1g \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/ubuntu-1604/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+


### PR DESCRIPTION
Builds on earlier work and provides the tooling required to create Linux OS packages (deb in this case).

**Modifies:** Dockerfile.ubuntu-1604

So that it includes the fpm package build tool and also copies in the packaging script

**Adds:** package.ubuntu-1604

which is the packaging script which runs fpm with the required parameters and dependencies