### PR TITLE
Add builds for openSUSE 15.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-1604 ubuntu-1804 ubuntu-2004 debian-9 debian-10 centos-6 centos-7 centos-8 opensuse-42 opensuse-15
+PLATFORMS := ubuntu-1604 ubuntu-1804 ubuntu-2004 debian-9 debian-10 centos-6 centos-7 centos-8 opensuse-42 opensuse-15 opensuse-152
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless
 
 deps:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ R binaries are built for the following Linux operating systems:
 - Ubuntu 16.04, 18.04, 20.04
 - Debian 9, 10
 - CentOS / Red Hat Enterprise Linux 6, 7, 8
-- openSUSE 42.3, 15.0
+- openSUSE 42.3, 15
 - SUSE Linux Enterprise 12, 15
 
 ## Quick Installation
@@ -125,8 +125,11 @@ Download the rpm package:
 # openSUSE 42.3 / SLES 12
 wget https://cdn.rstudio.com/r/opensuse-42/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
-# openSUSE 15.0 / SLES 15
+# openSUSE 15.1 / SLES 15 SP1
 wget https://cdn.rstudio.com/r/opensuse-15/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+
+# openSUSE 15.2 / SLES 15 SP2
+wget https://cdn.rstudio.com/r/opensuse-152/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:

--- a/builder/Dockerfile.opensuse-152
+++ b/builder/Dockerfile.opensuse-152
@@ -1,0 +1,84 @@
+FROM opensuse/leap:15.2
+
+ENV OS_IDENTIFIER opensuse-152
+
+# Most of these packages, and also the configure options that follow were determined
+# by reviewing "R-base.spec" from the following OpenSUSE RPM:
+# https://download.opensuse.org/repositories/devel:/languages:/R:/released/openSUSE_Leap_42.3/src/R-base-3.5.3-103.1.src.rpm
+
+RUN zypper --non-interactive update
+RUN zypper --non-interactive --gpg-auto-import-keys -n install \
+    bzip2 \
+    cairo-devel \
+    fdupes \
+    gcc \
+    gcc-c++ \
+    gcc-fortran \
+    glib2-devel \
+    glibc-locale \
+    help2man \
+    java-1_8_0-openjdk-devel \
+    libX11-devel \
+    libXScrnSaver-devel \
+    libXmu-devel \
+    libXt-devel \
+    libbz2-devel \
+    libcurl-devel \
+    libicu-devel \
+    libjpeg-devel \
+    libpng-devel \
+    libtiff-devel \
+    make \
+    pango-devel \
+    pcre-devel \
+    pcre2-devel \
+    perl \
+    perl-macros \
+    python \
+    python-pip \
+    readline-devel \
+    rpm-build \
+    ruby \
+    ruby-devel \
+    shadow \
+    tcl-devel \
+    texinfo \
+    texlive-bibtex \
+    texlive-cm-super \
+    texlive-dvips \
+    texlive-helvetic \
+    texlive-inconsolata \
+    texlive-latex \
+    texlive-makeindex \
+    texlive-metafont \
+    texlive-psnfss \
+    texlive-tex \
+    texlive-times \
+    tk-devel \
+    unzip \
+    wget \
+    xdg-utils \
+    xorg-x11-devel \
+    xz-devel \
+    zip \
+    zlib-devel \
+    && zypper clean
+
+RUN pip install awscli
+
+RUN gem install fpm && ln -s /usr/lib64/ruby/gems/2.5.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
+
+RUN chmod 0777 /opt
+
+# Configure flags for SUSE that don't use the defaults in build.sh
+ENV CONFIGURE_OPTIONS="\
+    --enable-R-shlib \
+    --with-tcltk \
+    --with-x \
+    --enable-memory-profiling \
+    --with-tcl-config=/usr/lib64/tclConfig.sh \
+    --with-tk-config=/usr/lib64/tkConfig.sh"
+
+COPY package.opensuse-152 /package.sh
+COPY build.sh .
+ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -111,3 +111,14 @@ services:
     image: r-builds:opensuse-15
     volumes:
       - ./integration/tmp:/tmp/output
+  opensuse-152:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.opensuse-152
+    image: r-builds:opensuse-152
+    volumes:
+      - ./integration/tmp:/tmp/output

--- a/builder/package.opensuse-152
+++ b/builder/package.opensuse-152
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/opensuse-152 ]]; then
+  mkdir -p /tmp/output/opensuse-152
+fi
+
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
+# create post-install script required for openblas
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
+# create after-remove script to remove internal blas
+cat <<EOF >> /before-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "RStudio, PBC" \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  --after-install /post-install.sh \
+  --after-remove /before-remove.sh \
+  -p /tmp/output/opensuse-152/ \
+  -d fontconfig \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-fortran \
+  -d glibc-locale \
+  -d gzip \
+  -d libbz2-devel \
+  -d libcairo2 \
+  -d libcurl-devel \
+  -d libfreetype6 \
+  -d libgomp1 \
+  -d libicu-devel \
+  -d libjpeg62 \
+  -d libpango-1_0-0 \
+  -d libreadline7 \
+  -d libtiff5 \
+  -d make \
+  -d openblas-devel \
+  -d ${pcre_lib} \
+  -d tar \
+  -d tcl \
+  -d tk \
+  -d unzip \
+  -d which \
+  -d xorg-x11 \
+  -d xorg-x11-fonts-100dpi \
+  -d xorg-x11-fonts-75dpi \
+  -d xz-devel \
+  -d zip \
+  -d zlib-devel \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/opensuse-152/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+

--- a/handler.py
+++ b/handler.py
@@ -132,6 +132,7 @@ def queue_builds(event, context):
                 'ubuntu-2004',
                 'ubuntu-1804',
                 'opensuse-15',
+                'opensuse-152',
                 'centos-8',
                 'debian-10',
             ] and version in ['3.3.0', '3.3.1', '3.3.2']:

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -271,6 +271,20 @@ rBuildsBatchJobDefinitionOpensuse15:
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:opensuse-15"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionOpensuse152:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:opensuse-152"
+    Timeout:
+      AttemptDurationSeconds: 7200
 
 # step function cloudwatch event trigger resources
 rBuildsEventRuleIamRole:

--- a/serverless.yml
+++ b/serverless.yml
@@ -55,7 +55,7 @@ provider:
       Ref: rBuildsBatchJobDefinitionOpensuse42
     JOB_DEFINITION_ARN_opensuse_15:
       Ref: rBuildsBatchJobDefinitionOpensuse15
-    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,ubuntu-2004,debian-9,debian-10,centos-6,centos-7,centos-8,opensuse-42,opensuse-15
+    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,ubuntu-2004,debian-9,debian-10,centos-6,centos-7,centos-8,opensuse-42,opensuse-15,opensuse-152
 
 functions:
   queueBuilds:


### PR DESCRIPTION
openSUSE 15.2 moved from ICU 60 to 65, so we'll need separate builds for openSUSE 15.0/15.1 and openSUSE 15.2. If you install the openSUSE 15.0 based package on 15.2, you'll get an error like this when running R:
```sh
$ /opt/R/3.6.3/bin/R
/opt/R/3.6.3/lib/R/bin/exec/R: error while loading shared libraries: libicuuc.so.60.2: cannot open shared object file: No such file or directory
```
The openSUSE 15.0 package may actually work on SLES 15 SP2 because it still has the `libicu60_2` runtime lib for compatibility, but it'll still be better to use an openSUSE 15.2 based package for SLES 15 SP2.

The Dockerfile and packaging scripts for 15.2 are the exact same as for 15.0. `libicu-devel` just pulls in a newer ICU now.

Also, I didn't update the quick install script here. That'll be easier to update and test after we get openSUSE 15.2 installers up.