### PR TITLE
Add builds for Debian 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-1604 ubuntu-1804 ubuntu-2004 debian-9 debian-10 centos-7 centos-8 opensuse-42 opensuse-15 opensuse-152 opensuse-153
+PLATFORMS := ubuntu-1604 ubuntu-1804 ubuntu-2004 debian-9 debian-10 debian-11 centos-7 centos-8 opensuse-42 opensuse-15 opensuse-152 opensuse-153
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless
 
 deps:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ wget https://cdn.rstudio.com/r/debian-9/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Debian 10
 wget https://cdn.rstudio.com/r/debian-10/pkgs/r-${R_VERSION}_1_amd64.deb
+
+# Debian 11
+wget https://cdn.rstudio.com/r/debian-11/pkgs/r-${R_VERSION}_1_amd64.deb
 ```
 
 Then install the package:
@@ -228,7 +231,7 @@ environment:
   # snip
   JOB_DEFINITION_ARN_debian_9:
     Ref: rBuildsBatchJobDefinitionDebian9
-  SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9,debian-10,centos-7,centos-8,opensuse-42,opensuse-15
+  SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,debian-9,debian-10,debian-11,centos-7,centos-8,opensuse-42,opensuse-15
 ```
 
 ### Makefile

--- a/builder/Dockerfile.debian-11
+++ b/builder/Dockerfile.debian-11
@@ -19,6 +19,9 @@ RUN gem install fpm
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 
+# R 3.x requires PCRE2 for Pango support on Debian 11
+ENV INCLUDE_PCRE2_IN_R_3 yes
+
 COPY package.debian-11 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/Dockerfile.debian-11
+++ b/builder/Dockerfile.debian-11
@@ -1,0 +1,24 @@
+FROM debian:bullseye
+
+ENV OS_IDENTIFIER debian-11
+
+RUN set -x \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && echo 'deb-src http://deb.debian.org/debian bullseye main' >> /etc/apt/sources.list \
+  && apt-get update \
+  && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
+     libopenblas-base libpcre2-dev make python3-pip ruby ruby-dev wget \
+  && apt-get build-dep -y r-base
+
+RUN pip3 install awscli
+
+RUN chmod 0777 /opt
+
+RUN gem install fpm
+
+# Override the default pager used by R
+ENV PAGER /usr/bin/pager
+
+COPY package.debian-11 /package.sh
+COPY build.sh .
+ENTRYPOINT ./build.sh

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -70,7 +70,12 @@ compile_r() {
   # Since there's no way to disable this in the configure script, and we need
   # PCRE2 for R 4.x, we hide PCRE2 from the configure script by temporarily
   # removing the pkg-config file and pcre2-config script.
-  if [[ "${1}" =~ ^3 ]] && pkg-config --exists libpcre2-8; then
+  #
+  # The INCLUDE_PCRE2_IN_R_3 environment variable can be set to include PCRE2
+  # in R 3.x builds, for distributions where PCRE2 is always required.
+  # In Debian 11, Pango now depends on PCRE2, so R 3.x will not be compiled with
+  # Pango support if the PCRE2 pkg-config file is missing.
+  if [[ "${1}" =~ ^3 ]] && pkg-config --exists libpcre2-8 && [ -z "$INCLUDE_PCRE2_IN_R_3" ]; then
     mkdir -p /tmp/pcre2
     pc_dir=$(pkg-config --variable pcfiledir libpcre2-8)
     mv ${pc_dir}/libpcre2-8.pc /tmp/pcre2

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -56,6 +56,17 @@ services:
     image: r-builds:debian-10
     volumes:
       - ./integration/tmp:/tmp/output
+  debian-11:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.debian-11
+    image: r-builds:debian-11
+    volumes:
+      - ./integration/tmp:/tmp/output
   centos-7:
     command: ./build.sh
     environment:

--- a/builder/package.debian-11
+++ b/builder/package.debian-11
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/debian-11 ]]; then
+  mkdir -p /tmp/output/debian-11
+fi
+
+# R 3.x requires PCRE1
+pcre_lib='libpcre2-dev'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='libpcre3-dev'
+fi
+
+fpm \
+  -s dir \
+  -t deb \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "RStudio, PBC" \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  -p /tmp/output/debian-11/ \
+  -d ca-certificates \
+  -d g++ \
+  -d gcc \
+  -d gfortran \
+  -d libbz2-dev \
+  -d libc6 \
+  -d libcairo2 \
+  -d libcurl4-openssl-dev \
+  -d libglib2.0-0 \
+  -d libgomp1 \
+  -d libicu-dev \
+  -d liblzma-dev \
+  -d libopenblas-dev \
+  -d libpango-1.0-0 \
+  -d libpangocairo-1.0-0 \
+  -d libpaper-utils \
+  -d ${pcre_lib} \
+  -d libpng16-16 \
+  -d libreadline8 \
+  -d libtcl8.6 \
+  -d libtiff5 \
+  -d libtk8.6 \
+  -d libx11-6 \
+  -d libxt6 \
+  -d make \
+  -d ucf \
+  -d unzip \
+  -d zip \
+  -d zlib1g-dev \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/debian-11/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+

--- a/builder/package.debian-11
+++ b/builder/package.debian-11
@@ -4,10 +4,10 @@ if [[ ! -d /tmp/output/debian-11 ]]; then
   mkdir -p /tmp/output/debian-11
 fi
 
-# R 3.x requires PCRE1
-pcre_lib='libpcre2-dev'
+# R 3.x requires PCRE1. On Debian 11, R 3.x also requires PCRE2 for Pango support.
+pcre_lib_flags='-d libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='libpcre3-dev'
+  pcre_lib_flags='-d libpcre2-dev -d libpcre3-dev'
 fi
 
 fpm \
@@ -39,7 +39,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
-  -d ${pcre_lib} \
+  ${pcre_lib_flags} \
   -d libpng16-16 \
   -d libreadline8 \
   -d libtcl8.6 \

--- a/handler.py
+++ b/handler.py
@@ -136,6 +136,7 @@ def queue_builds(event, context):
                 'opensuse-153',
                 'centos-8',
                 'debian-10',
+                'debian-11',
             ] and version in ['3.3.0', '3.3.1', '3.3.2']:
                 continue
             job_ids.append(_submit_job(version, platform))

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -201,6 +201,20 @@ rBuildsBatchJobDefinitionDebian10:
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:debian-10"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionDebian11:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:debian-11"
+    Timeout:
+      AttemptDurationSeconds: 7200
 rBuildsBatchJobDefinitionCentos7:
   Type: AWS::Batch::JobDefinition
   Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -45,6 +45,8 @@ provider:
       Ref: rBuildsBatchJobDefinitionDebian9
     JOB_DEFINITION_ARN_debian_10:
       Ref: rBuildsBatchJobDefinitionDebian10
+    JOB_DEFINITION_ARN_debian_11:
+      Ref: rBuildsBatchJobDefinitionDebian11
     JOB_DEFINITION_ARN_centos_7:
       Ref: rBuildsBatchJobDefinitionCentos7
     JOB_DEFINITION_ARN_centos_8:
@@ -57,7 +59,7 @@ provider:
       Ref: rBuildsBatchJobDefinitionOpensuse152
     JOB_DEFINITION_ARN_opensuse_153:
       Ref: rBuildsBatchJobDefinitionOpensuse153
-    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,ubuntu-2004,debian-9,debian-10,centos-7,centos-8,opensuse-42,opensuse-15,opensuse-152,opensuse-153
+    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,ubuntu-2004,debian-9,debian-10,debian-11,centos-7,centos-8,opensuse-42,opensuse-15,opensuse-152,opensuse-153
 
 functions:
   queueBuilds:


### PR DESCRIPTION
Add builds for Debian 11. Based on the Debian 10 builds, but with a few differences to work around new issues in Debian 11:

### Include PCRE2 in R 3.x on Debian 11 for Pango support
In Debian 11, Pango now depends on PCRE2 (indirectly via one of its dependencies), so R 3.x will not be compiled with Pango support if we hide PCRE2 to prevent R 3.5 and 3.6 from taking an unnecessary dependency on PCRE2. For context, we hide PCRE2 from R 3.x builds because both PCRE1 and PCRE2 are installed in the build image, and R 3.5/3.6 will take an unused dependency on PCRE2 if its present (https://github.com/rstudio/r-builds/pull/63).

If R 3.x was compiled without Pango support, the configure script will print:

```
checking whether pkg-config knows about cairo and pango... no
```

The `bitmapType` option in R will default to "Xlib" instead of the usual "Cairo":

```r
> getOption("bitmapType")
"Xlib"
```

And internationalized text rendering will be off. For example, rendering a plot with Chinese text results in boxes:
```r
png("nopango.png", type = "cairo")
plot(1:3, main = "test 你好，世界")
dev.off()
```
![plot with mis-rendered Chinese text without Pango support](https://user-images.githubusercontent.com/20401866/147992883-b125dfd1-ec78-48a5-b5bd-904d290257be.png)

### Fix compilation of R 3.6.1 and below due to changes in GCC 10

R <= 3.6.1 builds require additional compiler flags to work with GCC 10 and above:

- Add `-fcommon` to `CFLAGS` to work around an issue with the new default of `-fno-common` for C. This was fixed in R 3.6.2:
> * Source-code changes enable installation on platforms using gcc -fno-common (the expected default for gcc 10.x).
> https://cran.r-project.org/doc/manuals/r-release/NEWS.3.html

Without this flag, compilation fails with an error:

```sh
...
gcc -shared -fopenmp -L/usr/local/lib  -o libR.so CommandLineArgs.o Rdynload.o Renviron.o RNG.o agrep.o altclasses.o altrep.o apply.o arithmetic.o array.o attrib.o bind.o builtin.o character.o coerce.o colors.o complex.o connections.o context.o cum.o dcf.o datetime.o debug.o deparse.o devices.o dotcode.o dounzip.o dstruct.o duplicate.o edit.o engine.o envir.o errors.o eval.o format.o gevents.o gram.o gram-ex.o graphics.o grep.o identical.o inlined.o inspect.o internet.o iosupport.o lapack.o list.o localecharset.o logic.o main.o mapply.o match.o memory.o names.o objects.o options.o paste.o platform.o plot.o plot3d.o plotmath.o print.o printarray.o printvector.o printutils.o qsort.o radixsort.o random.o raw.o registration.o relop.o rlocale.o saveload.o scan.o seq.o serialize.o sort.o source.o split.o sprintf.o startup.o subassign.o subscript.o subset.o summary.o sysutils.o times.o unique.o util.o version.o g_alab_her.o g_cntrlify.o g_fontdb.o g_her_glyph.o xxxpr.o   `ls ../unix/*.o ../appl/*.o ../nmath/*.o` ../extra/tre/libtre.a    -lblas -lgfortran -lm -lquadmath   -lreadline  -lpcre2-8 -lpcre -llzma -lbz2 -lz -lrt -ldl -lm -licuuc -licui18n  
/usr/bin/ld: ../unix/system.o:/tmp/R-3.6.1/src/unix/../../src/include/Rinterface.h:157: multiple definition of `ptr_R_ProcessEvents'; ../unix/sys-unix.o:/tmp/R-3.6.1/src/unix/sys-unix.c:869: first defined here
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:177: libR.so] Error 1
make[3]: Leaving directory '/tmp/R-3.6.1/src/main'
```

- Add `-fallow-argument-mismatch` to `FFLAGS` to work around an issue with changes to argument mismatch checking in Fortran. This was fixed in R 3.6.2 but not mentioned in the NEWS for some reason. The only related reference I found was in the R Admin manual:
> * gfortran 10 by default gives a compilation error for the previously widespread practice of passing a Fortran array element where an array is expected, or a scalar instead of a length-one array. See https://gcc.gnu.org/gcc-10/porting_to.html.
> https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Using-Fortran

Without this flag, compilation fails with an error:

```sh
...
gfortran -fno-optimize-sibling-calls -fvisibility=hidden -fpic  -g -O2  -c lminfl.f -o lminfl.o
lminfl.f:117:57:

   95 |         call dqrsl(x, ldx, n, k, qraux, sigma, sigma, dummy,
      |                                               2          
......
  117 |                   call dqrsl(x, ldx, n, k, qraux, sigma, dummy, sigma,
      |                                                         1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
make[5]: *** [../../../../etc/Makeconf:190: lminfl.o] Error 1
make[5]: *** Waiting for unfinished jobs....
make[5]: Leaving directory '/tmp/R-3.6.1/src/library/stats/src'
make[4]: *** [../../../share/make/basepkg.mk:140: mksrc] Error 1
make[4]: Leaving directory '/tmp/R-3.6.1/src/library/stats'
make[3]: *** [Makefile:30: all] Error 2
```

