### PR TITLE
update builder (Docker and package files for better java support)

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -11,8 +11,7 @@ RUN yum -y update \
     gcc-c++ \
     gcc-gfortran \
     gcc-objc \
-    java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk-headless \
+    java-11-openjdk-devel \
     libICE-devel \
     libSM-devel \
     libX11-devel \
@@ -66,6 +65,9 @@ ENV CONFIGURE_OPTIONS="\
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
     --enable-prebuilt-html"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
 
 # RHEL 7 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"

--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -12,8 +12,7 @@ RUN dnf -y upgrade \
     cairo-devel \
     gcc-c++ \
     gcc-gfortran \
-    java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk-headless \
+    java-11-openjdk-devel \
     libICE-devel \
     libSM-devel \
     libX11-devel \
@@ -67,6 +66,9 @@ ENV CONFIGURE_OPTIONS="\
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
     --enable-prebuilt-html"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
 
 # RHEL 8 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"

--- a/builder/Dockerfile.debian-10
+++ b/builder/Dockerfile.debian-10
@@ -17,6 +17,9 @@ RUN chmod 0777 /opt
 # Pin fpm to avoid git dependency in 1.12.0
 RUN gem install fpm:1.11.0
 
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 

--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -17,6 +17,9 @@ RUN chmod 0777 /opt
 # Pin fpm to avoid git dependency in 1.12.0
 RUN gem install fpm:1.11.0
 
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 

--- a/builder/Dockerfile.opensuse-152
+++ b/builder/Dockerfile.opensuse-152
@@ -17,7 +17,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     glib2-devel \
     glibc-locale \
     help2man \
-    java-1_8_0-openjdk-devel \
+    java-11-openjdk-devel \
     libX11-devel \
     libXScrnSaver-devel \
     libXmu-devel \
@@ -73,6 +73,9 @@ RUN gem install fpm:1.11.0 && \
     ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
 
 RUN chmod 0777 /opt
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib64/jvm/java-11-openjdk
 
 # Configure flags for SUSE that don't use the defaults in build.sh
 ENV CONFIGURE_OPTIONS="\

--- a/builder/Dockerfile.opensuse-153
+++ b/builder/Dockerfile.opensuse-153
@@ -21,7 +21,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     # added ICU 69 (icu.691-devel) in a patch update. Prefer ICU 69 because the devel
     # packages can't coexist, and zypper now resolves libicu-devel to icu.691-devel.
     icu.691-devel \
-    java-1_8_0-openjdk-devel \
+    java-11-openjdk-devel \
     libX11-devel \
     libXScrnSaver-devel \
     libXmu-devel \
@@ -76,6 +76,9 @@ RUN gem install fpm:1.11.0 && \
     ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
 
 RUN chmod 0777 /opt
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib64/jvm/java-11-openjdk
 
 # Configure flags for SUSE that don't use the defaults in build.sh
 ENV CONFIGURE_OPTIONS="\

--- a/builder/Dockerfile.opensuse-42
+++ b/builder/Dockerfile.opensuse-42
@@ -75,6 +75,9 @@ RUN gem install ffi:1.12.2 fpm:1.11.0 && \
 
 RUN chmod 0777 /opt
 
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib64/jvm/java-1.8.0-openjdk
+
 # Work around issue with expired Let's Encrypt root certificate and OpenSSL 1.0.2,
 # which affects downloads from sourceforge.net (and possibly other sites).
 # On SLES 12, the issue can be resolved by updating ca-certificates-mozilla, but

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -16,6 +16,9 @@ RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
 
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 

--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -16,6 +16,9 @@ RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
 
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 

--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -15,6 +15,9 @@ RUN gem install fpm
 
 RUN chmod 0777 /opt
 
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -59,6 +59,7 @@ fpm \
   -d xz-devel \
   -d zip \
   -d zlib-devel \
+  -d java-11-openjdk-devel \ 
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -57,6 +57,7 @@ fpm \
   -d xz-devel \
   -d zip \
   -d zlib-devel \
+  -d openjdk-11-devel \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -52,6 +52,7 @@ fpm \
   -d unzip \
   -d zip \
   -d zlib1g-dev \
+  -d openjdk-11-jdk \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -52,6 +52,7 @@ fpm \
   -d unzip \
   -d zip \
   -d zlib1g-dev \
+  -d openjdk-8-jdk \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.opensuse-152
+++ b/builder/package.opensuse-152
@@ -68,6 +68,7 @@ fpm \
   -d xz-devel \
   -d zip \
   -d zlib-devel \
+  -d java-11-openjdk-devel \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.opensuse-153
+++ b/builder/package.opensuse-153
@@ -68,6 +68,7 @@ fpm \
   -d xz-devel \
   -d zip \
   -d zlib-devel \
+  -d java-11-openjdk-devel \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.opensuse-42
+++ b/builder/package.opensuse-42
@@ -66,6 +66,7 @@ fpm \
   -d xz-devel \
   -d zip \
   -d zlib-devel \
+  -d java-1_8_0-openjdk-devel \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -52,6 +52,7 @@ fpm \
   -d unzip \
   -d zip \
   -d zlib1g-dev \
+  -d openjdk-11-jdk \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -53,6 +53,7 @@ fpm \
   -d unzip \
   -d zip \
   -d zlib1g-dev \
+  -d openjdk-11-jdk \
   /opt/R/${R_VERSION}
 
 shopt -s extglob

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -53,6 +53,7 @@ fpm \
   -d unzip \
   -d zip \
   -d zlib1g-dev \
+  -d openjdk-11-jdk \
   /opt/R/${R_VERSION}
 
 shopt -s extglob


### PR DESCRIPTION
This pull request will add better java support to our opinionated R builds. 

Main issue is that the build of R from sources will auto-detect the java version present on the system. This is great to start with. The problem however that it detects the JAVA_HOME and sets it to the physically existing path. Such a path not only contains the major version of Java but also any patch level or minor release versions as defined by the linux distro. In this pull request all the files in the directory builder are updated to set JAVA_HOME to a folder that is independent of any security patches or updates applied to the underlying linux distro. 

Accepting this pull request will fix any issue that leads to the urban myth that using Java in R is difficult. 

An article on solutions.rstudio.com is in preparation https://github.com/rstudio/solutions.rstudio.com/pull/210