### PR TITLE
Add GitHub Actions workflow to test R builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,15 +43,13 @@ jobs:
         r_versions=$(python test/get_r_versions.py ${{ github.event.inputs.r_versions }})
         echo "::set-output name=r_versions::$r_versions"
 
-  test:
+  docker-images:
     needs: setup-matrix
     strategy:
       matrix:
         platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
-    env:
-      R_VERSIONS: ${{ join(fromJson(needs.setup-matrix.outputs.r_versions), ' ') }}
     runs-on: ubuntu-latest
-    name: ${{ matrix.platform }} (R ${{ join(fromJson(needs.setup-matrix.outputs.r_versions), ', ') }})
+    name: Docker image (${{ matrix.platform }})
     steps:
       - uses: actions/checkout@v3
 
@@ -75,23 +73,13 @@ jobs:
       # Use docker buildx instead of docker-compose here because cache exporting
       # does not seem to work as of docker-compose v2.6.0 and buildx v0.8.2, even
       # though it works with buildx individually.
-      - name: Build R
+      - name: Build image
         run: |
-          for version in ${{ env.R_VERSIONS }}; do
-            docker buildx build -t r-builds:${{ matrix.platform }} \
-              --file builder/Dockerfile.${{ matrix.platform }} \
-              --cache-from "type=local,src=/tmp/.buildx-cache" \
-              --cache-to "type=local,dest=/tmp/.buildx-cache-new,mode=max" \
-              --load \
-              builder
-            R_VERSION=$version make build-r-${{ matrix.platform }}
-          done
-
-      - name: Test R
-        run: |
-          for version in ${{ env.R_VERSIONS }}; do
-            R_VERSION=$version make test-r-${{ matrix.platform }}
-          done
+          docker buildx build -t r-builds:${{ matrix.platform }} \
+            --file builder/Dockerfile.${{ matrix.platform }} \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache-new,mode=max" \
+            builder
 
       # Temporary workaround for unbounded GHA cache growth with the local cache mode.
       # https://github.com/docker/build-push-action/issues/252
@@ -100,3 +88,42 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  test:
+    needs: [setup-matrix, docker-images]
+    strategy:
+      matrix:
+        platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
+        r_version: ${{ fromJson(needs.setup-matrix.outputs.r_versions) }}
+    runs-on: ubuntu-latest
+    name: ${{ matrix.platform }} (R ${{ matrix.r_version }})
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+
+      - name: Restore cached Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ matrix.platform }}-buildx-${{ github.sha }}
+          restore-keys: ${{ matrix.platform }}-buildx-
+
+      - name: Load cached Docker image
+        run: |
+          docker buildx build -t r-builds:${{ matrix.platform }} \
+            --file builder/Dockerfile.${{ matrix.platform }} \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --load \
+            builder
+
+      - name: Build R
+        run: |
+          R_VERSION=${{ matrix.r_version }} make build-r-${{ matrix.platform }}
+
+      - name: Test R
+        run: |
+          R_VERSION=${{ matrix.r_version }} make test-r-${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,7 @@ jobs:
   test:
     needs: [setup-matrix, docker-images]
     strategy:
+      fail-fast: false
       matrix:
         platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
         r_version: ${{ fromJson(needs.setup-matrix.outputs.r_versions) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,74 @@
+name: R builds
+
+on:
+  push:
+    paths:
+      - 'builder/**'
+      - 'test/**'
+      - 'Makefile'
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: |
+          Comma-separated list of platforms. Specify "all" to use all platforms (the default).
+        required: false
+        default: 'all'
+        type: string
+      r_versions:
+        description: |
+          Comma-separated list of R versions. Specify "last-N" to use the
+          last N minor R versions, or "all" to use all minor R versions since R 3.1.
+          Defaults to "last-5".
+        required: false
+        default: 'last-5'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.setup-matrix.outputs.platforms }}
+      r_versions: ${{ steps.setup-matrix.outputs.r_versions }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up matrix of platforms and R versions
+      id: setup-matrix
+      run: |
+        platforms=$(python test/get_platforms.py ${{ github.event.inputs.platforms }})
+        echo "::set-output name=platforms::$platforms"
+        r_versions=$(python test/get_r_versions.py ${{ github.event.inputs.r_versions }})
+        echo "::set-output name=r_versions::$r_versions"
+
+  test:
+    needs: setup-matrix
+    strategy:
+      matrix:
+        platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
+    env:
+      R_VERSIONS: ${{ join(fromJson(needs.setup-matrix.outputs.r_versions), ' ') }}
+    runs-on: ubuntu-latest
+    name: ${{ matrix.platform }} (R ${{ join(fromJson(needs.setup-matrix.outputs.r_versions), ', ') }})
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+          install: true
+
+      - name: Build R
+        run: |
+          for version in ${{ env.R_VERSIONS }}; do
+            R_VERSION=$version make build-r-${{ matrix.platform }}
+          done
+
+      - name: Test R
+        run: |
+          for version in ${{ env.R_VERSIONS }}; do
+            R_VERSION=$version make test-r-${{ matrix.platform }}
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          driver: docker
           install: true
 
+      # Enable Docker layer caching without having to push to a registry.
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache
+      # This may eventually be migrated to the GitHub Actions cache backend,
+      # which is still considered experimental.
+      # https://github.com/moby/buildkit#github-actions-cache-experimental
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ matrix.platform }}-buildx-${{ github.sha }}
+          restore-keys: ${{ matrix.platform }}-buildx-
+
+      # Use docker buildx instead of docker-compose here because cache exporting
+      # does not seem to work as of docker-compose v2.6.0 and buildx v0.8.2, even
+      # though it works with buildx individually.
       - name: Build R
         run: |
           for version in ${{ env.R_VERSIONS }}; do
+            docker buildx build -t r-builds:${{ matrix.platform }} \
+              --file builder/Dockerfile.${{ matrix.platform }} \
+              --cache-from "type=local,src=/tmp/.buildx-cache" \
+              --cache-to "type=local,dest=/tmp/.buildx-cache-new,mode=max" \
+              --load \
+              builder
             R_VERSION=$version make build-r-${{ matrix.platform }}
           done
 
@@ -72,3 +92,11 @@ jobs:
           for version in ${{ env.R_VERSIONS }}; do
             R_VERSION=$version make test-r-${{ matrix.platform }}
           done
+
+      # Temporary workaround for unbounded GHA cache growth with the local cache mode.
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - 'builder/**'
       - 'test/**'
       - 'Makefile'
+      - '.github/workflows/test.yml'
   workflow_dispatch:
     inputs:
       platforms:

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ $(foreach platform,$(PLATFORMS), \
     $(eval $(GEN_TARGETS)) \
 )
 
+print-platforms:
+	@echo $(PLATFORMS)
+
 # Helper for launching a bash session on a docker image of your choice. Defaults
 # to "ubuntu:xenial".
 TARGET_IMAGE?=ubuntu:xenial
@@ -68,4 +71,4 @@ bash:
 		-w /r-builds \
 		${TARGET_IMAGE} /bin/bash
 
-.PHONY: deps docker-build docker-push docker-down docker-build-package docker-shell-package-env ecr-login fetch-serverless-custom-file serverless-deploy
+.PHONY: deps docker-build docker-push docker-down docker-build-package docker-shell-package-env ecr-login fetch-serverless-custom-file print-platforms serverless-deploy

--- a/README.md
+++ b/README.md
@@ -226,6 +226,21 @@ environment:
 
 In order for the makefile to push these new platforms to ECR, add them to the PLATFORMS variable near the top of the Makefile
 
+### test/docker-compose.yml
+
+A new service in the `test/docker-compose.yml` file named according to the `platform-version` and containing the proper entries:
+
+```yaml
+  ubuntu-2204:
+    image: ubuntu:jammy
+    command: /r-builds/test/test-apt.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-2204
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ../:/r-builds
+```
+
 ### Submit a Pull Request
 
 Once you've followed the steps above, submit a pull request. On successful merge, builds for this platform will begin to be available from the CDN.
@@ -243,6 +258,16 @@ serverless invoke stepf -n rBuilds -d '{"force": true, "versions": ["3.6.3", "4.
 ```
 
 ## Testing
+
+Tests are automatically run on each push that changes a file in `builder/`, `test/`, or the `Makefile`.
+These tests validate that R was correctly configured, built, and packaged. By default, the tests run
+for the last 5 minor R versions on each platform.
+
+To run the tests manually, you can navigate to the [GitHub Actions workflow page](https://github.com/rstudio/r-builds/actions/workflows/test.yml)
+and use "Run workflow" to run the tests from a custom branch, list of platforms, and list of R versions.
+
+To skip the tests, add `[skip ci]` to your commit message. See [Skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)
+for more information.
 
 To test the R builds locally, you can use the `build-r-$PLATFORM` and `test-r-$PLATFORM`
 targets to build R and run the tests. The tests use the quick install script to install R,

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.0'
-
 services:
   ubuntu-1804:
     command: ./build.sh

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.0'
-
 services:
   ubuntu-1804:
     image: ubuntu:bionic

--- a/test/get_platforms.py
+++ b/test/get_platforms.py
@@ -1,0 +1,31 @@
+import argparse
+import json
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Print R-builds platforms as JSON.")
+    parser.add_argument(
+        'platforms',
+        type=str,
+        nargs='?',
+        default='all',
+        help='Comma-separated list of platforms. Specify "all" to use all platforms (the default).'
+    )
+    args = parser.parse_args()
+    platforms = _get_platforms(which=args.platforms)
+    print(json.dumps(platforms))
+
+
+def _get_platforms(which='all'):
+    supported_platforms = subprocess.check_output(['make', 'print-platforms'], text=True)
+    supported_platforms = supported_platforms.split()
+    if which == 'all':
+        return supported_platforms
+    platforms = which.split(',')
+    platforms = [p for p in platforms if p in supported_platforms]
+    return platforms
+
+
+if __name__ == '__main__':
+    main()

--- a/test/get_r_versions.py
+++ b/test/get_r_versions.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+import re
+import urllib.request
+
+VERSIONS_URL = 'https://cdn.rstudio.com/r/versions.json'
+
+# Minimum R version for "all"
+MIN_ALL_VERSION = '3.1.0'
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Print R-builds R versions as JSON.")
+    parser.add_argument(
+        'versions',
+        type=str,
+        nargs='?',
+        default='last-5',
+        help="""Comma-separated list of R versions. Specify "last-N" to use the
+            last N minor R versions, or "all" to use all minor R versions since R 3.1.
+            Defaults to "last-5".
+            """
+    )
+    args = parser.parse_args()
+    versions = _get_versions(which=args.versions)
+    print(json.dumps(versions))
+
+
+def _get_versions(which='all'):
+    supported_versions = sorted(_get_supported_versions(), reverse=True)
+    
+    last_n_versions = None
+    if which.startswith('last-'):
+        last_n_versions = int(which.replace('last-', ''))
+    elif which != 'all':
+        versions = which.split(',')
+        versions = [v for v in versions if v in supported_versions]
+        return versions
+
+    versions = {}
+    for ver in supported_versions:
+        # Skip unreleased versions (e.g., devel, next)
+        if not re.match(r'[\d.]', ver):
+            continue
+        if ver < MIN_ALL_VERSION:
+            continue
+        minor_ver = tuple(ver.split('.')[0:2])
+        if minor_ver not in versions:
+            versions[minor_ver] = ver
+    versions = sorted(list(versions.values()), reverse=True)
+
+    if last_n_versions:
+        return versions[0:last_n_versions]
+
+    return versions
+
+
+def _get_supported_versions():
+    request = urllib.request.Request(VERSIONS_URL)
+    response = urllib.request.urlopen(request)
+    data = response.read()
+    result = json.loads(data)
+    return result['r_versions']
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Supersedes https://github.com/rstudio/r-builds/pull/24. This takes a different approach that replaces Jenkins with GitHub Actions, which is more open (external contributors can see logs now), capable of running large build matrices, and has a few built-in features that were really useful here.

---

Currently, it's hard to maintain and add new R builds because the tests are almost completely run manually. The Jenkins job only builds the Docker images, and R has to be built and tested manually across a large matrix of platforms and R versions. To make maintenance and contribution easier, this adds a GitHub Actions workflow that runs the tests from #130 so you can spot check the R builds before opening a PR. Since the build matrix is huge:
- **Tests only run on the last 5 minor R versions** by default (currently 4.2.1, 4.1.3, 4.0.5, 3.6.3, 3.5.3), same as the Tidyverse and RSPM supported versions. The versions are determined automatically from https://cdn.rstudio.com/r/versions.json, so there's no maintenance to update the R versions. The tests will take ~20-50 mins to run like this (depending on whether the build images are cached) which is pretty long, but saves you from having to run the same tests manually. This can be adjusted if the the tests start taking too long or hit the GHA limits.
- **Tests only run on changes to files in `builder/`, `test/`, or the `Makefile`.** You should be able to update other parts of the repo like the AWS infra without having to wait on unnecessary tests.
  - Tests can also be force-skipped using GHA's built-in feature of adding `[skip ci]` to commit messages
- **Tests can be triggered manually in GitHub Actions with custom parameters**. When adding a new platform, you can go to the Actions page and kick off a test with just a single platform or the full list of R versions down to R 3.1.

![Manually trigger a test workflow in GitHub Actions](https://user-images.githubusercontent.com/20401866/184411077-55c363d8-c7b8-4137-9589-4f76d296ca32.png)

~~For future improvements, we could possibly cut time by pushing/pulling images to a public Docker Hub repo, but I didn't do that here.~~ I ended up adding Docker layer caching using Docker Buildx's local caching feature and GHA's built-in cache: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache. This cut the run time from 1.5 hours to ~20-50 mins, and doesn't use Docker Hub or any Docker registry.