### PR TITLE
Fix openSUSE 15.3 installation and update to ICU 69

### DIFF
--- a/builder/Dockerfile.opensuse-153
+++ b/builder/Dockerfile.opensuse-153
@@ -17,6 +17,10 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     glib2-devel \
     glibc-locale \
     help2man \
+    # openSUSE/SLES 15.3 originally shipped with ICU 65 (libicu-devel), but later
+    # added ICU 69 (icu.691-devel) in a patch update. Prefer ICU 69 because the devel
+    # packages can't coexist, and zypper now resolves libicu-devel to icu.691-devel.
+    icu.691-devel \
     java-1_8_0-openjdk-devel \
     libX11-devel \
     libXScrnSaver-devel \
@@ -24,7 +28,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     libXt-devel \
     libbz2-devel \
     libcurl-devel \
-    libicu-devel \
     libjpeg-devel \
     libpng-devel \
     libtiff-devel \

--- a/builder/package.opensuse-153
+++ b/builder/package.opensuse-153
@@ -44,12 +44,12 @@ fpm \
   -d gcc-fortran \
   -d glibc-locale \
   -d gzip \
+  -d icu.691-devel \
   -d libbz2-devel \
   -d libcairo2 \
   -d libcurl-devel \
   -d libfreetype6 \
   -d libgomp1 \
-  -d libicu-devel \
   -d libjpeg62 \
   -d libpango-1_0-0 \
   -d libreadline7 \


### PR DESCRIPTION
Fixes #104 by updating the openSUSE 15.3 builds to use the new default ICU version of 69, rather than 65. This may break existing users in some scenarios, but it's not too bad. If you had a package built against the system ICU 65 (e.g., stringi) and installed these new R builds, your installed packages should still work unless you manually remove `libicu-suse65_1`.