### PR TITLE
Fix ffi version for older distros where ruby<2.3

### DIFF
--- a/builder/Dockerfile.centos-6
+++ b/builder/Dockerfile.centos-6
@@ -206,7 +206,7 @@ RUN source /etc/profile.d/rvm.sh \
 RUN export PATH=/usr/local/rvm/rubies/ruby-2.6.3/bin/:/.gems/bin:${PATH} \
    && export GEM_HOME=/.gems \
    && export GEM_PATH=/.gems \
-   && gem install --no-document fpm \
+   && gem install ffi:1.12.2 --no-document fpm \
    && /usr/local/rvm/bin/rvm repair wrappers
 
 RUN echo 'source /etc/profile.d/rvm.sh' >> .bashrc

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -53,7 +53,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 RUN pip install awscli --upgrade --user && \
     ln -s /root/.local/bin/aws /usr/bin/aws
 
-RUN gem install fpm
+RUN gem install ffi:1.12.2 fpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -66,7 +66,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
-RUN gem install fpm && ln -s /usr/lib64/ruby/gems/2.1.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
+RUN gem install ffi:1.12.2 fpm && ln -s /usr/lib64/ruby/gems/2.1.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
 
 RUN chmod 0777 /opt
 


### PR DESCRIPTION
Use a specific `ffi` gem that is compatible with ruby < 2.3 for older distros.