### PR TITLE
Add R 4.0 support for CentOS 6, Debian, SUSE

### DIFF
--- a/builder/Dockerfile.centos-6
+++ b/builder/Dockerfile.centos-6
@@ -3,6 +3,7 @@ FROM centos:centos6
 ENV OS_IDENTIFIER centos-6
 
 RUN yum -y update \
+    && yum -y install epel-release \
     && yum -y install \
     bzip2-devel \
     cairo-devel \
@@ -34,8 +35,10 @@ RUN yum -y update \
     openssl-devel \
     pango-devel \
     pcre-devel \
+    pcre2-devel \
     pkgconfig \
     python \
+    python-pip \
     readline-devel \
     rpm-build \
     stunnel \
@@ -48,10 +51,6 @@ RUN yum -y update \
     xz-devel \
     zlib-devel \
     && yum clean all
-
-# Install pip
-RUN yum install -y epel-release && \
-   yum install -y python-pip
 
 # Install AWS CLI.
 RUN pip install awscli --upgrade --user && \

--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -7,7 +7,7 @@ RUN set -x \
   && echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas-base make python-pip ruby ruby-dev wget \
+     libopenblas-base libpcre2-dev make python-pip ruby ruby-dev wget \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli

--- a/builder/Dockerfile.opensuse-15
+++ b/builder/Dockerfile.opensuse-15
@@ -31,6 +31,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     make \
     pango-devel \
     pcre-devel \
+    pcre2-devel \
     perl \
     perl-macros \
     python \

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -32,6 +32,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     make \
     pango-devel \
     pcre-devel \
+    pcre2-devel \
     perl \
     perl-macros \
     python \

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -33,6 +33,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
+  -d libpcre2-8-0 \
   -d libpcre3 \
   -d libpng16-16 \
   -d libreadline7 \

--- a/builder/package.opensuse-15
+++ b/builder/package.opensuse-15
@@ -51,6 +51,7 @@ fpm \
   -d make \
   -d openblas-devel \
   -d pcre-devel \
+  -d pcre2-devel \
   -d tar \
   -d tcl \
   -d tk \

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -49,6 +49,7 @@ fpm \
   -d make \
   -d openblas-devel \
   -d pcre-devel \
+  -d pcre2-devel \
   -d tar \
   -d tcl \
   -d tk \


### PR DESCRIPTION
Support R 4.0 on CentOS 6, Debian 9, and openSUSE 42/15. This was mostly just adding PCRE2 to the build image and package dependencies. CentOS 7 and 8 already have a PCRE2 dependency, so they don't need any changes to build R 4.0.

Note that this adds an unnecessary PCRE2 dependency to R 3.x and keeps the unused PCRE1 dependency for R 4.x. Later, we should make these PCRE dependencies conditional, but it's kind of tricky to do right now since R 3.5 and 3.6 will link against PCRE2 if present. That means R 3.5+ will take on a PCRE2 dependency, as well as any package that links against libR like rJava (which means rJava binaries built on this new R 3.5/3.6 will be broken if used on an older R binary, or R from apt).

There's no flag to disable linking against PCRE2, but we could work around that by conditionally installing/removing PCRE2 based on R version, or hide PCRE2 from the configure script. But that's more complicated to implement/test so I think we should just get working R 4.0 binaries out for now.

### Testing
I manually built packages for each OS and did some minimal testing on them in a base OS container.

```sh
# Debian 9
$ /opt/R/4.0.0/bin/R -e 'sessionInfo()'
> sessionInfo()
R version 4.0.0 (2020-04-24)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Debian GNU/Linux 9 (stretch)

Matrix products: default
BLAS:   /usr/lib/openblas-base/libblas.so.3
LAPACK: /usr/lib/libopenblasp-r0.2.19.so

# CentOS 8
$ /opt/R/4.0.0/bin/R -e 'sessionInfo()'
> sessionInfo()
R version 4.0.0 (2020-04-24)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: CentOS Linux 8 (Core)

Matrix products: default
BLAS/LAPACK: /usr/lib64/libopenblasp-r0.3.3.so

# CentOS 7
$ /opt/R/4.0.0/bin/R -e 'sessionInfo()'
> sessionInfo()
R version 4.0.0 (2020-04-24)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: CentOS Linux 7 (Core)

Matrix products: default
BLAS/LAPACK: /usr/lib64/libopenblasp-r0.3.3.so

# CentOS 6
$ /opt/R/4.0.0/bin/R -e 'sessionInfo()'
> sessionInfo()
R version 4.0.0 (2020-04-24)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: CentOS release 6.10 (Final)

Matrix products: default
BLAS/LAPACK: /usr/lib64/libopenblasp-r0.3.3.so

# openSUSE 15
/opt/R/4.0.0/bin/R -e 'sessionInfo()'
> sessionInfo()
R version 4.0.0 (2020-04-24)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: openSUSE Leap 15.0

Matrix products: default
BLAS/LAPACK: /usr/lib64/libopenblas_pthreads.so.0

# openSUSE 42
$ /opt/R/4.0.0/bin/R -e 'sessionInfo()'
> sessionInfo()
R version 4.0.0 (2020-04-24)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: openSUSE Leap 42.3

Matrix products: default
BLAS/LAPACK: /usr/lib64/libopenblas_pthreads.so.0
```