### PR TITLE
SUSE compatibility fixes

### DIFF
--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -10,6 +10,7 @@ RUN zypper --non-interactive update
 RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     bzip2 \
     cairo-devel \
+    curl \
     fdupes \
     gcc \
     gcc-c++ \
@@ -58,7 +59,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     wget \
     xdg-utils \
     xorg-x11-devel \
-    xz-devel \
     zip \
     zlib-devel \
     && zypper clean
@@ -68,6 +68,19 @@ RUN pip install awscli
 RUN gem install fpm && ln -s /usr/lib64/ruby/gems/2.1.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
 
 RUN chmod 0777 /opt
+
+# Install an older xz 5.0.5 for compatibility with SLES 12
+ARG XZ_VERSION=5.0.5
+ARG XZ_DOWNLOAD_SHA1=26fec2c1e409f736e77a85e4ab314dc74987def0
+RUN curl -fsSL "https://sourceforge.net/projects/lzmautils/files/xz-{$XZ_VERSION}.tar.gz/download" -o xz.tar.gz \
+    && echo "$XZ_DOWNLOAD_SHA1  xz.tar.gz" | sha1sum -c - \
+    && CWD=`pwd` && TMP=`mktemp -d` \
+    && tar -C $TMP -zxvf xz.tar.gz \
+    && cd $TMP/xz* \
+    && ./configure \
+    && make \
+    && make install \
+    && cd $CWD && rm -rf $TMP && rm -rf xz.tar.gz
 
 # SUSE 12 doesn't have texi2any, so use makeinfo.
 ENV MAKEINFO=makeinfo

--- a/builder/package.opensuse-15
+++ b/builder/package.opensuse-15
@@ -43,11 +43,11 @@ fpm \
   -d libgomp1 \
   -d libicu-devel \
   -d libjpeg62 \
+  -d libpango-1_0-0 \
   -d libreadline7 \
   -d libtiff5 \
   -d make \
   -d openblas-devel \
-  -d pango-tools \
   -d pcre-devel \
   -d tar \
   -d tcl \

--- a/builder/package.opensuse-15
+++ b/builder/package.opensuse-15
@@ -43,7 +43,7 @@ fpm \
   -d libgomp1 \
   -d libicu-devel \
   -d libjpeg62 \
-  -d libreadline6 \
+  -d libreadline7 \
   -d libtiff5 \
   -d make \
   -d openblas-devel \

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -42,10 +42,10 @@ fpm \
   -d libgomp1 \
   -d libicu-devel \
   -d libjpeg62 \
+  -d libpango-1_0-0 \
   -d libtiff5 \
   -d make \
   -d openblas-devel \
-  -d pango-tools \
   -d pcre-devel \
   -d tar \
   -d tcl \


### PR DESCRIPTION
**Packaging**
- Replace libreadline6 with libreadline7 on openSUSE 15 for compatibility with SLES 15, and since libreadline7 was already being used for the build anyway
- Replace pango-tools with libpango on openSUSE 42 and 15 for compatibility with SLES, and since pango-tools' libpango dependency was really what we need

**Build**
- Build R with an older minor version of xz on openSUSE 42. SLES 12 has an older version of xz (5.0.5) than openSUSE 42.3 (5.2.2), so you get this message when starting R on SLES 12:
```
/opt/R/3.4.4/lib/R/bin/exec/R: /usr/lib64/liblzma.so.5: no version information available (required by /opt/R/3.4.4/lib/R/lib/libR.so)
```
The xz version will still be the same when a user installs the R rpm, but this message should go away since R's built against a more compatible xz.

For testing: I've built RPMs for R 3.1 and 3.5 locally, and ran the r-docker tests on openSUSE 42/15 and SLES 12 SP3/15