### PR TITLE
Update CentOS 8 Dockerfile for powertools repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bug, or ask questions on [RStudio Community](https://community.rstudio.com).
 R binaries are built for the following Linux operating systems:
 - Ubuntu 16.04, 18.04, 20.04
 - Debian 9, 10
-- CentOS / Red Hat Enterprise Linux 6, 7, 8
+- CentOS / Red Hat Enterprise Linux 7, 8
 - openSUSE 42.3, 15
 - SUSE Linux Enterprise 12, 15
 

--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -4,7 +4,7 @@ ENV OS_IDENTIFIER centos-8
 
 RUN dnf -y upgrade \
     && dnf -y install dnf-plugins-core \
-    && dnf config-manager --set-enabled PowerTools \
+    && dnf config-manager --set-enabled powertools \
     && dnf -y install \
     autoconf \
     automake \


### PR DESCRIPTION
The `PowerTools` repo was renamed to `powertools` (lowercase): https://bugs.centos.org/view.php?id=17920