### PR TITLE
Run tests in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,52 @@ pipeline {
         sh 'make docker-build'
       }
     }
+    stage('test images') {
+      parallel {
+        stage('R 3.1') {
+          agent { label 'docker' }
+          steps {
+            sh 'R_VERSION=3.1.3 make docker-build-r'
+            sh 'R_VERSION=3.1.3 make docker-test-r'
+          }
+        }
+        stage('R 3.2') {
+          agent { label 'docker' }
+          steps {
+            sh 'R_VERSION=3.2.5 make docker-build-r'
+            sh 'R_VERSION=3.2.5 make docker-test-r'
+          }
+        }
+        stage('R 3.3') {
+          agent { label 'docker' }
+          steps {
+            sh 'R_VERSION=3.3.3 make docker-build-r'
+            sh 'R_VERSION=3.3.3 make docker-test-r'
+          }
+        }
+        stage('R 3.4') {
+          agent { label 'docker' }
+          steps {
+            sh 'R_VERSION=3.4.4 make docker-build-r'
+            sh 'R_VERSION=3.4.4 make docker-test-r'
+          }
+        }
+        stage('R 3.5') {
+          agent { label 'docker' }
+          steps {
+            sh 'R_VERSION=3.5.3 make docker-build-r'
+            sh 'R_VERSION=3.5.3 make docker-test-r'
+          }
+        }
+        stage('R 3.6') {
+          agent { label 'docker' }
+          steps {
+            sh 'R_VERSION=3.6.1 make docker-build-r'
+            sh 'R_VERSION=3.6.1 make docker-test-r'
+          }
+        }
+      }
+    }
     stage('push images') {
       agent { label 'docker-4x' }
       when {

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ docker-build-r: docker-build
 docker-shell-r-env:
 	@cd builder && docker-compose run --entrypoint /bin/bash ubuntu-1604
 
+docker-test-r:
+	@cd test && docker-compose up
+
 ecr-login:
 	@eval $(shell aws ecr get-login --no-include-email --region $(AWS_REGION))
 
@@ -36,4 +39,4 @@ rebuild-all: deps fetch-serverless-custom-file
 serverless-deploy: deps fetch-serverless-custom-file
 	$(SLS_BINARY) deploy --stage dev
 
-.PHONY: deps docker-build docker-push docker-down docker-build-package docker-shell-package-env ecr-login fetch-serverless-custom-file serverless-deploy
+.PHONY: deps docker-build docker-push docker-down docker-build-package docker-shell-package-env docker-test-r ecr-login fetch-serverless-custom-file serverless-deploy

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '2.0'
+
+services:
+  ubuntu-1604:
+    image: ubuntu:xenial
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-1604
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  ubuntu-1804:
+    image: ubuntu:bionic
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-1804
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  debian-9:
+    image: debian:stretch
+    command: /test/test-deb.sh
+    environment:
+      - OS_IDENTIFIER=debian-9
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  centos-6:
+    image: centos:centos6
+    command: /test/test-centos.sh
+    environment:
+      - OS_IDENTIFIER=centos-6
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  centos-7:
+    image: centos:centos7
+    command: /test/test-centos.sh
+    environment:
+      - OS_IDENTIFIER=centos-7
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  opensuse-42:
+    image: opensuse/leap:42.3
+    command: /test/test-opensuse.sh
+    environment:
+      - OS_IDENTIFIER=opensuse-42
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages
+  opensuse-15:
+    image: opensuse/leap:15.0
+    command: /test/test-opensuse.sh
+    environment:
+      - OS_IDENTIFIER=opensuse-15
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ./:/test
+      - ../builder/integration/tmp:/packages

--- a/test/test-centos.sh
+++ b/test/test-centos.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+PKG_FILE=/packages/${OS_IDENTIFIER}/R-${R_VERSION}-1-1.x86_64.rpm
+
+if [ ! -f ${PKG_FILE} ]; then
+    echo "No package found, skipping tests"
+    exit 0
+fi
+
+yum -y -q update
+yum -y install epel-release
+yum -y install ${PKG_FILE}
+
+# Show rpm info
+rpm -qi R-${R_VERSION}
+
+/test/test-r.sh
+
+yum -y remove R-${R_VERSION}
+
+if [ -d /opt/R/${R_VERSION} ]; then
+    echo "Failed to uninstall completely"
+    exit 1
+fi

--- a/test/test-deb.sh
+++ b/test/test-deb.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+PKG_FILE=/packages/${OS_IDENTIFIER}/r-${R_VERSION}_1_amd64.deb
+
+if [ ! -f ${PKG_FILE} ]; then
+    echo "No package found, skipping tests"
+    exit 0
+fi
+
+export DEBIAN_FRONTEND=noninteractive 
+apt-get update -qq
+apt-get install -f -y ${PKG_FILE}
+
+# Show deb info
+apt-cache show r-${R_VERSION}
+
+/test/test-r.sh
+
+apt-get remove -y r-${R_VERSION}
+
+if [ -d /opt/R/${R_VERSION} ]; then
+    echo "Failed to uninstall completely"
+    exit 1
+fi

--- a/test/test-opensuse.sh
+++ b/test/test-opensuse.sh
@@ -8,7 +8,7 @@ if [ ! -f ${PKG_FILE} ]; then
     exit 0
 fi
 
-zypper --non-interactive install ${PKG_FILE}
+zypper --non-interactive --no-gpg-checks install ${PKG_FILE}
 
 # Show rpm info
 rpm -qi R-${R_VERSION}

--- a/test/test-opensuse.sh
+++ b/test/test-opensuse.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -ex
+
+PKG_FILE=/packages/${OS_IDENTIFIER}/R-${R_VERSION}-1-1.x86_64.rpm
+
+if [ ! -f ${PKG_FILE} ]; then
+    echo "No package found, skipping tests"
+    exit 0
+fi
+
+zypper --non-interactive install ${PKG_FILE}
+
+# Show rpm info
+rpm -qi R-${R_VERSION}
+
+/test/test-r.sh
+
+zypper --non-interactive remove R-${R_VERSION}
+
+if [ -d /opt/R/${R_VERSION} ]; then
+    echo "Failed to uninstall completely"
+    exit 1
+fi

--- a/test/test-r.sh
+++ b/test/test-r.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -ex
+
+R_HOME=/opt/R/${R_VERSION}/lib/R
+${R_HOME}/bin/R --version
+${R_HOME}/bin/Rscript -e 'sessionInfo()'
+
+# List R devel dependencies
+gcc --version
+g++ --version
+gfortran --version
+
+# List shared library dependencies (e.g. BLAS/LAPACK)
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${R_HOME}/lib ldd ${R_HOME}/lib/libR.so
+
+${R_HOME}/bin/Rscript /test/test.R

--- a/test/test.R
+++ b/test/test.R
@@ -1,0 +1,86 @@
+# HTTP mirror to support R 3.1
+options(repos = c("https://cloud.r-project.org", "http://cloud.r-project.org"))
+
+# Create a temp lib to avoid installing into the system library
+temp_lib <- tempdir()
+
+# Install a package without compilation
+install.packages("R6", lib = temp_lib)
+library(R6, lib.loc = temp_lib)
+
+# Install a package with compilation
+install.packages("BASIX", lib = temp_lib)
+library(BASIX, lib.loc = temp_lib)
+
+# Check iconv support
+if (!capabilities("iconv") || !all(c("ASCII", "LATIN1", "UTF-8") %in% iconvlist())) {
+  stop("missing iconv support")
+}
+
+# Check that built-in packages can be loaded
+for (pkg in rownames(installed.packages(priority = c("base", "recommended")))) {
+  if (!require(pkg, character.only = TRUE)) {
+    stop(sprintf("failed to load built-in package %s", pkg))
+  }
+}
+
+# Show capabilities. Warnings are returned on missing libraries.
+tryCatch(capabilities(), warning = function(w) {
+  print(capabilities())
+  stop(sprintf("missing libraries: %s", w$message))
+})
+
+# Check graphics devices
+# https://stat.ethz.ch/R-manual/R-devel/library/grDevices/html/Devices.html
+for (dev_name in c("png", "jpeg", "tiff", "svg", "bmp", "pdf", "postscript",
+                   "xfig", "pictex", "cairo_pdf", "cairo_ps")) {
+  # Skip unsupported graphics devices (e.g. tiff in R >= 3.3 on CentOS 6)
+  if (dev_name %in% names(capabilities()) && capabilities(dev_name) == FALSE) {
+    next
+  }
+  dev <- getFromNamespace(dev_name, "grDevices")
+  tryCatch({
+    file <- tempfile()
+    on.exit(unlink(file))
+    if (dev_name == "xfig") {
+      # Suppress warning from xfig when onefile = FALSE (the default)
+      dev(file, onefile = TRUE)
+    } else {
+      dev(file)
+    }
+    plot(1)
+    dev.off()
+  }, warning = function(w) {
+    # Catch errors which manifest as warnings (e.g. "failed to load cairo DLL")
+    stop(sprintf("graphics device %s failed: %s", dev_name, w$message))
+  })
+}
+
+# Check for unexpected output from graphics/text rendering.
+# Run externally to capture output from external processes.
+# For example, "Pango-WARNING **: failed to choose a font, expect ugly output"
+# messages when rendering text without any system fonts installed.
+output <- system2(R.home("bin/Rscript"), "-e 'png(tempfile()); plot(1)'", stdout = TRUE, stderr = TRUE)
+if (length(output) > 0) {
+  stop(sprintf("unexpected output returned from plotting:\n%s", paste(output, collapse = "\n")))
+}
+
+# Check download methods: libcurl (supported in R >= 3.2) and internal (based on libxml)
+if ("libcurl" %in% names(capabilities())) {
+  download.file("https://cloud.r-project.org", tempfile(), "libcurl")
+}
+tmpfile <- tempfile()
+write.csv("test", tmpfile)
+download.file(sprintf("file://%s", tmpfile), tempfile(), "internal")
+
+# Check that a pager is configured and help pages work
+# https://stat.ethz.ch/R-manual/R-devel/library/base/html/file.show.html
+output <- system2(R.home("bin/Rscript"), "-e 'help(stats)'", stdout = TRUE)
+if (length(output) == 0) {
+  stop("failed to display help pages; check that a pager is configured properly")
+}
+
+# Smoke test BLAS/LAPACK functionality. R may start just fine with an incompatible
+# BLAS/LAPACK library, and only fail when calling a BLAS or LAPACK routine.
+stopifnot(identical(crossprod(matrix(1)), matrix(1)))
+stopifnot(identical(chol(matrix(1)), matrix(1)))


### PR DESCRIPTION
This runs the tests from #23 in Jenkins, so we only push builder images to ECR if they produce working R binaries/packages. Since the r-builds matrix is huge, I only added tests for the latest patch of each minor version since 3.1.3. One of each minor version should still give pretty good coverage.

A big downside is that the tests add a lot of time to the Jenkins job -- about 40 mins extra right now. It might be possible to improve this with some Jenkinsfile tweaks, or we could pare down the build matrix. I did try the docker-4x agent originally, which built one R version in ~10 mins, but I think there's only one of those available at a time. Or, maybe the extra wait is fine since it still beats manual testing, and since r-builds doesn't change often anyway.