### PR TITLE
Fix missing Pango support in R 3.x for Ubuntu 22

### DIFF
--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -18,6 +18,9 @@ RUN chmod 0777 /opt
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager
 
+# R 3.x requires PCRE2 for Pango support on Ubuntu 22
+ENV INCLUDE_PCRE2_IN_R_3 yes
+
 COPY package.ubuntu-2204 /package.sh
 COPY build.sh .
 ENTRYPOINT ./build.sh

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -97,7 +97,7 @@ compile_r() {
   #
   # The INCLUDE_PCRE2_IN_R_3 environment variable can be set to include PCRE2
   # in R 3.x builds, for distributions where PCRE2 is always required.
-  # In Debian 11, Pango now depends on PCRE2, so R 3.x will not be compiled with
+  # In Debian 11/Ubuntu 22, Pango now depends on PCRE2, so R 3.x will not be compiled with
   # Pango support if the PCRE2 pkg-config file is missing.
   if [[ "${1}" =~ ^3 ]] && pkg-config --exists libpcre2-8 && [ -z "$INCLUDE_PCRE2_IN_R_3" ]; then
     mkdir -p /tmp/pcre2

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -4,10 +4,10 @@ if [[ ! -d /tmp/output/ubuntu-2204 ]]; then
   mkdir -p /tmp/output/ubuntu-2204
 fi
 
-# R 3.x requires PCRE1
-pcre_lib='libpcre2-dev'
+# R 3.x requires PCRE1. On Ubuntu 22, R 3.x also requires PCRE2 for Pango support.
+pcre_lib_flags='-d libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='libpcre3-dev'
+  pcre_lib_flags='-d libpcre2-dev -d libpcre3-dev'
 fi
 
 fpm \
@@ -40,7 +40,7 @@ fpm \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \
-  -d ${pcre_lib} \
+  ${pcre_lib_flags} \
   -d libpng16-16 \
   -d libreadline8 \
   -d libtcl8.6 \


### PR DESCRIPTION
Caught by the tests from https://github.com/rstudio/r-docker/pull/76 - similar to a Debian 11 issue (https://github.com/rstudio/r-builds/pull/106), the Ubuntu 22 builds are missing Pango support on R 3.x because Pango now depends on PCRE2:

```sh
$ docker run -it --rm rstudio/r-base:3.6-jammy

> png()
Error in .External2(C_X11, paste0("png::", filename), g$width, g$height,  : 
  unable to start device PNG
In addition: Warning message:
In png() : unable to open connection to X11 display ''

> getOption("bitmapType")
[1] "Xlib"
```

> **Include PCRE2 in R 3.x on Debian 11 for Pango support**
> In Debian 11, Pango now depends on PCRE2 (indirectly via one of its dependencies), so R 3.x will not be compiled with Pango support if we hide PCRE2 to prevent R 3.5 and 3.6 from taking an unnecessary dependency on PCRE2. For context, we hide PCRE2 from R 3.x builds because both PCRE1 and PCRE2 are installed in the build image, and R 3.5/3.6 will take an unused dependency on PCRE2 if its present (https://github.com/rstudio/r-builds/pull/63).

The fix is to set `INCLUDE_PCRE2_IN_R_3=yes` for the Ubuntu 22 builds. After the fix, Pango support should be compiled in, and the default `bitmapType` should be Cairo:

```sh
root@40473d4d2a9a:/# /opt/R/3.6.3/bin/R

R version 3.6.3 (2020-02-29) -- "Holding the Windsock"
Copyright (C) 2020 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

> png()
> getOption("bitmapType")
[1] "cairo"
```
