### PR TITLE
Fix header argument to curl and wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -360,7 +360,7 @@ do_download () {
         if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
           curl -fsSL "${header[@]}" --output "${file_name}" "${url}"
         else
-          curl -fsSL "${header[@]}" --output "${file_name}" --progress-bar "${url}"
+          curl -fL "${header[@]}" --output "${file_name}" --progress-bar "${url}"
         fi
         rc=$?
     # Otherwise, we can't go on.

--- a/install.sh
+++ b/install.sh
@@ -340,13 +340,13 @@ do_download () {
         echo "Downloading ${url}..."
         local header
         if [[ -n "${RS_USER_AGENT}" ]]; then
-          header="--header 'User-Agent: ${RS_USER_AGENT}'"
+          header="--header='User-Agent: ${RS_USER_AGENT}'"
         fi
 
         if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
-          wget -q "${header}" "${url}"
+          wget -q "${header[@]}" "${url}"
         else
-          wget --progress=bar "${header}" "${url}"
+          wget --progress=bar "${header[@]}" "${url}"
         fi
         rc=$?
     # Or, If curl is around, use that.
@@ -358,9 +358,9 @@ do_download () {
         fi
 
         if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
-          curl -fsSL "${header}" --output "${file_name}" "${url}"
+          curl -fsSL "${header[@]}" --output "${file_name}" "${url}"
         else
-          curl -fL "${header}" --output "${file_name}" --progress-bar "${url}"
+          curl -fsSL "${header[@]}" --output "${file_name}" --progress-bar "${url}"
         fi
         rc=$?
     # Otherwise, we can't go on.


### PR DESCRIPTION
Fix header argument being passed incorrectly to curl/wget.  The script works again. Oops!

This change makes it so:
1. `wget` is passed the right argument `--header=string` in exactly that format. Otherwise it didn't work (on CentOS 6)
2. Split the arguments in the `header` variable, if any, to ensure argument splitting occurs when calling out to curl/wget.
    - w/o this the whole built-up string was being passed as a single argument which is not what we want (and didn't work)