### PR TITLE
Build R-devel dailies

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Once you've followed the steps above, submit a pull request. On successful merge
 
 Periodically, someone with access to these resources may need to re-trigger every R version/platform combination. This quite easy with the `serverless` tool installed.
 
-```
+```bash
+# Rebuild all R versions
 serverless invoke stepf -n rBuilds -d '{"force": true}'
+
+# Rebuild specific R versions
+serverless invoke stepf -n rBuilds -d '{"force": true, "versions": ["3.6.3", "4.0.2"]}'
 ```

--- a/handler.py
+++ b/handler.py
@@ -94,8 +94,10 @@ def _submit_job(version, platform):
         return response['jobId']
 
 
-def _versions_to_build(force):
+def _versions_to_build(force, versions):
     cran_versions = _cran_all_r_versions()['r_versions']
+    if versions:
+        cran_versions = [v for v in cran_versions if v in versions]
     known_versions = _known_r_versions()['r_versions']
     new_versions = _compare_versions(cran_versions, known_versions)
 
@@ -117,7 +119,7 @@ def _check_for_job_status(jobs, status):
 
 def queue_builds(event, context):
     """Queue some builds."""
-    event['versions_to_build'] =  _versions_to_build(event.get('force', False))
+    event['versions_to_build'] =  _versions_to_build(event.get('force', False), event.get('versions'))
     event['supported_platforms'] = _to_list(os.environ.get('SUPPORTED_PLATFORMS', 'ubuntu-1604'))
     job_ids = []
     for version in event['versions_to_build']:

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -309,3 +309,17 @@ rBuildsEventRule:
           Fn::GetAtt: [ rBuildsEventRuleIamRole, Arn ]
         Arn:
           Ref: RBuildsStepFunction
+
+rBuildsDevelEventRule:
+  Type: AWS::Events::Rule
+  Properties:
+    Description: Build R-devel
+    ScheduleExpression: cron(0 4 * * ? *)
+    State: ${self:custom.${self:provider.stage}.eventRuleState}
+    Targets:
+      - Id: rbuilds
+        Input: '{"force": true, "versions": ["devel"]}'
+        RoleArn:
+          Fn::GetAtt: [ rBuildsEventRuleIamRole, Arn ]
+        Arn:
+          Ref: RBuildsStepFunction


### PR DESCRIPTION
- Adds support for building specific versions of R, specified via a `"versions"` array:
```sh
serverless invoke stepf -n rBuilds -d '{"force": true, "versions": ["3.6.3", "4.0.2"]}'
```

- Schedules R-devel to be built everyday at 4 AM UTC. The R-devel sources seem to be built at around 12 AM UTC everyday, so this should be plenty of time. See https://stat.ethz.ch/R/daily/?C=M;O=D

Depends on https://github.com/rstudio/r-builds/pull/41 for `R_VERSION=devel` support.

Closes #6 
Closes #47