### PR TITLE
Switch back to using OpenBLAS for Ubuntu 22

### DIFF
--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python3-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -27,7 +27,6 @@ fpm \
   -d gcc \
   -d gfortran \
   -d libbz2-dev \
-  -d libblas-dev \
   -d libc6 \
   -d libcairo2 \
   -d libcurl4 \
@@ -35,8 +34,8 @@ fpm \
   -d libgomp1 \
   -d libicu-dev \
   -d libjpeg8 \
-  -d liblapack-dev \
   -d liblzma-dev \
+  -d libopenblas-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
   -d libpaper-utils \


### PR DESCRIPTION
Switches the Ubuntu 22 R builds back to using OpenBLAS. When we added Ubuntu 20 support, there was a bug with the OpenBLAS package that caused hangs/crashes with R, so we replaced it with the (slower) default reference BLAS (https://github.com/rstudio/r-builds/issues/62). That bug doesn't affect Ubuntu 22 and was probably patched on Ubuntu 20 already, so we can switch back to using OpenBLAS. This change essentially reverts https://github.com/rstudio/r-builds/commit/1bedbc6ff6298a35e8d91c2bd45d61f8910c62af but for Ubuntu 22 (which was mostly copied from Ubuntu 20)

This change shouldn't break any existing installations of R on Ubuntu 22. You'll be able to reinstall R and continue using any previously installed packages. [Ubuntu/Debian makes BLAS libraries swappable at runtime](https://wiki.debian.org/DebianScience/LinearAlgebraLibraries) with the alternatives system, so you could also make this change on an existing installation by running `apt install libopenblas-dev`, and R will automatically switch to using OpenBLAS. You can also revert back to using the default BLAS with the `update-alternatives` command if you wanted to.