### PR TITLE
Use non-devel libicu for CentOS 6 rpm

### DIFF
--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -47,7 +47,7 @@ fpm \
   -d gcc-c++ \
   -d gcc-gfortran \
   -d libcurl-devel \
-  -d libicu-devel \
+  -d libicu \
   -d libSM \
   -d libtiff \
   -d libXmu \


### PR DESCRIPTION
For RHEL 6 support, since RHEL 6 only has the non-devel libicu by default.

RHEL 6 may have libicu-devel in its 'optional' channel according to this: https://access.redhat.com/solutions/389423. But the devel version of libicu isn't required to run R anyway (EPEL R also doesn't have it), so it might be easier on users to not require it.