### PR TITLE
Support building R-devel

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -40,7 +40,12 @@ archive_r() {
 
 fetch_r_source() {
   echo "Downloading R-${1}"
-  wget -q "${CRAN}/src/base/R-`echo ${1}| awk 'BEGIN {FS="."} {print $1}'`/R-${1}.tar.gz" -O /tmp/R-${1}.tar.gz
+  if [ "${1}" = devel ]; then
+    # Download the daily tarball of R devel
+    wget -q https://stat.ethz.ch/R/daily/R-devel.tar.gz -O /tmp/R-devel.tar.gz
+  else
+    wget -q "${CRAN}/src/base/R-`echo ${1}| awk 'BEGIN {FS="."} {print $1}'`/R-${1}.tar.gz" -O /tmp/R-${1}.tar.gz
+  fi
   echo "Extracting R-${1}"
   tar xf /tmp/R-${1}.tar.gz -C /tmp
   rm /tmp/R-${1}.tar.gz

--- a/handler.py
+++ b/handler.py
@@ -43,6 +43,7 @@ def _cran_all_r_versions():
     r_versions = []
     r_versions.extend(_cran_r_versions(CRAN_SRC_R3_URL))
     r_versions.extend(_cran_r_versions(CRAN_SRC_R4_URL))
+    r_versions.append('devel')
     return {'r_versions': r_versions}
 
 


### PR DESCRIPTION
Martin Maechler, a member of R core provides a daily tarball of R-devel
sources at https://stat.ethz.ch/R/daily. This provides support for
building based on this source if R_VERSION is set to 'devel'

There likely need to be more changes than this, for instance devel needs to be added to https://cdn.rstudio.com/r/versions.json and a daily build needs to be scheduled, but this at least gets us started to resolving #6