### PR TITLE
Takes version as 2nd arg, R versions, help and version CLI switches, silent json fetch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,10 @@ SCRIPT_ACTION=${SCRIPT_ACTION:-install}
 
 # Set to the full version to install. Must be either available on S3 or in the working directory
 R_VERSION=${R_VERSION:-}
+# The version may optionally be provided as a second argument
+if [[ "$2" != "" ]]; then
+  R_VERSION=$2cd
+fi
 
 SUDO=
 if [[ $(id -u) != "0" ]]; then
@@ -20,7 +24,7 @@ CDN_URL='https://cdn.rstudio.com/r'
 # The URL for listing available R versions
 VERSIONS_URL="${CDN_URL}/versions.json"
 
-R_VERSIONS=$(curl ${VERSIONS_URL} | \
+R_VERSIONS=$(curl -s ${VERSIONS_URL} | \
   # Matches the JSON line that contains the r versions
   grep r_versions | \
   # Gets the value of the `r_version` property (e.g., "[ 3.0.0, 3.0.3, ... ]")
@@ -104,6 +108,14 @@ show_versions () {
   for v in ${R_VERSIONS}
   do
     echo "  ${v}"
+  done
+}
+
+# Same as above but for automation purposes
+do_show_versions () {
+  for v in ${R_VERSIONS}
+  do
+    echo "${v}"
   done
 }
 
@@ -367,7 +379,6 @@ check_commands () {
 }
 
 do_install () {
-
   # Check for curl
   check_commands
 
@@ -401,5 +412,8 @@ do_install () {
 case ${SCRIPT_ACTION} in
   "install")
     do_install
+    ;;
+  "version")
+    do_show_versions
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -379,6 +379,7 @@ check_commands () {
 }
 
 do_install () {
+
   # Check for curl
   check_commands
 
@@ -413,7 +414,7 @@ case ${SCRIPT_ACTION} in
   "install")
     do_install
     ;;
-  "version")
+  "versions")
     do_show_versions
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+THIS_VERSION="1.0"
 
 # Call with:
 #   bash -c "$(curl -L https://rstd.io/r-install)"
@@ -10,7 +11,7 @@ SCRIPT_ACTION=${SCRIPT_ACTION:-install}
 R_VERSION=${R_VERSION:-}
 # The version may optionally be provided as a second argument
 if [[ "$2" != "" ]]; then
-  R_VERSION=$2cd
+  R_VERSION=$2
 fi
 
 SUDO=
@@ -409,12 +410,28 @@ do_install () {
   install "${installer_type}" "${installer_file_name}" "${os}" "${os_ver}"
 }
 
+do_show_usage() {
+  echo "r-builds quick install version ${THIS_VERSION}"
+  echo "Usage: `basename $0` [-i|-r|-v|-h|install|rversions|version|help]"
+  echo "Where:"
+  echo "'-i' or 'install' [version] (default) install the given version or list R versions available for quick install and prompt for one if none is provided"
+  echo "'-r' or 'rversions' list the R versions available for quick install, one per line"
+  echo "'-v' or 'versions' shows the version of this command"
+  echo "'-h' or 'help' show this info"
+}
+
 # Choose a command to perform
 case ${SCRIPT_ACTION} in
-  "install")
+  "-i"|"install")
     do_install
     ;;
-  "versions")
+  "-r"|"rversions")
     do_show_versions
     ;;
+  "-v"|"version")
+    echo "r-builds quick install version ${THIS_VERSION}"
+    ;;
+  "-h"|"help"|*)
+    do_show_usage
+    ;;   
 esac


### PR DESCRIPTION
Here are some facilities to promote automation around the quick install script:
- Take the version to be install as a 2nd argument to `install` or (`-i`). It's easier for the caller to only use the command line instead of passing the version as an environment variable.
- List all available versions with the CLI switch `rversions` (or `-r`). To make it easy for other scripts/commands to consume this output, a few additional changes were made:
   - The `curl` fetching `VERSIONS_URL` is done silently. Without this the `curl` output would mess with the consumers of this script that would only expect a list of versions, one per line.
   - `do_show_versions` was added because of the leading spaces needed by `show_versions` for formatting the prompt.
- The command version is shown with `-v` or `version`. Starting at 1.0.
- The command help is shown with `-h` or `help` or any other invalid option.