### PR TITLE
Quiet output while downloading in unattended mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -348,7 +348,7 @@ do_download () {
     elif [[ -z "${curl_rc}" ]]; then
         echo "Downloading ${url}..."
         if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
-          curl -sfL --output "${file_name}" "${url}"
+          curl -fsSL --output "${file_name}" "${url}"
         else
           curl -fL --output "${file_name}" --progress-bar "${url}"
         fi

--- a/install.sh
+++ b/install.sh
@@ -338,12 +338,20 @@ do_download () {
 
     if [[ -z "${wget_rc}" ]]; then
         echo "Downloading ${url}..."
-        wget --progress=bar "${url}"
+        if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
+          wget -q "${url}"
+        else
+          wget --progress=bar "${url}"
+        fi
         rc=$?
     # Or, If curl is around, use that.
     elif [[ -z "${curl_rc}" ]]; then
         echo "Downloading ${url}..."
-        curl --output "${file_name}" --progress-bar "${url}"
+        if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
+          curl -sfL --output "${file_name}" "${url}"
+        else
+          curl -fL --output "${file_name}" --progress-bar "${url}"
+        fi
         rc=$?
     # Otherwise, we can't go on.
     else


### PR DESCRIPTION
In unattended mode don't output progress details while downloading files.

Additionally for `curl`, fail on any non 2xx/3xx codes and follow redirects if any.