### PR TITLE
shift deploy to separate job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,19 +23,13 @@ pipeline {
       }
     }
     stage('deploy') {
-      agent {
-        dockerfile {
-          dir 'jenkins'
-          label 'docker-4x'
-          additionalBuildArgs '--build-arg DOCKER_GID=$(stat -c %g /var/run/docker.sock) --build-arg JENKINS_UID=$(id -u jenkins) --build-arg JENKINS_GID=$(id -g jenkins)'
-          args '-v /var/run/docker.sock:/var/run/docker.sock --group-add docker'
-        }
-      }
+      agent none
       when {
         branch 'master'
       }
       steps {
-        sh 'make serverless-deploy.production'
+        build(job: 'hostedapps/deploy/r-builds', wait: true,
+              parameters: [string(name: 'ENVIRONMENT', value: 'staging')])
       }
     }
   }

--- a/deploy.Jenkinsfile
+++ b/deploy.Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+  agent {
+    dockerfile {
+      dir 'jenkins'
+      label 'docker'
+      additionalBuildArgs '--build-arg DOCKER_GID=$(stat -c %g /var/run/docker.sock) --build-arg JENKINS_UID=$(id -u jenkins) --build-arg JENKINS_GID=$(id -g jenkins)'
+      args '-v /var/run/docker.sock:/var/run/docker.sock --group-add docker'
+    }
+  }
+  environment {
+    HOME = "."
+  }
+  options {
+    ansiColor('xterm')
+  }
+  parameters {
+    choice(name: 'ENVIRONMENT', choices: ['staging', 'production'],
+           description: 'The target environment to deploy to.')
+  }
+  stages {
+    stage('deploy') {
+      steps {
+        sh 'make serverless-deploy.${params.ENVIRONMENT}'
+      }
+    }
+  }
+}

--- a/deploy.Jenkinsfile
+++ b/deploy.Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('deploy') {
       steps {
-        sh 'make serverless-deploy.${params.ENVIRONMENT}'
+        sh "make serverless-deploy.${params.ENVIRONMENT}"
       }
     }
   }


### PR DESCRIPTION
This moves the serverless deploy to a separate job so that different environments can be targeted.

Notably, the creation of new docker images is not part of the deploy stage, and is not based per-environment -- master branch builds will push new docker images.