### PR TITLE
Add R builds for CentOS/RHEL 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-1604 ubuntu-1804 debian-9 centos-6 centos-7 opensuse-42 opensuse-15
+PLATFORMS := ubuntu-1604 ubuntu-1804 debian-9 centos-6 centos-7 centos-8 opensuse-42 opensuse-15
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless
 
 deps:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bug, or ask questions on [RStudio Community](https://community.rstudio.com).
 R binaries are built for the following Linux operating systems:
 - Ubuntu 16.04, 18.04
 - Debian 9
-- CentOS / Red Hat Enterprise Linux 6, 7
+- CentOS / Red Hat Enterprise Linux 6, 7, 8
 - openSUSE 42.3, 15.0
 - SUSE Linux Enterprise 12, 15
 
@@ -68,7 +68,7 @@ sudo gdebi r-${R_VERSION}_1_amd64.deb
 #### RHEL/CentOS Linux
 
 Enable the [Extra Packages for Enterprise Linux](https://fedoraproject.org/wiki/EPEL)
-repository:
+repository (RHEL/CentOS 6 and 7 only):
 
 ```bash
 # CentOS / RHEL 6
@@ -85,6 +85,9 @@ wget https://cdn.rstudio.com/r/centos-6/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
 # CentOS / RHEL 7
 wget https://cdn.rstudio.com/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+
+# CentOS / RHEL 8
+wget https://cdn.rstudio.com/r/centos-8/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:
@@ -208,7 +211,7 @@ environment:
   # snip
   JOB_DEFINITION_ARN_debian_9:
     Ref: rBuildsBatchJobDefinitionDebian9
-  SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9,centos-6,centos-7,opensuse-42,opensuse-15
+  SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9,centos-6,centos-7,centos-8,opensuse-42,opensuse-15
 ```
 
 ### Makefile

--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -1,0 +1,75 @@
+FROM centos:centos8
+
+ENV OS_IDENTIFIER centos-8
+
+RUN dnf -y upgrade \
+    && dnf -y install dnf-plugins-core \
+    && dnf config-manager --set-enabled PowerTools \
+    && dnf -y install \
+    autoconf \
+    automake \
+    bzip2-devel \
+    cairo-devel \
+    gcc-c++ \
+    gcc-gfortran \
+    java-1.8.0-openjdk-devel \
+    java-1.8.0-openjdk-headless \
+    libICE-devel \
+    libSM-devel \
+    libX11-devel \
+    libXmu-devel \
+    libXt-devel \
+    libcurl-devel \
+    libicu-devel \
+    libjpeg-devel \
+    libpng-devel \
+    libtiff-devel \
+    libtool \
+    make \
+    ncurses-devel \
+    pango-devel \
+    pcre-devel \
+    pcre2-devel \
+    python36 \
+    python3-pip \
+    readline-devel \
+    rpm-build \
+    ruby \
+    ruby-devel \
+    tcl-devel \
+    tex \
+    texinfo-tex \
+    texlive-collection-latexrecommended \
+    tk-devel \
+    valgrind-devel \
+    which \
+    wget \
+    xz-devel \
+    zlib-devel \
+    && dnf clean all
+
+# Install AWS CLI.
+RUN pip3 install awscli --upgrade --user \
+    && ln -s /root/.local/bin/aws /usr/bin/aws
+
+RUN gem install fpm
+
+RUN chmod 0777 /opt
+
+# Configure flags for CentOS 8 that don't use the defaults in build.sh
+ENV CONFIGURE_OPTIONS="\
+    --enable-R-shlib \
+    --with-tcltk \
+    --enable-memory-profiling \
+    --with-x \
+    --with-system-valgrind-headers \
+    --with-tcl-config=/usr/lib64/tclConfig.sh \
+    --with-tk-config=/usr/lib64/tkConfig.sh \
+    --enable-prebuilt-html"
+
+# RHEL 8 doesn't have the inconsolata font, so override the defaults.
+ENV R_RD4PDF="times,hyper"
+
+COPY package.centos-8 /package.sh
+COPY build.sh .
+ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -56,6 +56,17 @@ services:
     image: r-builds:centos-7
     volumes:
       - ./integration/tmp:/tmp/output
+  centos-8:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.centos-8
+    image: r-builds:centos-8
+    volumes:
+      - ./integration/tmp:/tmp/output
   opensuse-42:
     command: ./build.sh
     environment:

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -1,0 +1,59 @@
+if [[ ! -d /tmp/output/centos-8 ]]; then
+  mkdir -p /tmp/output/centos-8
+fi
+
+# create post-install script required for openblas
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblasp.so.0 /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
+# create after-remove script to remove internal blas
+cat <<EOF >> /before-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "RStudio Inc." \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio Inc https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  --after-install /post-install.sh \
+  --after-remove /before-remove.sh \
+  -p /tmp/output/centos-8/ \
+  -d bzip2-devel \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-gfortran \
+  -d libcurl-devel \
+  -d libicu-devel \
+  -d libSM \
+  -d libtiff \
+  -d libXmu \
+  -d libXt \
+  -d make \
+  -d openblas-threads \
+  -d pango \
+  -d pcre-devel \
+  -d pcre2-devel \
+  -d tcl \
+  -d tk \
+  -d unzip \
+  -d which \
+  -d xz-devel \
+  -d zip \
+  -d zlib-devel \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/centos-8/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -191,6 +191,18 @@ rBuildsBatchJobDefinitionCentos7:
       JobRoleArn:
         "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:centos-7"
+rBuildsBatchJobDefinitionCentos8:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:centos-8"
 rBuildsBatchJobDefinitionOpensuse42:
   Type: AWS::Batch::JobDefinition
   Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -45,11 +45,13 @@ provider:
       Ref: rBuildsBatchJobDefinitionCentos6
     JOB_DEFINITION_ARN_centos_7:
       Ref: rBuildsBatchJobDefinitionCentos7
+    JOB_DEFINITION_ARN_centos_8:
+      Ref: rBuildsBatchJobDefinitionCentos8
     JOB_DEFINITION_ARN_opensuse_42:
       Ref: rBuildsBatchJobDefinitionOpensuse42
     JOB_DEFINITION_ARN_opensuse_15:
       Ref: rBuildsBatchJobDefinitionOpensuse15
-    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9,centos-6,centos-7,opensuse-42,opensuse-15
+    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9,centos-6,centos-7,centos-8,opensuse-42,opensuse-15
 
 functions:
   queueBuilds:


### PR DESCRIPTION
This is pretty much the same as CentOS 7, but with a couple differences:

- `gcc-objc` was removed since RHEL 8 [dropped support for Objective C/C++](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/compilers-and-development-tools_considerations-in-adopting-rhel-8). I don't know if it can be replaced, but the EPEL 8 rpm also removed it without a replacement.
- Added the PowerTools repo for `texinfo-tex`, which is needed to build HTML versions of manuals (`dnf config-manager --set-enabled PowerTools`)
- Doesn't require EPEL anymore, since `openblas-threads` (runtime lib) is in the base CentOS/RHEL repo. `openblas-devel` does exist in CentOS 8's PowerTools repo, but I'm not sure if there's an equivalent repo in RHEL 8. Maybe the codeready-builder-for-rhel-8-*-rpms repo like mentioned in https://fedoraproject.org/wiki/EPEL

Testing: I've run the usual r-docker tests on these rpms in CentOS 8 and RHEL 8, but haven't done extensive testing beyond that yet.