### PR TITLE
Fix AWS CLI on CentOS 6

### DIFF
--- a/builder/Dockerfile.centos-6
+++ b/builder/Dockerfile.centos-6
@@ -37,8 +37,8 @@ RUN yum -y update \
     pcre-devel \
     pcre2-devel \
     pkgconfig \
-    python \
-    python-pip \
+    python34 \
+    python34-pip \
     readline-devel \
     rpm-build \
     stunnel \
@@ -53,7 +53,7 @@ RUN yum -y update \
     && yum clean all
 
 # Install AWS CLI.
-RUN pip install awscli --upgrade --user && \
+RUN pip3 install awscli --upgrade --user && \
     ln -s /root/.local/bin/aws /usr/bin/aws
 
 RUN chmod 0777 /opt


### PR DESCRIPTION
Continued from https://github.com/rstudio/r-builds/pull/51: I tried a staging build and CentOS 6 builds all failed with:
```
Storing artifact on s3: rstudio-r-builds-staging, tarball: R-3.4.3-centos-6.tar.gz
Traceback (most recent call last):
  File "/usr/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/root/.local/lib/python2.6/site-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/root/.local/lib/python2.6/site-packages/botocore/session.py", line 28, in <module>
    import botocore.configloader
  File "/root/.local/lib/python2.6/site-packages/botocore/configloader.py", line 19, in <module>
    from botocore.compat import six
  File "/root/.local/lib/python2.6/site-packages/botocore/compat.py", line 26, in <module>
    from dateutil.tz import tzlocal
  File "/root/.local/lib/python2.6/site-packages/dateutil/tz/__init__.py", line 2, in <module>
    from .tz import *
  File "/root/.local/lib/python2.6/site-packages/dateutil/tz/tz.py", line 308
    self._tznames[0] in {'UTC', 'GMT'} and
                              ^
SyntaxError: invalid syntax
```

I think this is because the AWS CLI no longer supports Python 2.6. It's an invalid syntax error for set literals, which only Python 2.7+ supports. Installing Python 3.4 from EPEL seems to fix this:
```sh
# Before
[root@2d6778e7a461 /]# aws s3
Traceback (most recent call last):
  File "/usr/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/root/.local/lib/python2.6/site-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/root/.local/lib/python2.6/site-packages/botocore/session.py", line 28, in <module>
    import botocore.configloader
  File "/root/.local/lib/python2.6/site-packages/botocore/configloader.py", line 19, in <module>
    from botocore.compat import six
  File "/root/.local/lib/python2.6/site-packages/botocore/compat.py", line 26, in <module>
    from dateutil.tz import tzlocal
  File "/root/.local/lib/python2.6/site-packages/dateutil/tz/__init__.py", line 2, in <module>
    from .tz import *
  File "/root/.local/lib/python2.6/site-packages/dateutil/tz/tz.py", line 308
    self._tznames[0] in {'UTC', 'GMT'} and

# After
[root@1400c8ef1e24 /]# aws --version
aws-cli/1.18.49 Python/3.4.10 Linux/4.15.0-96-generic botocore/1.15.49
```