### PR TITLE
Fix incompatibility with default gcc on CentOS/RHEL 6

### DIFF
--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -21,8 +21,9 @@ export GEM_HOME=/.gems
 export GEM_PATH=/.gems
 
 # Additional config for C++11 support in R 3.6.
-# R 3.6 no longer sets CXX11 flags without a full C++11 compiler present, but
+# R 3.6.0 no longer sets CXX11 flags without a full C++11 compiler present, but
 # the default gcc 4.4.7 still partially supports C++11 through -std=gnu++0x.
+# Use the same CXX11 flags as the defaults in R versions prior to 3.6.0.
 sed -i 's/^CXX11\ =\ .*/CXX11\ =\ g++/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
 sed -i 's/^CXX11FLAGS\ =\ .*/CXX11FLAGS\ =\ -g\ -O2\ \$\(LTO\)/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
 sed -i 's/^CXX11PICFLAGS\ =\ .*/CXX11PICFLAGS\ =\ -fpic/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf

--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -d /tmp/output/centos-6 ]]; then
   mkdir -p /tmp/output/centos-6
 fi

--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -24,7 +24,7 @@ export GEM_PATH=/.gems
 sed -i 's/^CXX11\ =\ .*/CXX11\ =\ g++/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
 sed -i 's/^CXX11FLAGS\ =\ .*/CXX11FLAGS\ =\ -g\ -O2\ \$\(LTO\)/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
 sed -i 's/^CXX11PICFLAGS\ =\ .*/CXX11PICFLAGS\ =\ -fpic/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
-sed -i 's/^CXX11STD\ =\ .*/CXX11STD\ =\ -std=gnu++11/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
+sed -i 's/^CXX11STD\ =\ .*/CXX11STD\ =\ -std=gnu++0x/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
 
 fpm \
   -s dir \

--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -20,7 +20,9 @@ export PATH=/usr/local/rvm/rubies/ruby-2.6.3/bin/:/.gems/bin:${PATH}
 export GEM_HOME=/.gems
 export GEM_PATH=/.gems
 
-# Additional config for c++11 support
+# Additional config for C++11 support in R 3.6.
+# R 3.6 no longer sets CXX11 flags without a full C++11 compiler present, but
+# the default gcc 4.4.7 still partially supports C++11 through -std=gnu++0x.
 sed -i 's/^CXX11\ =\ .*/CXX11\ =\ g++/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
 sed -i 's/^CXX11FLAGS\ =\ .*/CXX11FLAGS\ =\ -g\ -O2\ \$\(LTO\)/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf
 sed -i 's/^CXX11PICFLAGS\ =\ .*/CXX11PICFLAGS\ =\ -fpic/g' /opt/R/${R_VERSION}/lib/R/etc/Makeconf

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -d /tmp/output/centos-7 ]]; then
   mkdir -p /tmp/output/centos-7
 fi

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -d /tmp/output/debian-9 ]]; then
   mkdir -p /tmp/output/debian-9
 fi

--- a/builder/package.opensuse-15
+++ b/builder/package.opensuse-15
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -d /tmp/output/opensuse-15 ]]; then
   mkdir -p /tmp/output/opensuse-15
 fi

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -d /tmp/output/opensuse-42 ]]; then
   mkdir -p /tmp/output/opensuse-42
 fi

--- a/builder/package.ubuntu-1604
+++ b/builder/package.ubuntu-1604
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -d /tmp/output/ubuntu-1604 ]]; then
   mkdir -p /tmp/output/ubuntu-1604
 fi

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ ! -d /tmp/output/ubuntu-1804 ]]; then
   mkdir -p /tmp/output/ubuntu-1804
 fi


### PR DESCRIPTION
@aronatkins discovered that when you install R on a CentOS 6 system with the default gcc, some packages like `digest` fail to install:
```r
> install.packages("digest")

* installing *source* package 'digest' ...
** package 'digest' successfully unpacked and MD5 sums checked
** using staged installation
** libs
g++ -std=gnu++11 -I"/opt/R/3.6.1/lib/R/include" -DNDEBUG   -I/usr/local/include  -fpic  -g -O2  -c SpookyV2.cpp -o SpookyV2.o
cc1plus: error: unrecognized command line option "-std=gnu++11"
```
But `digest` installs fine when using R from EPEL 6.

The problem is that we set the `-std=gnu++11` flag for packages that require C++11:
https://github.com/rstudio/r-builds/blob/7182392191dc455a2787370f25d6f499bfeef1d9/builder/package.centos-6#L23-L27

But the default gcc on CentOS/RHEL 6 (gcc 4.4.7) isn't new enough to support `-std=gnu++11`, only `-std=gnu++0x`: https://gcc.gnu.org/projects/cxx-status.html#cxx11. So any R packages that compile with C++11 (like `digest`) will immediately fail.

This switches the gcc flag to `-std=gnu++0x` for compatibility with the default gcc. I'm not real familiar with the differences between `-std=gnu++0x` and `-std=gnu++11`, but it sounds like they're equivalent -- `gnu++0x` is just deprecated in newer gcc versions: https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-C_002b_002b11-code
