### PR TITLE
Update quick install script for openSUSE 15.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,6 +100,9 @@ detect_os_version () {
   if [[ "${os}" == "Ubuntu" ]]; then
     cat /etc/os-release | grep -e "^VERSION_ID\=*" | cut -f 2 -d '=' | sed -e 's/[".]//g'
   fi
+  if [[ "${os}" == "SLES15" ]] || [[ "${os}" == "LEAP15" ]]; then
+    cat /etc/os-release | grep -e "^VERSION_ID\=*" | cut -f 2 -d '=' | sed -e 's/[".]//g'
+  fi
 }
 
 # Returns the installer type
@@ -174,7 +177,11 @@ download_url () {
         echo "${CDN_URL}/opensuse-42/pkgs/${name}"
         ;;
       "LEAP15" | "SLES15")
-        echo "${CDN_URL}/opensuse-15/pkgs/${name}"
+        if [ "${ver}" -ge 152 ]; then
+          echo "${CDN_URL}/opensuse-152/pkgs/${name}"
+        else
+          echo "${CDN_URL}/opensuse-15/pkgs/${name}"
+        fi
         ;;
     esac
   fi


### PR DESCRIPTION
Updates the install script to download from https://cdn.rstudio.com/r/opensuse-152/ for openSUSE 15.2/SLES 15 SP2 and above, and https://cdn.rstudio.com/r/opensuse-15/ for openSUSE 15.1/SLES 15 SP1 and below.

For testing, I ran this on openSUSE 15.0, 15.1, 15.2, SLES 15 SP1, and SLES 15 SP2 systems:
```sh
bash -c "$(curl https://raw.githubusercontent.com/rstudio/r-builds/5d5d555d2bb47a9fbd34c909aaccabaf528337a9/install.sh)"
```

