### PR TITLE
Skip CentOS 8 / R 3.3 builds with the configure script bug

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -113,8 +113,10 @@ def queue_builds(event, context):
     job_ids = []
     for version in event['versions_to_build']:
         for platform in event['supported_platforms']:
-            # skip bionic builds with a configure script bug
-            if (platform == 'ubuntu-1804' or platform == 'opensuse-15') and version in ['3.3.0', '3.3.1', '3.3.2']:
+            # In R 3.3.0, 3.3.1, and 3.3.2, the configure script check for the
+            # zlib version fails to handle versions longer than 5 characters.
+            # Skip builds affected by this bug.
+            if platform in ['ubuntu-1804', 'opensuse-15', 'centos-8'] and version in ['3.3.0', '3.3.1', '3.3.2']:
                 continue
             job_ids.append(_submit_job(version, platform))
     event['jobIds'] = job_ids


### PR DESCRIPTION
I just tried building CentOS 8, and everything worked fine except for R 3.3.0, 3.3.1, and 3.3.2. It looks like the same issue that Ubuntu 18 and openSUSE 15 had with the configure script bug.

```
21:24:35 checking if zlib version >= 1.2.5... no
21:24:35 configure: error: zlib library and headers are required
21:24:36 checking whether zlib support suffices...
```

More details about the bug, for future reference: https://stat.ethz.ch/pipermail/r-devel/2017-February/073752.html