### PR TITLE
run the deploy as the new bespoke role

### DIFF
--- a/deploy.Jenkinsfile
+++ b/deploy.Jenkinsfile
@@ -20,7 +20,9 @@ pipeline {
   stages {
     stage('deploy') {
       steps {
-        sh "make serverless-deploy.${params.ENVIRONMENT}"
+        withAWS(role:'r-builds-deploy') {
+          sh "make serverless-deploy.${params.ENVIRONMENT}"
+        }
       }
     }
   }


### PR DESCRIPTION
uses the new `r-builds-deploy` role, and closes #98