### PR TITLE
Add ubuntu 22.04 (jammy) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-1604 ubuntu-1804 ubuntu-2004 debian-9 debian-10 centos-7 centos-8 opensuse-42 opensuse-15 opensuse-152 opensuse-153
+PLATFORMS := ubuntu-1604 ubuntu-1804 ubuntu-2004 ubuntu-2204 debian-9 debian-10 centos-7 centos-8 opensuse-42 opensuse-15 opensuse-152 opensuse-153
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless
 
 deps:

--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -1,0 +1,24 @@
+FROM ubuntu:jammy
+
+ENV OS_IDENTIFIER ubuntu-2204
+
+RUN set -x \
+  && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install -y libblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get build-dep -y r-base
+
+RUN pip3 install awscli
+
+# Pin fpm to avoid git dependency in 1.12.0
+RUN gem install fpm:1.11.0
+
+RUN chmod 0777 /opt
+
+# Override the default pager used by R
+ENV PAGER /usr/bin/pager
+
+COPY package.ubuntu-2004 /package.sh
+COPY build.sh .
+ENTRYPOINT ./build.sh

--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -11,14 +11,13 @@ RUN set -x \
 
 RUN pip3 install awscli
 
-# Pin fpm to avoid git dependency in 1.12.0
-RUN gem install fpm:1.11.0
+RUN gem install fpm
 
 RUN chmod 0777 /opt
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 
-COPY package.ubuntu-2004 /package.sh
+COPY package.ubuntu-2204 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -78,17 +78,17 @@ services:
     image: r-builds:centos-7
     volumes:
       - ./integration/tmp:/tmp/output
-  centos-8:
-    command: ./build.sh
-    environment:
-      - R_VERSION=${R_VERSION}
-      - LOCAL_STORE=/tmp/output
-    build:
-      context: .
-      dockerfile: Dockerfile.centos-8
-    image: r-builds:centos-8
-    volumes:
-      - ./integration/tmp:/tmp/output
+  # centos-8:
+  #   command: ./build.sh
+  #   environment:
+  #     - R_VERSION=${R_VERSION}
+  #     - LOCAL_STORE=/tmp/output
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.centos-8
+  #   image: r-builds:centos-8
+  #   volumes:
+  #     - ./integration/tmp:/tmp/output
   opensuse-42:
     command: ./build.sh
     environment:

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -34,6 +34,17 @@ services:
     image: r-builds:ubuntu-2004
     volumes:
       - ./integration/tmp:/tmp/output
+  ubuntu-2204:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.ubuntu-2204
+    image: r-builds:ubuntu-2204
+    volumes:
+      - ./integration/tmp:/tmp/output
   debian-9:
     command: ./build.sh
     environment:

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/ubuntu-2204 ]]; then
+  mkdir -p /tmp/output/ubuntu-2204
+fi
+
+# R 3.x requires PCRE1
+pcre_lib='libpcre2-dev'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='libpcre3-dev'
+fi
+
+fpm \
+  -s dir \
+  -t deb \
+  -v 1 \
+  -n R-${R_VERSION} \
+  --vendor "RStudio, PBC" \
+  --deb-priority "optional" \
+  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
+  --license "GPL-2" \
+  -p /tmp/output/ubuntu-2204/ \
+  -d g++ \
+  -d gcc \
+  -d gfortran \
+  -d libbz2-dev \
+  -d libblas-dev \
+  -d libc6 \
+  -d libcairo2 \
+  -d libcurl4 \
+  -d libglib2.0-0 \
+  -d libgomp1 \
+  -d libicu-dev \
+  -d libjpeg8 \
+  -d liblapack-dev \
+  -d liblzma-dev \
+  -d libpango-1.0-0 \
+  -d libpangocairo-1.0-0 \
+  -d libpaper-utils \
+  -d ${pcre_lib} \
+  -d libpng16-16 \
+  -d libreadline8 \
+  -d libtcl8.6 \
+  -d libtiff5 \
+  -d libtk8.6 \
+  -d libx11-6 \
+  -d libxt6 \
+  -d make \
+  -d ucf \
+  -d unzip \
+  -d zip \
+  -d zlib1g-dev \
+  /opt/R/${R_VERSION}
+
+shopt -s extglob
+export PKG_FILE=$(ls /tmp/output/ubuntu-2204/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)

--- a/handler.py
+++ b/handler.py
@@ -129,6 +129,7 @@ def queue_builds(event, context):
             # zlib version fails to handle versions longer than 5 characters.
             # Skip builds affected by this bug.
             if platform in [
+                'ubuntu-2204',
                 'ubuntu-2004',
                 'ubuntu-1804',
                 'opensuse-15',

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -173,6 +173,20 @@ rBuildsBatchJobDefinitionUbuntu2004:
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:ubuntu-2004"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionUbuntu2204:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:ubuntu-2204"
+    Timeout:
+      AttemptDurationSeconds: 7200
 rBuildsBatchJobDefinitionDebian9:
   Type: AWS::Batch::JobDefinition
   Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -41,6 +41,8 @@ provider:
       Ref: rBuildsBatchJobDefinitionUbuntu1804
     JOB_DEFINITION_ARN_ubuntu_2004:
       Ref: rBuildsBatchJobDefinitionUbuntu2004
+    JOB_DEFINITION_ARN_ubuntu_2204:
+      Ref: rBuildsBatchJobDefinitionUbuntu2204
     JOB_DEFINITION_ARN_debian_9:
       Ref: rBuildsBatchJobDefinitionDebian9
     JOB_DEFINITION_ARN_debian_10:
@@ -57,7 +59,7 @@ provider:
       Ref: rBuildsBatchJobDefinitionOpensuse152
     JOB_DEFINITION_ARN_opensuse_153:
       Ref: rBuildsBatchJobDefinitionOpensuse153
-    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,ubuntu-2004,debian-9,debian-10,centos-7,centos-8,opensuse-42,opensuse-15,opensuse-152,opensuse-153
+    SUPPORTED_PLATFORMS: ubuntu-1604,ubuntu-1804,ubuntu-2004,ubuntu-2204,debian-9,debian-10,centos-7,centos-8,opensuse-42,opensuse-15,opensuse-152,opensuse-153
 
 functions:
   queueBuilds:


### PR DESCRIPTION
So i can create a new set of r-base images based on jammy, so I can build an updated revdepcheck-cloud docker image based on those 🎪 