### PR TITLE
Increase `queueBuilds` function timeout for full rebuilds

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -61,7 +61,7 @@ provider:
 
 functions:
   queueBuilds:
-    timeout: 30
+    timeout: 90
     handler: handler.queue_builds
   jobQueueStatus:
     handler: handler.poll_running_jobs


### PR DESCRIPTION
There are now so many platforms and R versions that `queueBuilds` takes more than 30 seconds to submit all jobs in a full rebuild, and hits the 30 second timeout:

```sh
$ ./node_modules/.bin/serverless invoke stepf -s staging -n rBuilds -d '{"force": true}'
......
{
  executionArn: 'arn:aws:states:us-east-1:263245908434:execution:r-builds-staging:3824f894-d53b-4b82-b785-0eceb274e0d3',
  stateMachineArn: 'arn:aws:states:us-east-1:263245908434:stateMachine:r-builds-staging',
  name: '3824f894-d53b-4b82-b785-0eceb274e0d3',
  status: 'FAILED',
  startDate: 2021-10-29T16:02:45.542Z,
  stopDate: 2021-10-29T16:03:15.764Z,
  input: '{"force": true}',
  error: 'Lambda.Unknown',
  cause: 'The cause could not be determined because Lambda did not return an error type. Returned payload: {"errorMessage":"2021-10-29T16:03:15.756Z 6a875273-964f-492b-a9ff-572c4cc36a6f Task timed out after 30.03 seconds"}'
}
```

```
...
2021-10-29T11:03:15.515-05:00	Started job for R:4.0.2,Platform:opensuse-152,id:33a6ab8a-2e41-49a9-9b42-f827b714ac7c
2021-10-29T11:03:15.590-05:00	Started job for R:4.0.2,Platform:opensuse-153,id:28fa7073-e850-4241-b762-f4d834644e12
2021-10-29T11:03:15.663-05:00	Started job for R:4.0.3,Platform:ubuntu-1604,id:4bfe0c35-977f-4686-b1a5-5487701e4f78
2021-10-29T11:03:15.754-05:00	Started job for R:4.0.3,Platform:ubuntu-1804,id:0acf52dd-9c07-40f1-ba5e-f0d9abc6fc11
2021-10-29T11:03:15.757-05:00	END RequestId: 6a875273-964f-492b-a9ff-572c4cc36a6f
2021-10-29T11:03:15.757-05:00	REPORT RequestId: 6a875273-964f-492b-a9ff-572c4cc36a6f Duration: 30030.11 ms Billed Duration: 30000 ms Memory Size: 1024 MB Max Memory Used: 35 MB
2021-10-29T11:03:15.757-05:00	2021-10-29T16:03:15.756Z 6a875273-964f-492b-a9ff-572c4cc36a6f Task timed out after 30.03 seconds
```

This bumps the function timeout to 90 seconds, which I've confirmed works in staging.