### PR TITLE
Remove PCRE2 dependency for R 3.x; add libs required to link against R library

### DIFF
--- a/builder/package.centos-6
+++ b/builder/package.centos-6
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/centos-6 ]]; then
   mkdir -p /tmp/output/centos-6
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
 mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep 
@@ -60,8 +66,7 @@ fpm \
   -d make \
   -d openblas-devel \
   -d pango \
-  -d pcre-devel \
-  -d pcre2-devel \
+  -d ${pcre_lib} \
   -d tcl \
   -d tk \
   -d unzip \

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/centos-7 ]]; then
   mkdir -p /tmp/output/centos-7
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
 mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep 
@@ -45,8 +51,7 @@ fpm \
   -d make \
   -d openblas-devel \
   -d pango \
-  -d pcre-devel \
-  -d pcre2-devel \
+  -d ${pcre_lib} \
   -d tcl \
   -d tk \
   -d unzip \

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -2,6 +2,12 @@ if [[ ! -d /tmp/output/centos-8 ]]; then
   mkdir -p /tmp/output/centos-8
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
 mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
@@ -43,8 +49,7 @@ fpm \
   -d make \
   -d openblas-threads \
   -d pango \
-  -d pcre-devel \
-  -d pcre2-devel \
+  -d ${pcre_lib} \
   -d tcl \
   -d tk \
   -d unzip \

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/debian-10 ]]; then
   mkdir -p /tmp/output/debian-10
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='libpcre2-8-0'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='libpcre3'
+fi
+
 fpm \
   -s dir \
   -t deb \
@@ -33,8 +39,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
-  -d libpcre2-8-0 \
-  -d libpcre3 \
+  -d ${pcre_lib} \
   -d libpng16-16 \
   -d libreadline7 \
   -d libtcl8.6 \

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -5,9 +5,9 @@ if [[ ! -d /tmp/output/debian-10 ]]; then
 fi
 
 # R 3.x requires PCRE1
-pcre_lib='libpcre2-8-0'
+pcre_lib='libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='libpcre3'
+  pcre_lib='libpcre3-dev'
 fi
 
 fpm \

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -27,14 +27,14 @@ fpm \
   -d g++ \
   -d gcc \
   -d gfortran \
-  -d libbz2-1.0 \
+  -d libbz2-dev \
   -d libc6 \
   -d libcairo2 \
   -d libcurl4-openssl-dev \
   -d libglib2.0-0 \
   -d libgomp1 \
-  -d libicu63 \
-  -d liblzma5 \
+  -d libicu-dev \
+  -d liblzma-dev \
   -d libopenblas-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
@@ -51,7 +51,7 @@ fpm \
   -d ucf \
   -d unzip \
   -d zip \
-  -d zlib1g \
+  -d zlib1g-dev \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -5,9 +5,9 @@ if [[ ! -d /tmp/output/debian-9 ]]; then
 fi
 
 # R 3.x requires PCRE1
-pcre_lib='libpcre2-8-0'
+pcre_lib='libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='libpcre3'
+  pcre_lib='libpcre3-dev'
 fi
 
 fpm \

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/debian-9 ]]; then
   mkdir -p /tmp/output/debian-9
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='libpcre2-8-0'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='libpcre3'
+fi
+
 fpm \
   -s dir \
   -t deb \
@@ -33,8 +39,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
-  -d libpcre2-8-0 \
-  -d libpcre3 \
+  -d ${pcre_lib} \
   -d libpng16-16 \
   -d libreadline7 \
   -d libtcl8.6 \

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -27,14 +27,14 @@ fpm \
   -d g++ \
   -d gcc \
   -d gfortran \
-  -d libbz2-1.0 \
+  -d libbz2-dev \
   -d libc6 \
   -d libcairo2 \
   -d libcurl4-openssl-dev \
   -d libglib2.0-0 \
   -d libgomp1 \
-  -d libicu57 \
-  -d liblzma5 \
+  -d libicu-dev \
+  -d liblzma-dev \
   -d libopenblas-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
@@ -51,7 +51,7 @@ fpm \
   -d ucf \
   -d unzip \
   -d zip \
-  -d zlib1g \
+  -d zlib1g-dev \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.opensuse-15
+++ b/builder/package.opensuse-15
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/opensuse-15 ]]; then
   mkdir -p /tmp/output/opensuse-15
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
 mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
@@ -50,8 +56,7 @@ fpm \
   -d libtiff5 \
   -d make \
   -d openblas-devel \
-  -d pcre-devel \
-  -d pcre2-devel \
+  -d ${pcre_lib} \
   -d tar \
   -d tcl \
   -d tk \

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/opensuse-42 ]]; then
   mkdir -p /tmp/output/opensuse-42
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
 mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
@@ -48,8 +54,7 @@ fpm \
   -d libtiff5 \
   -d make \
   -d openblas-devel \
-  -d pcre-devel \
-  -d pcre2-devel \
+  -d ${pcre_lib} \
   -d tar \
   -d tcl \
   -d tk \

--- a/builder/package.ubuntu-1604
+++ b/builder/package.ubuntu-1604
@@ -26,15 +26,15 @@ fpm \
   -d g++ \
   -d gcc \
   -d gfortran \
-  -d libbz2-1.0 \
+  -d libbz2-dev \
   -d libc6 \
   -d libcairo2 \
   -d libcurl3 \
   -d libglib2.0-0 \
   -d libgomp1 \
-  -d libicu55 \
+  -d libicu-dev \
   -d libjpeg8 \
-  -d liblzma5 \
+  -d liblzma-dev \
   -d libopenblas-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
@@ -51,7 +51,7 @@ fpm \
   -d ucf \
   -d unzip \
   -d zip \
-  -d zlib1g \
+  -d zlib1g-dev \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.ubuntu-1604
+++ b/builder/package.ubuntu-1604
@@ -5,9 +5,9 @@ if [[ ! -d /tmp/output/ubuntu-1604 ]]; then
 fi
 
 # R 3.x requires PCRE1
-pcre_lib='libpcre2-8-0'
+pcre_lib='libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='libpcre3'
+  pcre_lib='libpcre3-dev'
 fi
 
 fpm \

--- a/builder/package.ubuntu-1604
+++ b/builder/package.ubuntu-1604
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/ubuntu-1604 ]]; then
   mkdir -p /tmp/output/ubuntu-1604
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='libpcre2-8-0'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='libpcre3'
+fi
+
 fpm \
   -s dir \
   -t deb \
@@ -33,8 +39,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
-  -d libpcre2-8-0 \
-  -d libpcre3 \
+  -d ${pcre_lib} \
   -d libpng16-16 \
   -d libreadline6 \
   -d libtcl8.6 \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -26,15 +26,15 @@ fpm \
   -d g++ \
   -d gcc \
   -d gfortran \
-  -d libbz2-1.0 \
+  -d libbz2-dev \
   -d libc6 \
   -d libcairo2 \
   -d libcurl4 \
   -d libglib2.0-0 \
   -d libgomp1 \
-  -d libicu60 \
+  -d libicu-dev \
   -d libjpeg8 \
-  -d liblzma5 \
+  -d liblzma-dev \
   -d libopenblas-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
@@ -51,7 +51,7 @@ fpm \
   -d ucf \
   -d unzip \
   -d zip \
-  -d zlib1g \
+  -d zlib1g-dev \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -5,9 +5,9 @@ if [[ ! -d /tmp/output/ubuntu-1804 ]]; then
 fi
 
 # R 3.x requires PCRE1
-pcre_lib='libpcre2-8-0'
+pcre_lib='libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='libpcre3'
+  pcre_lib='libpcre3-dev'
 fi
 
 fpm \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/ubuntu-1804 ]]; then
   mkdir -p /tmp/output/ubuntu-1804
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='libpcre2-8-0'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='libpcre3'
+fi
+
 fpm \
   -s dir \
   -t deb \
@@ -33,8 +39,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
-  -d libpcre2-8-0 \
-  -d libpcre3 \
+  -d ${pcre_lib} \
   -d libpng16-16 \
   -d libreadline7 \
   -d libtcl8.6 \

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -5,9 +5,9 @@ if [[ ! -d /tmp/output/ubuntu-2004 ]]; then
 fi
 
 # R 3.x requires PCRE1
-pcre_lib='libpcre2-8-0'
+pcre_lib='libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='libpcre3'
+  pcre_lib='libpcre3-dev'
 fi
 
 fpm \

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -26,17 +26,17 @@ fpm \
   -d g++ \
   -d gcc \
   -d gfortran \
-  -d libbz2-1.0 \
+  -d libbz2-dev \
   -d libblas-dev \
   -d libc6 \
   -d libcairo2 \
   -d libcurl4 \
   -d libglib2.0-0 \
   -d libgomp1 \
-  -d libicu66 \
+  -d libicu-dev \
   -d libjpeg8 \
   -d liblapack-dev \
-  -d liblzma5 \
+  -d liblzma-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
@@ -52,7 +52,7 @@ fpm \
   -d ucf \
   -d unzip \
   -d zip \
-  -d zlib1g \
+  -d zlib1g-dev \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -4,6 +4,12 @@ if [[ ! -d /tmp/output/ubuntu-2004 ]]; then
   mkdir -p /tmp/output/ubuntu-2004
 fi
 
+# R 3.x requires PCRE1
+pcre_lib='libpcre2-8-0'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='libpcre3'
+fi
+
 fpm \
   -s dir \
   -t deb \
@@ -34,8 +40,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
-  -d libpcre2-8-0 \
-  -d libpcre3 \
+  -d ${pcre_lib} \
   -d libpng16-16 \
   -d libreadline8 \
   -d libtcl8.6 \


### PR DESCRIPTION
Follow-up of https://github.com/rstudio/r-builds/pull/56: R 3.5 and 3.6 link against PCRE2 if present, but don't actually use it. Since we added PCRE2 to the build images for R 4.0, the R 3.5+ binaries for Ubuntu, Debian, and SUSE took on an unnecessary PCRE2 dependency (CentOS has always had PCRE2). 

This PR removes the PCRE2 dependency for the R 3.x binaries and packages, and the unused PCRE1 dependency for the R 4.x packages.

Since there's no configure flag to disable linking against PCRE2, we temporarily hide PCRE2 from the configure script for R 3.x builds. R 3.x detects the presence of PCRE2 using either `pkg-config --exists libpcre2-8` or checking for the `pcre2-config` script on the PATH, so we temporarily remove these during the build.
(See https://github.com/wch/r-source/blob/7d25524f8b83d63979cc18f0914a321bfbe9a819/m4/R.m4#L3139-L3155)

Other ways I looked into were conditionally installing or removing PCRE2 based on R version, removing libpcre2-8.so, modifying the pkg-config path and PATH, and splitting the build images into R 3 and 4, but they all felt more complicated than this.

---

The second part of this PR is adding dev dependencies required to link against libR: PCRE, LZMA, bzip2, zlib, and ICU. The CentOS and SUSE packages have had these, but the Ubuntu and Debian packages have not, so this is also for consistency. These dev libs aren't required to run R, but some really common packages like rJava need them to install from source.

See https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Compiling-against-the-R-library for more info:
```sh
$ R CMD config --ldflags
-Wl,--export-dynamic -fopenmp -L/usr/local/lib -L/opt/R/3.6.3/lib/R/lib -lR -lpcre -llzma -lbz2 -lz -lrt -ldl -lm -licuuc -licui18n
```


### Testing
For testing, we should confirm that:
- `-lpcre2-8` doesn't show up in the `R CMD config --ldflags` for R 3.5 and 3.6
```sh
# Ubuntu 16
$ /opt/R/4.0.0/bin/R CMD config --ldflags
-Wl,--export-dynamic -fopenmp -L/usr/local/lib -L/opt/R/4.0.0/lib/R/lib -lR -lpcre2-8 -llzma -lbz2 -lz -lrt -ldl -lm -licuuc -licui18n

$ /opt/R/3.6.3/bin/R CMD config --ldflags
-Wl,--export-dynamic -fopenmp -L/usr/local/lib -L/opt/R/3.6.3/lib/R/lib -lR -lpcre -llzma -lbz2 -lz -lrt -ldl -lm -licuuc -licui18n

$ /opt/R/3.5.3/bin/R CMD config --ldflags
-Wl,--export-dynamic -fopenmp -L/usr/local/lib -L/opt/R/3.5.3/lib/R/lib -lR -lpcre -llzma -lbz2 -lz -lrt -ldl -lm -licuuc -licui18n
```
- the R 3.x packages include PCRE1 only, and the R 4.0 packages include PCRE2 only
```sh
# Ubuntu 16
$ dpkg -I ubuntu-1604/r-4.0.0_1_amd64.deb | grep Depends | grep libpcre2-dev
 Depends: g++, gcc, gfortran, libbz2-dev, libc6, libcairo2, libcurl3, libglib2.0-0, libgomp1, libicu-dev, libjpeg8, liblzma-dev, libopenblas-dev, libpango-1.0-0, libpangocairo-1.0-0, libpaper-utils, libpcre2-dev, libpng16-16, libreadline6, libtcl8.6, libtiff5, libtk8.6, libx11-6, libxt6, make, ucf, unzip, zip, zlib1g-dev

$ dpkg -I ubuntu-1604/r-3.6.3_1_amd64.deb | grep Depends | grep libpcre3-dev
 Depends: g++, gcc, gfortran, libbz2-dev, libc6, libcairo2, libcurl3, libglib2.0-0, libgomp1, libicu-dev, libjpeg8, liblzma-dev, libopenblas-dev, libpango-1.0-0, libpangocairo-1.0-0, libpaper-utils, libpcre3-dev, libpng16-16, libreadline6, libtcl8.6, libtiff5, libtk8.6, libx11-6, libxt6, make, ucf, unzip, zip, zlib1g-dev

$ dpkg -I ubuntu-1604/r-3.5.3_1_amd64.deb | grep Depends | grep libpcre3-dev
 Depends: g++, gcc, gfortran, libbz2-dev, libc6, libcairo2, libcurl3, libglib2.0-0, libgomp1, libicu-dev, libjpeg8, liblzma-dev, libopenblas-dev, libpango-1.0-0, libpangocairo-1.0-0, libpaper-utils, libpcre3-dev, libpng16-16, libreadline6, libtcl8.6, libtiff5, libtk8.6, libx11-6, libxt6, make, ucf, unzip, zip, zlib1g-dev

# CentOS 8
$ rpm -qpR centos-8/R-4.0.0-1-1.x86_64.rpm | grep pcre2-devel
pcre2-devel

$ rpm -qpR centos-8/R-3.6.3-1-1.x86_64.rpm | grep pcre-devel
pcre-devel

$ rpm -qpR centos-8/R-3.5.3-1-1.x86_64.rpm | grep pcre-devel
pcre-devel
```
- `-dev` versions of PCRE, LZMA, bzip2, zlib, and ICU show up in the Ubuntu/Debian package Depends (see above)

I'm adding checks for these to scripts in https://github.com/rstudio/r-builds/pull/23 to make this testing easier. I'll probably just merge those test scripts since manual testing keeps getting harder with the evergrowing build matrix.