### PR TITLE
Update instance types

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -82,7 +82,7 @@ rBuildsEcsLaunchTemplate:
       BlockDeviceMappings:
         - DeviceName: /dev/xvdcz
           Ebs:
-            VolumeType: gp2
+            VolumeType: gp3
             VolumeSize: 64
 
 rBuildsBatchComputeEnvironment:

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -105,16 +105,15 @@ rBuildsBatchComputeEnvironment:
       InstanceRole:
         "Fn::GetAtt": [ rBuildsIamInstanceProfile, Arn ]
       InstanceTypes:
-        - m4.large
-        - m4.xlarge
-        - m4.2xlarge
-        - m4.4xlarge
-        - m4.10xlarge
-        - m4.16xlarge
-        - r4.large
-        - r4.xlarge
-        - r4.2xlarge
-        - r4.4xlarge
+        - m6i
+        - m5
+        - m5a
+        - r6i
+        - r5
+        - r5a
+        - c6i
+        - c5
+        - c5a
       Ec2KeyPair: ${self:custom.ec2KeyPair}
       Tags: ${self:provider.stackTags}
       MinvCpus: 0

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -101,7 +101,7 @@ rBuildsBatchComputeEnvironment:
       SecurityGroupIds: ${self:custom.securityGroupIds}
       Subnets: ${self:custom.subnets}
       Type: SPOT
-      BidPercentage: 60
+      BidPercentage: 85
       InstanceRole:
         "Fn::GetAtt": [ rBuildsIamInstanceProfile, Arn ]
       InstanceTypes:


### PR DESCRIPTION
More modern and less expensive instance types, update the bid percentage to match python-builds as well.

Changing this will update the launch template, which will pull in a newer ami instead of the deprecated `ami-0d09143c6fc181fe3`

closes #126