### PR TITLE
Tests for R binaries and packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ docker-build-r: docker-build
 docker-shell-r-env:
 	@cd builder && docker-compose run --entrypoint /bin/bash ubuntu-1604
 
+docker-test-r:
+	@cd test && docker-compose up
+
 ecr-login:
 	@eval $(shell aws ecr get-login --no-include-email --region $(AWS_REGION))
 
@@ -45,4 +48,4 @@ bash:
 		-w /r-builds \
 		${TARGET_IMAGE} /bin/bash
 
-.PHONY: deps docker-build docker-push docker-down docker-build-package docker-shell-package-env ecr-login fetch-serverless-custom-file serverless-deploy
+.PHONY: deps docker-build docker-push docker-down docker-build-package docker-shell-package-env docker-test-r ecr-login fetch-serverless-custom-file serverless-deploy

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -46,6 +46,15 @@ services:
     volumes:
       - ./:/test
       - ../builder/integration/tmp:/packages
+  centos-8:
+    image: centos:centos8
+    command: /test/test-centos.sh
+    environment:
+      - OS_IDENTIFIER=centos-8
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
   opensuse-42:
     image: opensuse/leap:42.3
     command: /test/test-opensuse.sh

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -19,6 +19,24 @@ services:
     volumes:
       - ./:/test
       - ../builder/integration/tmp:/packages
+  ubuntu-2004:
+    image: ubuntu:focal
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-2004
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  debian-10:
+    image: debian:buster
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=debian-10
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
   debian-9:
     image: debian:stretch
     command: /test/test-deb.sh

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '2.0'
+
+services:
+  ubuntu-1604:
+    image: ubuntu:xenial
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-1604
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  ubuntu-1804:
+    image: ubuntu:bionic
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-1804
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  debian-9:
+    image: debian:stretch
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=debian-9
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  centos-6:
+    image: centos:centos6
+    command: /test/test-centos.sh
+    environment:
+      - OS_IDENTIFIER=centos-6
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  centos-7:
+    image: centos:centos7
+    command: /test/test-centos.sh
+    environment:
+      - OS_IDENTIFIER=centos-7
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  opensuse-42:
+    image: opensuse/leap:42.3
+    command: /test/test-opensuse.sh
+    environment:
+      - OS_IDENTIFIER=opensuse-42
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  opensuse-15:
+    image: opensuse/leap:15.0
+    command: /test/test-opensuse.sh
+    environment:
+      - OS_IDENTIFIER=opensuse-15
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages

--- a/test/test-centos.sh
+++ b/test/test-centos.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+PKG_FILE=/packages/${OS_IDENTIFIER}/R-${R_VERSION}-1-1.x86_64.rpm
+
+if [ ! -f ${PKG_FILE} ]; then
+    echo "No package found, skipping tests"
+    exit 0
+fi
+
+yum -y -q update
+yum -y install epel-release
+yum -y install ${PKG_FILE}
+
+# Show rpm info
+rpm -qi R-${R_VERSION}
+
+/test/test-r.sh
+
+yum -y remove R-${R_VERSION}
+
+if [ -d /opt/R/${R_VERSION} ]; then
+    echo "Failed to uninstall completely"
+    exit 1
+fi

--- a/test/test-deb.sh
+++ b/test/test-deb.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+PKG_FILE=/packages/${OS_IDENTIFIER}/r-${R_VERSION}_1_amd64.deb
+
+if [ ! -f ${PKG_FILE} ]; then
+    echo "No package found, skipping tests"
+    exit 0
+fi
+
+export DEBIAN_FRONTEND=noninteractive 
+apt-get update -qq
+apt-get install -f -y ${PKG_FILE}
+
+# Show deb info
+apt-cache show r-${R_VERSION}
+
+/test/test-r.sh
+
+apt-get remove -y r-${R_VERSION}
+
+if [ -d /opt/R/${R_VERSION} ]; then
+    echo "Failed to uninstall completely"
+    exit 1
+fi

--- a/test/test-opensuse.sh
+++ b/test/test-opensuse.sh
@@ -8,7 +8,7 @@ if [ ! -f ${PKG_FILE} ]; then
     exit 0
 fi
 
-zypper --non-interactive install ${PKG_FILE}
+zypper --non-interactive --no-gpg-checks install ${PKG_FILE}
 
 # Show rpm info
 rpm -qi R-${R_VERSION}

--- a/test/test-opensuse.sh
+++ b/test/test-opensuse.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -ex
+
+PKG_FILE=/packages/${OS_IDENTIFIER}/R-${R_VERSION}-1-1.x86_64.rpm
+
+if [ ! -f ${PKG_FILE} ]; then
+    echo "No package found, skipping tests"
+    exit 0
+fi
+
+zypper --non-interactive install ${PKG_FILE}
+
+# Show rpm info
+rpm -qi R-${R_VERSION}
+
+/test/test-r.sh
+
+zypper --non-interactive remove R-${R_VERSION}
+
+if [ -d /opt/R/${R_VERSION} ]; then
+    echo "Failed to uninstall completely"
+    exit 1
+fi

--- a/test/test-r.sh
+++ b/test/test-r.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -ex
+
+R_HOME=/opt/R/${R_VERSION}/lib/R
+${R_HOME}/bin/R --version
+${R_HOME}/bin/Rscript -e 'sessionInfo()'
+
+# List R devel dependencies
+gcc --version
+g++ --version
+gfortran --version
+
+# List shared library dependencies (e.g. BLAS/LAPACK)
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${R_HOME}/lib ldd ${R_HOME}/lib/libR.so
+
+${R_HOME}/bin/Rscript /test/test.R

--- a/test/test.R
+++ b/test/test.R
@@ -1,0 +1,86 @@
+# HTTP mirror to support R 3.1
+options(repos = c("https://cloud.r-project.org", "http://cloud.r-project.org"))
+
+# Create a temp lib to avoid installing into the system library
+temp_lib <- tempdir()
+
+# Install a package without compilation
+install.packages("R6", lib = temp_lib)
+library(R6, lib.loc = temp_lib)
+
+# Install a package with compilation
+install.packages("BASIX", lib = temp_lib)
+library(BASIX, lib.loc = temp_lib)
+
+# Check iconv support
+if (!capabilities("iconv") || !all(c("ASCII", "LATIN1", "UTF-8") %in% iconvlist())) {
+  stop("missing iconv support")
+}
+
+# Check that built-in packages can be loaded
+for (pkg in rownames(installed.packages(priority = c("base", "recommended")))) {
+  if (!require(pkg, character.only = TRUE)) {
+    stop(sprintf("failed to load built-in package %s", pkg))
+  }
+}
+
+# Show capabilities. Warnings are returned on missing libraries.
+tryCatch(capabilities(), warning = function(w) {
+  print(capabilities())
+  stop(sprintf("missing libraries: %s", w$message))
+})
+
+# Check graphics devices
+# https://stat.ethz.ch/R-manual/R-devel/library/grDevices/html/Devices.html
+for (dev_name in c("png", "jpeg", "tiff", "svg", "bmp", "pdf", "postscript",
+                   "xfig", "pictex", "cairo_pdf", "cairo_ps")) {
+  # Skip unsupported graphics devices (e.g. tiff in R >= 3.3 on CentOS 6)
+  if (dev_name %in% names(capabilities()) && capabilities(dev_name) == FALSE) {
+    next
+  }
+  dev <- getFromNamespace(dev_name, "grDevices")
+  tryCatch({
+    file <- tempfile()
+    on.exit(unlink(file))
+    if (dev_name == "xfig") {
+      # Suppress warning from xfig when onefile = FALSE (the default)
+      dev(file, onefile = TRUE)
+    } else {
+      dev(file)
+    }
+    plot(1)
+    dev.off()
+  }, warning = function(w) {
+    # Catch errors which manifest as warnings (e.g. "failed to load cairo DLL")
+    stop(sprintf("graphics device %s failed: %s", dev_name, w$message))
+  })
+}
+
+# Check for unexpected output from graphics/text rendering.
+# Run externally to capture output from external processes.
+# For example, "Pango-WARNING **: failed to choose a font, expect ugly output"
+# messages when rendering text without any system fonts installed.
+output <- system2(R.home("bin/Rscript"), "-e 'png(tempfile()); plot(1)'", stdout = TRUE, stderr = TRUE)
+if (length(output) > 0) {
+  stop(sprintf("unexpected output returned from plotting:\n%s", paste(output, collapse = "\n")))
+}
+
+# Check download methods: libcurl (supported in R >= 3.2) and internal (based on libxml)
+if ("libcurl" %in% names(capabilities())) {
+  download.file("https://cloud.r-project.org", tempfile(), "libcurl")
+}
+tmpfile <- tempfile()
+write.csv("test", tmpfile)
+download.file(sprintf("file://%s", tmpfile), tempfile(), "internal")
+
+# Check that a pager is configured and help pages work
+# https://stat.ethz.ch/R-manual/R-devel/library/base/html/file.show.html
+output <- system2(R.home("bin/Rscript"), "-e 'help(stats)'", stdout = TRUE)
+if (length(output) == 0) {
+  stop("failed to display help pages; check that a pager is configured properly")
+}
+
+# Smoke test BLAS/LAPACK functionality. R may start just fine with an incompatible
+# BLAS/LAPACK library, and only fail when calling a BLAS or LAPACK routine.
+stopifnot(identical(crossprod(matrix(1)), matrix(1)))
+stopifnot(identical(chol(matrix(1)), matrix(1)))

--- a/test/test.R
+++ b/test/test.R
@@ -12,6 +12,10 @@ library(R6, lib.loc = temp_lib)
 install.packages("BASIX", lib = temp_lib)
 library(BASIX, lib.loc = temp_lib)
 
+# Install a package that compiles with C++11 (old enough to be supported on CentOS 6)
+install.packages("digest", lib = temp_lib)
+library(digest, lib.loc = temp_lib)
+
 # Check iconv support
 if (!capabilities("iconv") || !all(c("ASCII", "LATIN1", "UTF-8") %in% iconvlist())) {
   stop("missing iconv support")

--- a/test/test.R
+++ b/test/test.R
@@ -88,3 +88,14 @@ if (length(output) == 0) {
 # BLAS/LAPACK library, and only fail when calling a BLAS or LAPACK routine.
 stopifnot(identical(crossprod(matrix(1)), matrix(1)))
 stopifnot(identical(chol(matrix(1)), matrix(1)))
+
+# Check that R 3.x depends on PCRE1, and R 4.x depends on PCRE2.
+# R 3.5 and 3.6 will link against PCRE2 if present, and take on an unnecessary dependency.
+ld_flags <- system2(R.home("bin/R"), c("CMD", "config", "--ldflags"), stdout = TRUE)
+has_pcre1 <- grepl("-lpcre\\b", ld_flags)
+has_pcre2 <- grepl("-lpcre2-8\\b", ld_flags)
+if (R.version$major == "3") {
+  stopifnot(has_pcre1 && !has_pcre2)
+} else {
+  stopifnot(has_pcre2 && !has_pcre1)
+}


### PR DESCRIPTION
These are tests to help verify that the R binaries are configured/compiled properly, and that the R packages work.

Specifically, this installs the R deb/rpm in a base OS container, runs some R tests, and uninstalls the deb/rpm. The R tests were copied from https://github.com/rstudio/r-docker, but I only pulled in the tests relevant to r-builds (e.g. BLAS is configured properly, no missing runtime libraries, help pages work).

To test locally, first build the R packages:
```sh
# Build R 3.5.3 on each OS
R_VERSION=3.5.3 make docker-build-r

# Or build on a specific OS
cd builder && R_VERSION=3.5.3 docker-compose up ubuntu-1604

# Note: this outputs packages to builder/integration/tmp. To rebuild,
# clear out any existing packages in that directory
```

And then run the tests:
```sh
# Test R 3.5.3 on each OS
R_VERSION=3.5.3 make docker-test-r

# Or test on a specific OS
cd test && R_VERSION=3.5.3 docker-compose up ubuntu-1604
```