### PR TITLE
Add note about enabling the Optional repo on RHEL 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noa
 sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ```
 
+> Note that on RHEL 7, you may also need to enable the Optional repository:
+> ```bash
+> # For RHEL 7 users with certificate subscriptions:
+> sudo subscription-manager repos --enable "rhel-*-optional-rpms"
+>
+> # Or alternatively, using yum:
+> sudo yum install yum-utils
+> sudo yum-config-manager --enable "rhel-*-optional-rpms"
+> ```
+
 Download the rpm package:
 ```bash
 # CentOS / RHEL 6


### PR DESCRIPTION
The "Optional" repository is needed to install `pcre2-devel` for R on RHEL 7. This is already documented as a recommendation in the [EPEL install instructions](https://fedoraproject.org/wiki/EPEL), but it's useful to explicitly note it here as well.

The instructions were copied from EPEL's wiki, but I also added an alternative method using `yum-config-manager`. The `subscription-manager` method only works if you have a certificate-based RHEL 7 subscription, so it doesn't work on [RHEL AMIs for Amazon EC2](https://aws.amazon.com/partners/redhat/faqs/). On EC2, you use `yum-config-manager` instead. 

Also, the repos on the RHEL AMIs are named differently: `rhel-7-server-rhui-optional-rpms` vs. `rhel-7-server-optional-rpms`. But using a wildcard, I believe the `yum-config-manager --enable "rhel-*-optional-rpms"` command would also work on a regular RHEL server in case anyone tries it.

**Question**: do we want to add this to the quickinstall script? Getting it to work properly across all RHEL systems could be tricky. If you run `subscription-manager` on an EC2 instance, yum starts pestering you with "This system is not registered with an entitlement server" messages, which is annoying to turn off. And `yum-config-manager` doesn't actually work on my RHEL 7 subscription VM for some odd reason or bug. One thing we could do is to check if the "Optional" repo is enabled, and just exit with a warning + instructions if not enabled.

---

I also looked into whether we could drop `pcre2-devel` to runtime-only `pcre2`, but decided against it. R links against pcre2, so some packages would fail to install from source (e.g. rJava) if we removed the development headers:
```sh
[root@a2e17c2b7cc5 /]# R CMD config --ldflags
-Wl,--export-dynamic -fopenmp -L/usr/local/lib -L/opt/R/3.6.1/lib/R/lib -lR -lpcre2-8 -lpcre -llzma -lbz2 -lz -lrt -ldl -lm -licuuc -licui18n
```

The `R-core-devel` package from EPEL also depends on packages from the Optional repo, so hopefully it's not too much trouble for users to add it.