### PR TITLE
Enables building of RPMs for opensuse

### DIFF
--- a/builder/Dockerfile.opensuse-15
+++ b/builder/Dockerfile.opensuse-15
@@ -28,6 +28,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     libjpeg-devel \
     libpng-devel \
     libtiff-devel \
+    make \
     pango-devel \
     pcre-devel \
     perl \
@@ -36,6 +37,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     python-pip \
     readline-devel \
     rpm-build \
+    ruby \
+    ruby-devel \
     shadow \
     tcl-devel \
     texinfo \
@@ -62,6 +65,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
+RUN gem install fpm && ln -s /usr/lib64/ruby/gems/2.5.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
+
 RUN chmod 0777 /opt
 
 # Configure flags for SUSE that don't use the defaults in build.sh
@@ -73,5 +78,6 @@ ENV CONFIGURE_OPTIONS="\
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh"
 
+COPY package.opensuse-15 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -28,6 +28,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     libjpeg-devel \
     libpng-devel \
     libtiff-devel \
+    make \
     pango-devel \
     pcre-devel \
     perl \
@@ -36,6 +37,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     python-pip \
     readline-devel \
     rpm-build \
+    ruby \
+    ruby-devel \
     shadow \
     tcl-devel \
     texinfo \
@@ -62,6 +65,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
+RUN gem install fpm && ln -s /usr/lib64/ruby/gems/2.1.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
+
 RUN chmod 0777 /opt
 
 # SUSE 12 doesn't have texi2any, so use makeinfo.
@@ -77,5 +82,6 @@ ENV CONFIGURE_OPTIONS="\
     --with-tk-config=/usr/lib64/tkConfig.sh \
     --enable-prebuilt-html"
 
+COPY package.opensuse-42 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/package.opensuse-15
+++ b/builder/package.opensuse-15
@@ -20,7 +20,7 @@ fpm \
   -t rpm \
   -v 1 \
   -n R-${R_VERSION} \
-  --vendor "R-Project" \
+  --vendor "RStudio Inc." \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
   --url "http://www.r-project.org/" \
@@ -52,6 +52,7 @@ fpm \
   -d tar \
   -d tcl \
   -d tk \
+  -d unzip \
   -d which \
   -d xorg-x11 \
   -d xorg-x11-fonts-100dpi \

--- a/builder/package.opensuse-15
+++ b/builder/package.opensuse-15
@@ -1,0 +1,66 @@
+if [[ ! -d /tmp/output/opensuse-15 ]]; then
+  mkdir -p /tmp/output/opensuse-15
+fi
+
+# create post-install script required for openblas
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
+# create after-remove script to remove internal blas
+cat <<EOF >> /before-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "R-Project" \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  --after-install /post-install.sh \
+  --after-remove /before-remove.sh \
+  -p /tmp/output/opensuse-15/ \
+  -d fontconfig \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-fortran \
+  -d glibc-locale \
+  -d gzip \
+  -d libbz2-devel \
+  -d libcairo2 \
+  -d libcurl-devel \
+  -d libfreetype6 \
+  -d libgomp1 \
+  -d libicu-devel \
+  -d libjpeg62 \
+  -d libreadline6 \
+  -d libtiff5 \
+  -d make \
+  -d openblas-devel \
+  -d pango-tools \
+  -d pcre-devel \
+  -d tar \
+  -d tcl \
+  -d tk \
+  -d which \
+  -d xorg-x11 \
+  -d xorg-x11-fonts-100dpi \
+  -d xorg-x11-fonts-75dpi \
+  -d xz-devel \
+  -d zip \
+  -d zlib-devel \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/opensuse-15/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -20,7 +20,7 @@ fpm \
   -t rpm \
   -v 1 \
   -n R-${R_VERSION} \
-  --vendor "R Project" \
+  --vendor "RStudio Inc." \
   --deb-priority "optional" \
   --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
   --url "http://www.r-project.org/" \
@@ -50,6 +50,7 @@ fpm \
   -d tar \
   -d tcl \
   -d tk \
+  -d unzip \
   -d which \
   -d xorg-x11 \
   -d xorg-x11-fonts-100dpi \

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -1,0 +1,64 @@
+if [[ ! -d /tmp/output/opensuse-42 ]]; then
+  mkdir -p /tmp/output/opensuse-42
+fi
+
+# create post-install script required for openblas
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
+# create after-remove script to remove internal blas
+cat <<EOF >> /before-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "R Project" \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  --after-install /post-install.sh \
+  --after-remove /before-remove.sh \
+  -p /tmp/output/opensuse-42/ \
+  -d fontconfig \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-fortran \
+  -d glibc-locale \
+  -d libbz2-devel \
+  -d libcairo2 \
+  -d libcurl-devel \
+  -d libfreetype6 \
+  -d libgomp1 \
+  -d libicu-devel \
+  -d libjpeg62 \
+  -d libtiff5 \
+  -d make \
+  -d openblas-devel \
+  -d pango-tools \
+  -d pcre-devel \
+  -d tar \
+  -d tcl \
+  -d tk \
+  -d which \
+  -d xorg-x11 \
+  -d xorg-x11-fonts-100dpi \
+  -d xorg-x11-fonts-75dpi \
+  -d xz-devel \
+  -d zip \
+  -d zlib-devel \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/opensuse-42/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+


### PR DESCRIPTION
Builds on earlier work and provides the tooling required to create Linux OS packages (RPM in this case).

**Modifies:** Dockerfile.opensuse-42, Dockerfile.opensuse-15

So that it includes the fpm package build tool and also copies in the packaging script

**Adds:** package.opensuse-42, package.opensuse-15

which is the packaging script which runs fpm with the required parameters and dependencies