### PR TITLE
Fix R 4.1.0 builds for openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,3 +247,37 @@ serverless invoke stepf -n rBuilds -d '{"force": true}'
 # Rebuild specific R versions
 serverless invoke stepf -n rBuilds -d '{"force": true, "versions": ["3.6.3", "4.0.2"]}'
 ```
+
+## Testing
+
+To test the R builds locally, you can build the images:
+
+```bash
+# Build images for all platforms
+make docker-build
+
+# Or build the image for a single platform
+(cd builder && docker-compose build ubuntu-2004)
+```
+
+Then run the build script:
+
+```bash
+# Build R for all platforms
+R_VERSION=4.0.5 make docker-build-r
+
+# Build R for a single platform
+(cd builder && R_VERSION=4.0.5 docker-compose up ubuntu-2004)
+
+# Alternatively, run the build script from within a container
+docker run -it --rm --entrypoint "/bin/bash" r-builds:ubuntu-2004
+
+# Build R 4.0.5
+R_VERSION=4.0.5 ./build.sh
+
+# Build R devel
+R_VERSION=devel ./build.sh
+
+# Build a prerelease version of R (e.g., alpha or beta)
+R_VERSION=rc R_TARBALL_URL=https://cran.r-project.org/src/base-prerelease/R-latest.tar.gz ./build.sh
+```

--- a/builder/Dockerfile.opensuse-15
+++ b/builder/Dockerfile.opensuse-15
@@ -43,9 +43,11 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     shadow \
     tcl-devel \
     texinfo \
+    texlive-ae \
     texlive-bibtex \
     texlive-cm-super \
     texlive-dvips \
+    texlive-fancyvrb \
     texlive-helvetic \
     texlive-inconsolata \
     texlive-latex \

--- a/builder/Dockerfile.opensuse-152
+++ b/builder/Dockerfile.opensuse-152
@@ -43,9 +43,11 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     shadow \
     tcl-devel \
     texinfo \
+    texlive-ae \
     texlive-bibtex \
     texlive-cm-super \
     texlive-dvips \
+    texlive-fancyvrb \
     texlive-helvetic \
     texlive-inconsolata \
     texlive-latex \

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -35,8 +35,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     pcre2-devel \
     perl \
     perl-macros \
-    python \
-    python-pip \
     readline-devel \
     rpm-build \
     ruby \
@@ -64,7 +62,10 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     zlib-devel \
     && zypper clean
 
-RUN pip install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
 
 # Pin fpm for compatibility with Ruby < 2.3
 RUN gem install ffi:1.12.2 fpm:1.11.0 && \

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -42,9 +42,11 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     shadow \
     tcl-devel \
     texinfo \
+    texlive-ae \
     texlive-bibtex \
     texlive-cm-super \
     texlive-dvips \
+    texlive-fancyvrb \
     texlive-helvetic \
     texlive-inconsolata \
     texlive-latex \

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -40,7 +40,10 @@ archive_r() {
 
 fetch_r_source() {
   echo "Downloading R-${1}"
-  if [ "${1}" = devel ]; then
+  if [ -n "${R_TARBALL_URL}" ]; then
+    # Custom tarball URL for testing (e.g., R alpha and beta releases)
+    wget -q "${R_TARBALL_URL}" -O /tmp/R-${1}.tar.gz
+  elif [ "${1}" = devel ]; then
     # Download the daily tarball of R devel
     wget -q https://stat.ethz.ch/R/daily/R-devel.tar.gz -O /tmp/R-devel.tar.gz
   else


### PR DESCRIPTION
A couple fixes from testing the R 4.1.0 RC:
- Fix openSUSE 42 image builds. AWS CLI v1 is no longer supported on Python 2.7/3.4, so install the standalone AWS CLI v2 instead.
- Install newly required TeX packages for R 4.1 in all openSUSE versions: `texlive-ae` and `texlive-fancyvrb`
- Add a new `R_TARBALL_URL` environment variable to the build script for locally testing custom R builds. For example, to build an R 4.1.0 RC from https://cran.r-project.org/src/base-prerelease/:
```sh
$ R_VERSION=rc R_TARBALL_URL=https://cran.r-project.org/src/base-prerelease/R-rc_2021-05-10_r80288.tar.gz ./build.sh

$ /opt/R/rc/bin/R --version         
R version 4.1.0 RC (2021-05-10 r80288) -- "Camp Pontanezen"
Copyright (C) 2021 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under the terms of the
GNU General Public License versions 2 or 3.
For more information about these matters see
https://www.gnu.org/licenses/.
```


For reference, here were the error messages about the missing `texlive-fancyvrb` and `texlive-ae` packages on openSUSE:

```sh
building/updating vignettes for package 'stats' ...
processing 'reshape.Rnw'
Error: compiling TeX file 'reshape.tex' failed with message:
Running 'texi2dvi' on 'reshape.tex' failed.
LaTeX errors:
! LaTeX Error: File `fancyvrb.sty' not found.

Type X to quit or <RETURN> to proceed,
or enter new name. (Default extension: sty)

! Emergency stop.
<read *> 
         
l.19 \begingroup
                ^^M
!  ==> Fatal error occurred, no output PDF file produced!
Execution halted
make[1]: *** [Makefile:105: vignettes-lattice] Error 1
make[1]: Leaving directory '/tmp/R-rc/src/library'
make: *** [Makefile:81: vignettes] Error 2
```
```sh
building/updating vignettes for package 'stats' ...
processing 'reshape.Rnw'
Error: compiling TeX file 'reshape.tex' failed with message:
Running 'texi2dvi' on 'reshape.tex' failed.
LaTeX errors:
! LaTeX Error: File `ae.sty' not found.

Type X to quit or <RETURN> to proceed,
or enter new name. (Default extension: sty)

! Emergency stop.
<read *> 
         
l.30 \ifthenelse
                {\boolean{Sweave@inconsolata}}{%^^M
!  ==> Fatal error occurred, no output PDF file produced!
Execution halted
make[1]: *** [Makefile:105: vignettes-lattice] Error 1
make[1]: Leaving directory '/tmp/R-rc/src/library'
make: *** [Makefile:81: vignettes] Error 2
```