### PR TITLE
Build the next version of R as well

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -46,11 +46,15 @@ fetch_r_source() {
   elif [ "${1}" = devel ]; then
     # Download the daily tarball of R devel
     wget -q https://stat.ethz.ch/R/daily/R-devel.tar.gz -O /tmp/R-devel.tar.gz
+  elif [ "${1}" = "next" ]; then
+    wget -q https://cran.r-project.org/src/base-prerelease/R-latest.tar.gz -O /tmp/R-next.tar.gz
   else
     wget -q "${CRAN}/src/base/R-`echo ${1}| awk 'BEGIN {FS="."} {print $1}'`/R-${1}.tar.gz" -O /tmp/R-${1}.tar.gz
   fi
   echo "Extracting R-${1}"
   tar xf /tmp/R-${1}.tar.gz -C /tmp
+  dirname=`tar tzvf /tmp/R-next.tar.gz | head -1 | awk '{ print $NF }' | cut -d/ -f1`
+  mv /tmp/${dirname} /tmp/R-${1}
   rm /tmp/R-${1}.tar.gz
 }
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -53,8 +53,11 @@ fetch_r_source() {
   fi
   echo "Extracting R-${1}"
   tar xf /tmp/R-${1}.tar.gz -C /tmp
-  dirname=`tar tzvf /tmp/R-next.tar.gz | head -1 | awk '{ print $NF }' | cut -d/ -f1`
-  mv /tmp/${dirname} /tmp/R-${1}
+  # 'next' may contain R-patched/, R-alpha/, etc. make it R-next/
+  if [ "${1}" = "next" ]; then
+      dirname=`tar tzvf /tmp/R-next.tar.gz | head -1 | awk '{ print $NF }' | cut -d/ -f1`
+      mv /tmp/${dirname} /tmp/R-next
+  fi
   rm /tmp/R-${1}.tar.gz
 }
 

--- a/handler.py
+++ b/handler.py
@@ -43,6 +43,7 @@ def _cran_all_r_versions():
     r_versions = []
     r_versions.extend(_cran_r_versions(CRAN_SRC_R3_URL))
     r_versions.extend(_cran_r_versions(CRAN_SRC_R4_URL))
+    r_versions.append('next')
     r_versions.append('devel')
     return {'r_versions': r_versions}
 

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -318,7 +318,7 @@ rBuildsDevelEventRule:
     State: ${self:custom.${self:provider.stage}.eventRuleState}
     Targets:
       - Id: rbuilds
-        Input: '{"force": true, "versions": ["devel"]}'
+        Input: '{"force": true, "versions": ["next", "devel"]}'
         RoleArn:
           Fn::GetAtt: [ rBuildsEventRuleIamRole, Arn ]
         Arn:


### PR DESCRIPTION
R-next is R-patched if there is no active release process, and R-alpha -> R-beta -> R-rc -> R-prerelease before a release. After the release it switches back to R-patched.

The name 'next' is not great, but 'latest' means "latest release" for many people, and `prerelease` is used by R core for the very last build before the actual release.

I tested Ubuntu 18.04 and 20.04 locally. Did not build on other OSes, but since we already build release and devel, it should be fine, I think. 

I also did not test that serverless stuff, obviously. If passing a two-element list to `version` works, then that should be fine as well.