### PR TITLE
Add missing openSUSE 15.2 job definition

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -55,6 +55,8 @@ provider:
       Ref: rBuildsBatchJobDefinitionOpensuse42
     JOB_DEFINITION_ARN_opensuse_15:
       Ref: rBuildsBatchJobDefinitionOpensuse15
+    JOB_DEFINITION_ARN_opensuse_152:
+      Ref: rBuildsBatchJobDefinitionOpensuse152
     SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,ubuntu-2004,debian-9,debian-10,centos-6,centos-7,centos-8,opensuse-42,opensuse-15,opensuse-152
 
 functions:


### PR DESCRIPTION
@joncfoo I missed this environment variable in https://github.com/rstudio/r-builds/pull/73, and only realized it when kicking off builds. I'll go ahead and merge since it's a small change.