### PR TITLE
Update to supported version of AWS CLI on Ubuntu 16

### DIFF
--- a/builder/Dockerfile.ubuntu-1604
+++ b/builder/Dockerfile.ubuntu-1604
@@ -6,10 +6,13 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python-pip ruby ruby-dev \
+  && apt-get install -y curl libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget ruby ruby-dev \
   && apt-get build-dep -y r-base
 
-RUN pip install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
 
 # Pin fpm to avoid git dependency in 1.12.0
 RUN gem install fpm:1.11.0


### PR DESCRIPTION
The R 4.1.2 build for Ubuntu 16 failed to upload the package because AWS CLI v1 is no longer supported with Python 2.7:
```sh
2021-10-28T18:16:28.535-05:00	Storing artifact on s3: rstudio-r-builds-staging, tarball: R-3.6.3-ubuntu-1604.tar.gz
2021-10-28T18:16:29.045-05:00	Traceback (most recent call last):
2021-10-28T18:16:29.045-05:00	File "/usr/local/bin/aws", line 19, in <module>
2021-10-28T18:16:29.045-05:00	import awscli.clidriver
2021-10-28T18:16:29.045-05:00	File "/usr/local/lib/python2.7/dist-packages/awscli/clidriver.py", line 17, in <module>
2021-10-28T18:16:29.048-05:00	import botocore.session
2021-10-28T18:16:29.048-05:00	File "/usr/local/lib/python2.7/dist-packages/botocore/session.py", line 30, in <module>
2021-10-28T18:16:29.049-05:00	import botocore.client
2021-10-28T18:16:29.049-05:00	File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 16, in <module>
2021-10-28T18:16:29.053-05:00	from botocore.args import ClientArgsCreator
2021-10-28T18:16:29.053-05:00	File "/usr/local/lib/python2.7/dist-packages/botocore/args.py", line 26, in <module>
2021-10-28T18:16:29.055-05:00	from botocore.signers import RequestSigner
2021-10-28T18:16:29.055-05:00	File "/usr/local/lib/python2.7/dist-packages/botocore/signers.py", line 19, in <module>
2021-10-28T18:16:29.056-05:00	import botocore.auth
2021-10-28T18:16:29.056-05:00	File "/usr/local/lib/python2.7/dist-packages/botocore/auth.py", line 121
2021-10-28T18:16:29.056-05:00	pairs.append(f'{quoted_key}={quoted_value}')
2021-10-28T18:16:29.056-05:00	^
2021-10-28T18:16:29.056-05:00	SyntaxError: invalid syntax
```

This updates AWS CLI to v2 to get it working again.

Before:
```sh
$ aws --version
Traceback (most recent call last):
  File "/usr/local/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/usr/local/lib/python2.7/dist-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/usr/local/lib/python2.7/dist-packages/botocore/session.py", line 30, in <module>
    import botocore.client
  File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 16, in <module>
    from botocore.args import ClientArgsCreator
  File "/usr/local/lib/python2.7/dist-packages/botocore/args.py", line 26, in <module>
    from botocore.signers import RequestSigner
  File "/usr/local/lib/python2.7/dist-packages/botocore/signers.py", line 19, in <module>
    import botocore.auth
  File "/usr/local/lib/python2.7/dist-packages/botocore/auth.py", line 121
    pairs.append(f'{quoted_key}={quoted_value}')
                                              ^
SyntaxError: invalid syntax
```

After:
```sh
$ aws --version
aws-cli/2.3.2 Python/3.8.8 Linux/4.15.0-161-generic exe/x86_64.ubuntu.16 prompt/off
```