### PR TITLE
Pin fpm to 1.11.0

### DIFF
--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -52,7 +52,8 @@ RUN dnf -y upgrade \
 RUN pip3 install awscli --upgrade --user \
     && ln -s /root/.local/bin/aws /usr/bin/aws
 
-RUN gem install fpm
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.debian-10
+++ b/builder/Dockerfile.debian-10
@@ -14,7 +14,8 @@ RUN pip3 install awscli
 
 RUN chmod 0777 /opt
 
-RUN gem install fpm
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -14,7 +14,8 @@ RUN pip install awscli
 
 RUN chmod 0777 /opt
 
-RUN gem install fpm
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.opensuse-15
+++ b/builder/Dockerfile.opensuse-15
@@ -66,7 +66,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
-RUN gem install fpm && \
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0 && \
     ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
 
 RUN chmod 0777 /opt

--- a/builder/Dockerfile.opensuse-152
+++ b/builder/Dockerfile.opensuse-152
@@ -66,7 +66,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
-RUN gem install fpm && \
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0 && \
     ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
 
 RUN chmod 0777 /opt

--- a/builder/Dockerfile.ubuntu-1604
+++ b/builder/Dockerfile.ubuntu-1604
@@ -11,7 +11,8 @@ RUN set -x \
 
 RUN pip install awscli
 
-RUN gem install fpm
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -11,7 +11,8 @@ RUN set -x \
 
 RUN pip install awscli
 
-RUN gem install fpm
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -11,7 +11,8 @@ RUN set -x \
 
 RUN pip3 install awscli
 
-RUN gem install fpm
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
 


### PR DESCRIPTION
Fixes #86

fpm 1.12.0 adds an unintended runtime dependency on git, which should be fixed in a future release of fpm (https://github.com/jordansissel/fpm/issues/1751). Pin fpm for now since installing git has its own side effects, such as installing `less` and changing the default pager on systems where `less` isn't available by default. It'll be more complicated to handle the pager issues (for example, https://github.com/rstudio/r-builds/pull/5).