### PR TITLE
Update README with deb/rpm installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,130 @@
 # r-builds
 
-This repository orchestrates tools to produce R binaries obtainable from:
-https://cdn.rstudio.com/r. The binaries are available as a
+This repository orchestrates tools to produce R binaries. The binaries are available as a
 community resource, **they are not professionally supported by RStudio**. 
 The R language is open source, please see the official documentation at https://www.r-project.org/.
 
 These binaries are not a replacement to existing binary distributions for R.
 The binaries were built with the following considerations:
-- They use a minimal, documented set of
-  [build](https://github.com/rstudio/r-builds/tree/master/builder) and
-  [runtime](https://github.com/rstudio/r-docker) dependencies.  
+- They use a minimal set of [build and runtime dependencies](builder).
 - They are designed to be used side-by-side, e.g., on [RStudio Server Pro](https://docs.rstudio.com/ide/server-pro/r-versions.html#using-multiple-versions-of-r-concurrently).
 - They give users a consistent option for accessing R across different Linux distributions.
 
 These binaries have been extensively tested, and are used in production everyday
 on [RStudio Cloud](https://rstudio.cloud) and
 [shinyapps.io](https://shinyapps.io). Please open an issue to report a specific
-bug, and address questions on [RStudio
-Community](https://community.rstudio.com).
+bug, or ask questions on [RStudio Community](https://community.rstudio.com).
 
-## Example Usage
+## Supported Platforms
 
-These binaries are designed to be copied onto a server, as opposed to installed
-using a system package manager like `apt` or `yum`. This approach allows administrators
-to offer multiple versions of R side-by-side. 
+R binaries are built for the following Linux operating systems:
+- Ubuntu 16.04, 18.04
+- Debian 9
+- CentOS / Red Hat Enterprise Linux 6, 7
+- openSUSE 42.3, 15.0
+- SUSE Linux Enterprise 12, 15
+
+## Installation
+
+### Specify R version
+
+Define the version of R that you want to install. Available versions
+of R can be found here: https://cdn.rstudio.com/r/versions.json
+```bash
+R_VERSION=3.5.3
+```
+
+### Download and install R
+
+#### Ubuntu/Debian Linux
+
+Download the deb package:
+```bash
+# Ubuntu 16.04
+wget https://cdn.rstudio.com/r/ubuntu-1604/pkgs/r-${R_VERSION}_1_amd64.deb
+
+# Ubuntu 18.04
+wget https://cdn.rstudio.com/r/ubuntu-1804/pkgs/r-${R_VERSION}_1_amd64.deb
+
+# Debian 9
+wget https://cdn.rstudio.com/r/debian-9/pkgs/r-${R_VERSION}_1_amd64.deb
+```
+
+Then install the package:
+```bash
+sudo apt-get install gdebi-core
+sudo gdebi r-${R_VERSION}_1_amd64.deb
+```
+
+#### RHEL/CentOS Linux
+
+Enable the [Extra Packages for Enterprise Linux](https://fedoraproject.org/wiki/EPEL)
+repository:
 
 ```bash
-# Install runtime pre-reqs
-# Then copy the desired R version from the CDN
-
-OS_IDENTIFIER=ubuntu-1804
-R_VERSION=3.5.3
-
-wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz 
-mkdir -p /opt/R 
-tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz 
-rm R-${R_VERSION}.tar.gz
-
-# execute R from this directory
-/opt/R/${R_VERSION}/bin/R -e 'capabilities()'
-
-# optionally add this version to the path
-PATH=/opt/R/${R_VERSION}/bin:${PATH}
-
-# OR optionally link the binaries to /usr
-ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R 
-ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript
-ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R 
-```
-The R binary can be obtain from the CDN using a URL with the format:  
-
-```
-https://cdn.rstudio.com/r/<OS_IDENTIFIER>/R-<R_VERSION>-<OS_IDENTIFIER>.tar.gz
+# CentOS / RHEL 7
+sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ```
 
-The list of currently available R versions can be obtained here:
-https://cdn.rstudio.com/r/versions.json.  
+Download the rpm package:
+```bash
+# CentOS / RHEL 7
+wget https://cdn.rstudio.com/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+```
 
-The following operating systems are supported:  
+Then install the package:
+```bash
+sudo yum install R-${R_VERSION}-1-1.x86_64.rpm
+```
 
-|Operating System|OS Identifier| 
-|---|---|
-|CentOS 6|centos-6|
-|CentOS 7|centos-7|
-|Debian 9|debian-9|
-|OpenSUSE 15.1|opensuse-15|
-|OpenSUSE 42.3|opensuse-42|
-|Ubuntu 16.04 Xenial|ubuntu-1604|
-|Ubuntu 18.04 Bionic|ubuntu-1804|
+#### SUSE Linux
 
-The R binaries are built on these open source containers, but have been tested
-on their commerical equivalents. For example, the CentOS binaries also work on
-RedHat Enterprise Linux (REHL) and the OpenSUSE binaries also work on SUSE Linux
-Enterprise Server (SLES).
+Enable the [Science](https://en.opensuse.org/openSUSE:Science_Repositories) repository (SLES 12 only):
+```bash
+# SLES 12
+sudo zypper --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/science/SLE_12/science.repo
+```
 
-Please see [r-docker](https://github.com/rstudio/r-docker) and
-[r-system-requirements](https://github.com/rstudio/r-system-requirements) for
-more information on using these binaries. The `r-docker` repository documents
-required runtime system dependencies and provides users with docker images
-containing these dependencies. The `r-system-requirements` repository contains
-information on the additional system dependencies that may be required to
-install and use R packages.
+Download the rpm package:
+```bash
+# openSUSE 42.3 / SLES 12
+wget https://cdn.rstudio.com/r/opensuse-42/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+
+# openSUSE 15.0 / SLES 15
+wget https://cdn.rstudio.com/r/opensuse-15/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+```
+
+Then install the package:
+```bash
+sudo zypper --no-gpg-checks install R-${R_VERSION}-1-1.x86_64.rpm
+```
+
+### Verify R installation
+
+Test that R was successfully installed by running:
+```bash
+/opt/R/${R_VERSION}/bin/R --version
+```
+
+### Add R to the system path
+
+To ensure that R is available on the system path, create symbolic links to
+the version of R that you installed:
+
+```bash
+sudo ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R 
+sudo ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
+```
+
+### Optional post-installation steps
+
+You may want to install additional system dependencies for R packages.
+We recommend installing a TeX distribution (such as [TinyTeX](https://yihui.name/tinytex/)
+or TeX Live) and Pandoc. For more information on system dependencies, see
+[system requirements for R packages](https://github.com/rstudio/r-system-requirements).
+
+If you want to install multiple versions of R on the same system, you can
+repeat these steps to install a different version of R alongside existing versions.
 
 ---
 
@@ -94,7 +138,7 @@ new platform or inspect an existing platform.
 
 ### Dockerfile
 
-Create a `builder/Dockerfile.platform-version` (where `platform-version` is `ubuntu-1604` or `centos-74`, etc.) This file must contain four major tasks:
+Create a `builder/Dockerfile.platform-version` (where `platform-version` is `ubuntu-1604` or `centos-7`, etc.) This file must contain four major tasks:
 
 1. an `OS_IDENTIFIER` env with the `platform-version`.
 2. a step which ensures the R source build dependencies are installed
@@ -149,7 +193,7 @@ environment:
   # snip
   JOB_DEFINITION_ARN_debian_9:
     Ref: rBuildsBatchJobDefinitionDebian9
-  SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9
+  SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9,centos-6,centos-7,opensuse-42,opensuse-15
 ```
 
 ### Makefile


### PR DESCRIPTION
Rewrites the install steps to use the new rpm/deb packages instead of tarballs. I adapted the format from https://docs.rstudio.com/resources/r/install-r-binary/, which will eventually be the official place, I think.