### PR TITLE
Add OS info to user agent; set user agent in system Rprofile

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -94,8 +94,9 @@ compile_r() {
   make
   make install
 
-  # Add OS identifier to the default HTTP user agent
-  cat <<EOF >> /opt/R/${1}/lib/R/etc/Rprofile.site
+  # Add OS identifier to the default HTTP user agent.
+  # Set this in the system Rprofile so it works when R is run with --vanilla.
+  cat <<EOF >> /opt/R/${1}/lib/R/library/base/R/Rprofile
 ## Set the default HTTP user agent
 local({
   os_identifier <- if (file.exists("/etc/os-release")) {


### PR DESCRIPTION
Follow-up of #30:

- Adds OS information to the default user agent in the form of `ID-VERSION_ID` from `/etc/os-release`. For distros without `/etc/os-release` (CentOS/RHEL 6), we fall back to the r-builds OS identifier. Examples of the new user agents:
  - RHEL 7: `R/3.6.1 (rhel-7.7) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)`
  - RHEL 6: `R/3.6.1 (centos-6) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)`
- Sets the user agent through the system Rprofile so that it works when R is run with `--vanilla`. This works around the issue with installing binaries through the IDE prompt (see https://github.com/rstudio/rstudio/issues/5369)

**A few questions**
- For CentOS/RHEL 6, is it ok to fall back to the r-builds OS identifier? Should we try to parse `/etc/system-release` instead, or is there something better?
- I just realized that openSUSE 15's `ID` has a hyphen in it, so the user agent looks like `R/3.6.1 (opensuse-leap-15.0)`. Would that cause issues for parsing? We could use something like a space to separate ID and version instead.

**Testing**

I built R 3.0.3 and 3.6.1 for each OS and checked the user agent under `R --vanilla`. Here's what they look like for R 3.6:
```sh
# Debian 9
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (debian-9) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# Ubuntu 16
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (ubuntu-16.04) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# Ubuntu 18
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (ubuntu-18.04) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# CentOS 6
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (centos-6) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# CentOS 7
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (centos-7) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# RHEL 6
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (centos-6) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# RHEL 7
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (rhel-7.7) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# openSUSE 42
/opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (opensuse-42.3) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# openSUSE 15
/opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (opensuse-leap-15.0) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# SLES 12
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (sles-12.4) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"

# SLES 15
$ /opt/R/3.6.1/bin/R --vanilla -e 'getOption("HTTPUserAgent")'
> getOption("HTTPUserAgent")
[1] "R/3.6.1 (sles-15) R (3.6.1 x86_64-pc-linux-gnu x86_64 linux-gnu)"
```