### PR TITLE
Allows building of RPMs for CentOS 6

### DIFF
--- a/builder/Dockerfile.centos-6
+++ b/builder/Dockerfile.centos-6
@@ -37,6 +37,7 @@ RUN yum -y update \
     pkgconfig \
     python \
     readline-devel \
+    rpm-build \
     stunnel \
     tcl-devel \
     texinfo-tex \
@@ -189,9 +190,34 @@ ENV MAKEINFO=makeinfo
 # RHEL 6 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"
 
+#-- required for fpm --
+## install rvm
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - \
+   && curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - \
+   && curl -L get.rvm.io | bash -s stable
+## use rvm to install ruby
+RUN source /etc/profile.d/rvm.sh \
+   && /usr/local/rvm/bin/rvm reload \
+   && /usr/local/rvm/bin/rvm requirements run \
+   && /usr/local/rvm/bin/rvm install 2.6.3 \
+   && /usr/local/rvm/bin/rvm use 2.6.3 --default
+
+
+# RUN gem install fpm -v 0.4.26
+RUN export PATH=/usr/local/rvm/rubies/ruby-2.6.3/bin/:/.gems/bin:${PATH} \
+   && export GEM_HOME=/.gems \
+   && export GEM_PATH=/.gems \
+   && gem install --no-document fpm \
+   && /usr/local/rvm/bin/rvm repair wrappers
+
+RUN echo 'source /etc/profile.d/rvm.sh' >> .bashrc
+#----------------------
+
+
 # Copy a script to help set up the environment
 COPY env_centos6.sh ./env.sh
 
+COPY package.centos-6 /package.sh
 COPY build.sh .
 
 # Copy a script to clean up after the build

--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -42,6 +42,7 @@ fpm \
   --after-remove /before-remove.sh \
   -p /tmp/output/centos-6/ \
   -d bzip2-devel \
+  -d dejavu-sans-fonts \
   -d gcc \
   -d gcc-c++ \
   -d gcc-gfortran \

--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -1,0 +1,70 @@
+if [[ ! -d /tmp/output/centos-6 ]]; then
+  mkdir -p /tmp/output/centos-6
+fi
+
+# create post-install script required for openblas
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep 
+ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
+# create after-remove script to remove internal blas
+cat <<EOF >> /before-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
+# set environment for fpm
+export PATH=/usr/local/rvm/rubies/ruby-2.6.3/bin/:/.gems/bin:${PATH}
+export GEM_HOME=/.gems
+export GEM_PATH=/.gems
+
+# Additional config for c++11 support
+sed -i 's/^CXX11\ =\ .*/CXX11\ =\ g++/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
+sed -i 's/^CXX11FLAGS\ =\ .*/CXX11FLAGS\ =\ -g\ -O2\ \$\(LTO\)/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
+sed -i 's/^CXX11PICFLAGS\ =\ .*/CXX11PICFLAGS\ =\ -fpic/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
+sed -i 's/^CXX11STD\ =\ .*/CXX11STD\ =\ -std=gnu++11/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "RStudio Inc." \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  --after-install /post-install.sh \
+  --after-remove /before-remove.sh \
+  -p /tmp/output/centos-6/ \
+  -d bzip2-devel \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-gfortran \
+  -d libcurl-devel \
+  -d libicu-devel \
+  -d libSM \
+  -d libtiff \
+  -d libXmu \
+  -d libXt \
+  -d make \
+  -d openblas-devel \
+  -d pango \
+  -d pcre-devel \
+  -d pcre2-devel \
+  -d tcl \
+  -d tk \
+  -d unzip \
+  -d which \
+  -d xz-devel \
+  -d zip \
+  -d zlib-devel \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/centos-6/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+


### PR DESCRIPTION
Builds on earlier work and provides the tooling required to create Linux OS packages (deb in this case).

Modifies: Dockerfile.centos-6

So that it includes the fpm package build tool and also copies in the packaging scriip
Adds: package.centos-6

which is the packaging script which runs fpm with the required parameters and dependencies