### PR TITLE
Including libopenblas fails to build on Ubuntu 20

### DIFF
--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get install -y libblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli

--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libpcre2-dev wget python3-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -21,6 +21,7 @@ fpm \
   -d gcc \
   -d gfortran \
   -d libbz2-1.0 \
+  -d libblas3 \
   -d libc6 \
   -d libcairo2 \
   -d libcurl4 \
@@ -29,7 +30,6 @@ fpm \
   -d libicu66 \
   -d libjpeg8 \
   -d liblzma5 \
-  -d libopenblas-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
@@ -51,4 +51,3 @@ fpm \
 
 shopt -s extglob
 export PKG_FILE=$(ls /tmp/output/ubuntu-2004/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
-

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -21,7 +21,7 @@ fpm \
   -d gcc \
   -d gfortran \
   -d libbz2-1.0 \
-  -d libblas3 \
+  -d libblas-dev \
   -d libc6 \
   -d libcairo2 \
   -d libcurl4 \
@@ -29,6 +29,7 @@ fpm \
   -d libgomp1 \
   -d libicu66 \
   -d libjpeg8 \
+  -d liblapack-dev \
   -d liblzma5 \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \


### PR DESCRIPTION
Builds on Ubuntu 20 were getting stuck on `byte compiling grDevices` as evidenced by build instances that had to be manually terminated after _days_ :disappointed:

Removing `libopenblas` as a build dependency allows the builds to complete as a workaround. FWICT, this change ends up using `libblas3` which gets pulled in from `apt-get build-dep r-base`