### PR TITLE
Openblas java

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -3,6 +3,7 @@ FROM centos:centos7
 ENV OS_IDENTIFIER centos-7
 
 RUN yum -y update \
+    && yum -y install epel-release \
     && yum -y install \
     autoconf \
     automake \
@@ -26,6 +27,7 @@ RUN yum -y update \
     libtool \
     make \
     ncurses-devel \
+    openblas-devel \
     pango-devel \
     pcre-devel \
     pcre2-devel \
@@ -56,6 +58,9 @@ RUN gem install ffi:1.12.2 fpm:1.11.0
 
 RUN chmod 0777 /opt
 
+# OpenBLAS definition
+ENV BLAS_LIBS="-L/usr/lib64 -lopenblasp"
+
 # Configure flags for CentOS 7 that don't use the defaults in build.sh
 ENV CONFIGURE_OPTIONS="\
     --enable-R-shlib \
@@ -66,6 +71,9 @@ ENV CONFIGURE_OPTIONS="\
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
     --enable-prebuilt-html"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
 
 # RHEL 7 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"

--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -27,6 +27,7 @@ RUN dnf -y upgrade \
     libtool \
     make \
     ncurses-devel \
+    openblas-devel \
     pango-devel \
     pcre-devel \
     pcre2-devel \
@@ -57,7 +58,10 @@ RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
 
-# Configure flags for CentOS 8 that don't use the defaults in build.sh
+# OpenBLAS definition
+ENV BLAS_LIBS="-L/usr/lib64 -lopenblasp"
+
+# Configure flags for CentOS 7 that don't use the defaults in build.sh
 ENV CONFIGURE_OPTIONS="\
     --enable-R-shlib \
     --with-tcltk \
@@ -67,6 +71,9 @@ ENV CONFIGURE_OPTIONS="\
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
     --enable-prebuilt-html"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
 
 # RHEL 8 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"

--- a/builder/Dockerfile.debian-10
+++ b/builder/Dockerfile.debian-10
@@ -7,12 +7,22 @@ RUN set -x \
   && echo 'deb-src http://deb.debian.org/debian buster main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas-base libpcre2-dev make python3-pip ruby ruby-dev wget \
+     libopenblas-dev libpcre2-dev make openjdk-11-jdk python3-pip ruby ruby-dev wget \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
 
+# OpenBLAS
+ENV BLAS_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -lblas"
+ENV LAPACK_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -llapack"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
 RUN chmod 0777 /opt
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # Pin fpm to avoid git dependency in 1.12.0
 RUN gem install fpm:1.11.0

--- a/builder/Dockerfile.debian-11
+++ b/builder/Dockerfile.debian-11
@@ -7,7 +7,7 @@ RUN set -x \
   && echo 'deb-src http://deb.debian.org/debian bullseye main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas-base libpcre2-dev make python3-pip ruby ruby-dev wget \
+     libopenblas-dev libpcre2-dev make openjdk-11-jdk python3-pip ruby ruby-dev wget \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
@@ -15,6 +15,13 @@ RUN pip3 install awscli
 RUN chmod 0777 /opt
 
 RUN gem install fpm
+
+# OpenBLAS
+ENV BLAS_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -lblas"
+ENV LAPACK_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -llapack"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.debian-9
+++ b/builder/Dockerfile.debian-9
@@ -7,7 +7,7 @@ RUN set -x \
   && echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas-base libpcre2-dev make python-pip ruby ruby-dev wget \
+     libopenblas-dev libpcre2-dev make openjdk-11-jdk python-pip ruby ruby-dev wget \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli
@@ -16,6 +16,13 @@ RUN chmod 0777 /opt
 
 # Pin fpm to avoid git dependency in 1.12.0
 RUN gem install fpm:1.11.0
+
+# OpenBLAS
+ENV BLAS_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -lblas"
+ENV LAPACK_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -llapack"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.opensuse-153
+++ b/builder/Dockerfile.opensuse-153
@@ -32,6 +32,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     libpng-devel \
     libtiff-devel \
     make \
+    openblas-devel \
     pango-devel \
     pcre-devel \
     pcre2-devel \
@@ -85,6 +86,12 @@ ENV CONFIGURE_OPTIONS="\
     --enable-memory-profiling \
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh"
+
+# Add Support for OpenBLAS
+ENV BLAS_LIBS="-L/usr/lib64 -lopenblas"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib64/jvm/java-1.8.0-openjdk
 
 COPY package.opensuse-153 /package.sh
 COPY build.sh .

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python-pip ruby ruby-dev \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-dev libpcre2-dev wget openjdk-11-jdk python-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli
@@ -15,6 +15,13 @@ RUN pip install awscli
 RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
+
+# OpenBLAS
+ENV BLAS_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -lblas"
+ENV LAPACK_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -llapack"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get install -y libblas-dev libcurl4-openssl-dev libicu-dev libopenblas-dev libpcre2-dev wget openjdk-11-jdk python3-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
@@ -15,6 +15,13 @@ RUN pip3 install awscli
 RUN gem install fpm:1.11.0
 
 RUN chmod 0777 /opt
+
+# OpenBLAS 
+ENV BLAS_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -lblas"
+ENV LAPACK_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -llapack"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-dev libpcre2-dev wget openjdk-11-jdk python3-pip ruby ruby-dev \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
@@ -14,6 +14,13 @@ RUN pip3 install awscli
 RUN gem install fpm
 
 RUN chmod 0777 /opt
+
+# OpenBLAS 
+ENV BLAS_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -lblas"
+ENV LAPACK_LIBS="-L /usr/lib/x86_64-linux-gnu/openblas/ -llapack"
+
+# Make sure that patching the OS does not break Java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -137,6 +137,9 @@ compile_r() {
   make
   make install
 
+  # Run javareconf to activate java bindings
+  /opt/R/${1}/bin/R CMD javareconf  
+
   # Add OS identifier to the default HTTP user agent.
   # Set this in the system Rprofile so it works when R is run with --vanilla.
   cat <<EOF >> /opt/R/${1}/lib/R/library/base/R/Rprofile

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -10,19 +10,6 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='pcre-devel'
 fi
 
-# create post-install script required for openblas
-cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep 
-ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
-EOF
-
-# create after-remove script to remove internal blas
-cat <<EOF >> /before-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
-fi
-EOF
-
 fpm \
   -s dir \
   -t rpm \
@@ -35,13 +22,13 @@ fpm \
   --description "GNU R statistical computation and graphics system" \
   --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
   --license "GPL-2" \
-  --after-install /post-install.sh \
-  --after-remove /before-remove.sh \
   -p /tmp/output/centos-7/ \
   -d bzip2-devel \
   -d gcc \
   -d gcc-c++ \
   -d gcc-gfortran \
+  -d java-1.8.0-openjdk-devel \
+  -d java-1.8.0-openjdk-headless \
   -d libcurl-devel \
   -d libicu-devel \
   -d libSM \

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -8,19 +8,6 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='pcre-devel'
 fi
 
-# create post-install script required for openblas
-cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblasp.so.0 /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
-EOF
-
-# create after-remove script to remove internal blas
-cat <<EOF >> /before-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
-fi
-EOF
-
 fpm \
   -s dir \
   -t rpm \
@@ -40,6 +27,8 @@ fpm \
   -d gcc \
   -d gcc-c++ \
   -d gcc-gfortran \
+  -d java-1.8.0-openjdk-devel \
+  -d java-1.8.0-openjdk-headless \
   -d libcurl-devel \
   -d libicu-devel \
   -d libSM \

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -48,6 +48,7 @@ fpm \
   -d libx11-6 \
   -d libxt6 \
   -d make \
+  -d openjdk-11-jdk \
   -d ucf \
   -d unzip \
   -d zip \

--- a/builder/package.debian-11
+++ b/builder/package.debian-11
@@ -48,6 +48,7 @@ fpm \
   -d libx11-6 \
   -d libxt6 \
   -d make \
+  -d openjdk-11-jdk \
   -d ucf \
   -d unzip \
   -d zip \

--- a/builder/package.debian-9
+++ b/builder/package.debian-9
@@ -48,6 +48,7 @@ fpm \
   -d libx11-6 \
   -d libxt6 \
   -d make \
+  -d openjdk-11-jdk \
   -d ucf \
   -d unzip \
   -d zip \

--- a/builder/package.opensuse-153
+++ b/builder/package.opensuse-153
@@ -10,19 +10,6 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='pcre-devel'
 fi
 
-# create post-install script required for openblas
-cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
-EOF
-
-# create after-remove script to remove internal blas
-cat <<EOF >> /before-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
-fi
-EOF
-
 fpm \
   -s dir \
   -t rpm \
@@ -45,6 +32,7 @@ fpm \
   -d glibc-locale \
   -d gzip \
   -d icu.691-devel \
+  -d java-11-openjdk-devel \
   -d libbz2-devel \
   -d libcairo2 \
   -d libcurl-devel \

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -48,6 +48,7 @@ fpm \
   -d libx11-6 \
   -d libxt6 \
   -d make \
+  -d openjdk-11-jdk \
   -d ucf \
   -d unzip \
   -d zip \

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -35,7 +35,7 @@ fpm \
   -d libgomp1 \
   -d libicu-dev \
   -d libjpeg8 \
-  -d liblapack-dev \
+  -d libopenblas-dev \
   -d liblzma-dev \
   -d libpango-1.0-0 \
   -d libpangocairo-1.0-0 \
@@ -49,6 +49,7 @@ fpm \
   -d libx11-6 \
   -d libxt6 \
   -d make \
+  -d openjdk-11-jdk \
   -d ucf \
   -d unzip \
   -d zip \

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -48,6 +48,7 @@ fpm \
   -d libx11-6 \
   -d libxt6 \
   -d make \
+  -d openjdk-11-jdk \
   -d ucf \
   -d unzip \
   -d zip \


### PR DESCRIPTION
This is an extension of https://github.com/rstudio/r-builds/pull/113 with additional stuff around OpenBLAS support (make it more consistent and also add OpenBLAS support for Ubuntu 20.04 (Ubuntu 20.04 currently only works with default BLAS/LAPACK and hence some benchmarks are 5 to 6 x slower compared to OpenBLAS. 

As for general benchmarking I have put together a github repo in https://github.com/michaelmayer2/r-builds-bench that will run https://github.com/michaelmayer2/r-benchmarks/blob/main/R-benchmark-25/R-benchmark-25.R. That's also how I found out about the performance issue in Ubuntu 20.04. 