### PR TITLE
Update SLES 12 installation for Science repository removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ sudo yum install R-${R_VERSION}-1-1.x86_64.rpm
 
 #### SUSE Linux
 
-Enable the [Science](https://en.opensuse.org/openSUSE:Science_Repositories) repository (SLES 12 only):
+Enable the Python backports repository (SLES 12 only):
 ```bash
 # SLES 12
-sudo zypper --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/science/SLE_12/science.repo
+VERSION="SLE_$(grep "^VERSION=" /etc/os-release | sed -e 's/VERSION=//' -e 's/"//g' -e 's/-/_/')"
+sudo zypper --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/devel:/languages:/python:/backports/$VERSION/devel:languages:python:backports.repo
 ```
 
 Download the rpm package:

--- a/install.sh
+++ b/install.sh
@@ -291,7 +291,7 @@ install_pre () {
       install_epel "${ver}"
       ;;
     "SLES12")
-      install_sci
+      install_python_backports
       ;;
     "LEAP12" | "LEAP15" | "SLES15")
       ;;
@@ -317,9 +317,10 @@ install_epel () {
   esac
 }
 
-# Installs the Science repository for SLES 12
-install_sci () {
-  ${SUDO} zypper --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/science/SLE_12/science.repo
+# Installs the Python backports repository for SLES 12
+install_python_backports () {
+  SLE_VERSION="SLE_$(grep "^VERSION=" /etc/os-release | sed -e 's/VERSION=//' -e 's/"//g' -e 's/-/_/')"
+  ${SUDO} zypper --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/devel:/languages:/python:/backports/$SLE_VERSION/devel:languages:python:backports.repo
 }
 
 do_download () {


### PR DESCRIPTION
The Science repo (required for OpenBLAS) no longer supports SLES 12, so the SLES 12 installation is currently broken: https://download.opensuse.org/repositories/science/

I looked for alternative repositories with OpenBLAS, and found several working candidates:
- [Python backports](https://build.opensuse.org/package/show/devel%3Alanguages%3Apython%3Abackports/openblas%3Aserial) (`devel:languages:python:backports`) provides OpenBLAS 0.3.9 on SLES 12 SP4 and SP5, same version as Science
- [SUSE Cloud Foundry](https://build.opensuse.org/package/show/Cloud%3APlatform%3AStack-SLE%3Apackages/openblas) (`Cloud:Platform:Stack-SLE:packages`) provides OpenBLAS 0.2.19 on SLES 12 SP4
- [OpenStack](https://build.opensuse.org/package/show/Cloud%3AOpenStack%3AQueens/openblas%3Aserial) (`Cloud:OpenStack:Queens` or `Cloud:OpenStack:Rocky`) provides OpenBLAS 0.2.20 on SLES 12 SP3 and 0.3.2 on SP4

These repos all seem reliable, and not prone to dropping SLES 12 support like Science. I tested them all on SLES 12 SP4 and SP5 and didn't find any issues. I'm not totally sure which would work best, but I picked the Python backports repo here since it supports both SP4 and SP5, and provides the same OpenBLAS version as before. It's also probably more likely to be found on a data science box. The other two are meant for SUSE's cloud platform products.

To test this, you can run the quick install script on a SLES 12 SP4 or SP5 system:
```sh
bash -c "$(curl -L https://raw.githubusercontent.com/rstudio/r-builds/sles12-repo/install.sh)"
```

Or add the repo manually, and then install R:
```sh
VERSION="SLE_$(grep "^VERSION=" /etc/os-release | sed -e 's/VERSION=//' -e 's/"//g' -e 's/-/_/')"
sudo zypper --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/devel:/languages:/python:/backports/$VERSION/devel:languages:python:backports.repo
```

Once R is installed, you can confirm that OpenBLAS is being used by checking for `libopenblas_pthreads.so.0` in R's `sessionInfo()`:
```r
> sessionInfo()
R version 3.6.3 (2020-02-29)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: SUSE Linux Enterprise Server 12 SP5

Matrix products: default
BLAS/LAPACK: /usr/lib64/libopenblas_pthreads.so.0
```


