### PR TITLE
Work around broken OpenBLAS dependency for SLES 12

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -29,6 +29,8 @@ RUN yum -y update \
     pango-devel \
     pcre-devel \
     pcre2-devel \
+    python3 \
+    python3-pip \
     readline-devel \
     rpm-build \
     ruby \
@@ -45,12 +47,8 @@ RUN yum -y update \
     zlib-devel \
     && yum clean all
 
-# Install pip for python
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py
-
 # Install AWS CLI.
-RUN pip install awscli --upgrade --user && \
+RUN pip3 install awscli --upgrade --user && \
     ln -s /root/.local/bin/aws /usr/bin/aws
 
 RUN gem install ffi:1.12.2 fpm

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -51,7 +51,8 @@ RUN yum -y update \
 RUN pip3 install awscli --upgrade --user && \
     ln -s /root/.local/bin/aws /usr/bin/aws
 
-RUN gem install ffi:1.12.2 fpm
+# Pin fpm for compatibility with Ruby < 2.3
+RUN gem install ffi:1.12.2 fpm:1.11.0
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.opensuse-15
+++ b/builder/Dockerfile.opensuse-15
@@ -66,7 +66,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
-RUN gem install fpm && ln -s /usr/lib64/ruby/gems/2.5.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
+RUN gem install fpm && \
+    ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.opensuse-152
+++ b/builder/Dockerfile.opensuse-152
@@ -66,7 +66,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
-RUN gem install fpm && ln -s /usr/lib64/ruby/gems/2.5.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
+RUN gem install fpm && \
+    ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -66,7 +66,9 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
-RUN gem install ffi:1.12.2 fpm && ln -s /usr/lib64/ruby/gems/2.1.0/gems/fpm-1.11.0/bin/fpm /bin/fpm
+# Pin fpm for compatibility with Ruby < 2.3
+RUN gem install ffi:1.12.2 fpm:1.11.0 && \
+    ln -s /usr/bin/fpm.ruby2.1 /usr/local/bin/fpm
 
 RUN chmod 0777 /opt
 

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -13,7 +13,7 @@ fi
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
 mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+ln -s /usr/lib64/libopenblas_pthreads.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
 EOF
 
 # create after-remove script to remove internal blas
@@ -53,7 +53,7 @@ fpm \
   -d libpango-1_0-0 \
   -d libtiff5 \
   -d make \
-  -d openblas-devel \
+  -d libopenblas_pthreads-devel \
   -d ${pcre_lib} \
   -d tar \
   -d tcl \


### PR DESCRIPTION
For https://github.com/rstudio/r-builds/issues/82

On SLES 12, installing `openblas-devel` from the python-backports repo currently doesn't work because it depends on a newer `libopenblas_pthreads-devel` dependency that has not been published:
```sh
$ VERSION="SLE_$(grep "^VERSION=" /etc/os-release | sed -e 's/VERSION=//' -e 's/"//g' -e 's/-/_/')"
$ sudo zypper --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/devel:/languages:/python:/backports/$VERSION/devel:languages:python:backports.repo
$ sudo zypper install openblas-devel
...
Problem: nothing provides libopenblas_pthreads-devel = 0.3.12 needed by openblas-devel-0.3.12-2.5.x86_64
 Solution 1: do not install openblas-devel-0.3.12-2.5.x86_64
 Solution 2: break openblas-devel-0.3.12-2.5.x86_64 by ignoring some of its dependencies

Choose from above solutions by number or cancel [1/2/c] (c): 

# libopenblas_pthreads-devel is only available in version 0.3.10, not 0.3.12
$ sudo zypper search -s libopenblas_pthreads-devel
S | Name                       | Type    | Version    | Arch   | Repository                                    
--+----------------------------+---------+------------+--------+-----------------------------------------------
  | libopenblas_pthreads-devel | package | 0.3.10-6.3 | x86_64 | Backport builds of Python Modules (SLE_12_SP5)
```

To work around this, we can switch the dependency to `libopenblas_pthreads-devel`, which provides the same library but does install properly (version 0.3.10). The difference between the two packages is that `openblas-devel` provides `libopenblas.so`, while `libopenblas_pthreads-devel` provides `libopenblas_pthreads.so`. Both symlink to the same library:
```sh
$ rpm -ql openblas-devel
/usr/lib64/cmake
/usr/lib64/cmake/openblas
/usr/lib64/cmake/openblas/OpenBLASConfig.cmake
/usr/lib64/cmake/openblas/OpenBLASConfigVersion.cmake
/usr/lib64/libopenblas.so

$ rpm -ql libopenblas_pthreads-devel
/usr/lib64/libopenblas_pthreads.so
/usr/lib64/libopenblasp.so

$ readlink -f /usr/lib64/libopenblas.so
/usr/lib64/libopenblas_pthreads.so.0

$ readlink -f /usr/lib64/libopenblas_pthreads.so
/usr/lib64/libopenblas_pthreads.so.0
```

So users should be able to install this new opensuse-42 RPM over an old one without breaking existing packages that use BLAS.