### PR TITLE
Work around issue with expired root certificate on openSUSE 42

### DIFF
--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -75,6 +75,15 @@ RUN gem install ffi:1.12.2 fpm:1.11.0 && \
 
 RUN chmod 0777 /opt
 
+# Work around issue with expired Let's Encrypt root certificate and OpenSSL 1.0.2,
+# which affects downloads from sourceforge.net (and possibly other sites).
+# On SLES 12, the issue can be resolved by updating ca-certificates-mozilla, but
+# openSUSE 42 (EOL) requires a manual removal of the expired DST Root CA X3 cerificate.
+# https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
+# https://www.suse.com/support/kb/doc/?id=000020401
+RUN rm /usr/share/pki/trust/DST_Root_CA_X3.pem && \
+    update-ca-certificates
+
 # Install an older xz 5.0.5 for compatibility with SLES 12
 ARG XZ_VERSION=5.0.5
 ARG XZ_DOWNLOAD_SHA1=26fec2c1e409f736e77a85e4ab314dc74987def0


### PR DESCRIPTION
Fixes the Docker image builds for openSUSE 42.

One of the Let's Encrypt root certificates expired in September 2021, so the Docker builds were failing on a curl to https://sourceforge.net:
```sh
Step 10/15 : RUN curl -fsSL "https://sourceforge.net/projects/lzmautils/files/xz-{$XZ_VERSION}.tar.gz/download" -o xz.tar.gz     && echo "$XZ_DOWNLOAD_SHA1  xz.tar.gz" | sha1sum -c -     && CWD=`pwd` && TMP=`mktemp -d`     && tar -C $TMP -zxvf xz.tar.gz     && cd $TMP/xz*     && ./configure     && make     && make install     && cd $CWD && rm -rf $TMP && rm -rf xz.tar.gz
 ---> Running in d8ccaa296904
curl: (60) SSL certificate problem: certificate has expired
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```

Workarounds for the expired DST Root CA X3 certificate are listed in a few articles from OpenSSL, Lets Encrypt, and SUSE:
- https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
- https://www.suse.com/support/kb/doc/?id=000020401
- https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/

SLES 12 provides a simple fix through an updated `ca-certificates-mozilla` package, but unfortunately, openSUSE 42.3 is EOL and doesn't have the updated package in its repos. Instead, this manually removes the expired root certificate using Workaround 1 from the [OpenSSL article](https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/).
