### PR TITLE
Use default user-agent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,29 +338,20 @@ do_download () {
 
     if [[ -z "${wget_rc}" ]]; then
         echo "Downloading ${url}..."
-        local header
-        if [[ -n "${RS_USER_AGENT}" ]]; then
-          header="--header='User-Agent: ${RS_USER_AGENT}'"
-        fi
 
         if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
-          wget -q "${header[@]}" "${url}"
+          wget -q --header "User-Agent: ${RS_USER_AGENT:-r-builds}" "${url}"
         else
-          wget --progress=bar "${header[@]}" "${url}"
+          wget --progress=bar --header "User-Agent: ${RS_USER_AGENT:-r-builds}" "${url}"
         fi
         rc=$?
     # Or, If curl is around, use that.
     elif [[ -z "${curl_rc}" ]]; then
         echo "Downloading ${url}..."
-        local header
-        if [[ -n "${RS_USER_AGENT}" ]]; then
-          header="-H 'User-Agent: ${RS_USER_AGENT}'"
-        fi
-
         if [[ "${RUN_UNATTENDED}" -ne "0" ]]; then
-          curl -fsSL "${header[@]}" --output "${file_name}" "${url}"
+          curl -fsSL -H "User-Agent: ${RS_USER_AGENT:-r-builds}" --output "${file_name}" "${url}"
         else
-          curl -fL "${header[@]}" --output "${file_name}" --progress-bar "${url}"
+          curl -fL -H "User-Agent: ${RS_USER_AGENT:-r-builds}" --output "${file_name}" --progress-bar "${url}"
         fi
         rc=$?
     # Otherwise, we can't go on.


### PR DESCRIPTION
This sets a default user-agent which can be overridden by `RS_USER_AGENT`.

```
# RS_USER_AGENT not set

> curl -fL -H "User-Agent: ${RS_USER_AGENT:-r-builds}" https://httpbin.org/headers
{
  "headers": {
    "Accept": "*/*", 
    "Host": "httpbin.org", 
    "User-Agent": "r-builds", 
  }
}

> wget -qO- --header "User-Agent: ${RS_USER_AGENT:-r-builds}" https://httpbin.org/headers
{
  "headers": {
    "Accept": "*/*", 
    "Host": "httpbin.org", 
    "User-Agent": "r-builds", 
  }
}

# RS_USER_AGENT set
> export RS_USER_AGENT="rsc-setup/098123 foo"

> curl -fL -H "User-Agent: ${RS_USER_AGENT:-r-builds}" https://httpbin.org/headers
{
  "headers": {
    "Accept": "*/*", 
    "Content-Length": "0", 
    "Host": "httpbin.org", 
    "User-Agent": "rsc-setup/098123 foo"
  }
}

> wget -qO- --header "User-Agent: ${RS_USER_AGENT:-r-builds}" https://httpbin.org/headers
{
  "headers": {
    "Accept": "*/*", 
    "Accept-Encoding": "identity", 
    "Content-Length": "0", 
    "Host": "httpbin.org", 
    "User-Agent": "rsc-setup/098123 foo"
  }
}

```