### PR TITLE
Update R-devel tarball location

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -45,7 +45,7 @@ fetch_r_source() {
     wget -q "${R_TARBALL_URL}" -O /tmp/R-${1}.tar.gz
   elif [ "${1}" = devel ]; then
     # Download the daily tarball of R devel
-    wget -q https://stat.ethz.ch/R/daily/R-devel.tar.gz -O /tmp/R-devel.tar.gz
+    wget -q https://cran.r-project.org/src/base-prerelease/R-devel.tar.gz -O /tmp/R-devel.tar.gz
   elif [ "${1}" = "next" ]; then
     wget -q https://cran.r-project.org/src/base-prerelease/R-latest.tar.gz -O /tmp/R-next.tar.gz
   else


### PR DESCRIPTION
The R-devel tarballs at https://stat.ethz.ch/R/daily/ are currently broken and an empty file. Update the URL to the working R-devel tarballs at https://cran.r-project.org/src/base-prerelease/R-devel.tar.gz (https://github.com/r-hub/r-minimal/commit/b319570bd44e2d5f6bbb3e515035cd3fed2b57b2)