### PR TITLE
Update Lambda runtime to Python 3.8

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ package:
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.8
   stage: ${opt:stage, self:custom.defaultStage}
   deploymentBucket:
     name: ${self:custom.deploymentBucket}


### PR DESCRIPTION
Resolves https://github.com/rstudio/r-builds/issues/121

Update the Lambda runtime to `python3.8` (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). I can't test an actual deployment yet, but did at least try a dry-run serverless deploy.

The latest available runtime is actually Python 3.9, but it's not supported out-of-box by the serverless-python-requirements plugin yet (https://github.com/serverless/serverless-python-requirements/issues/647). I think there's a workaround for this, but not sure if it's worth the effort.

