### PR TITLE
Add R builds for RHEL 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-1804 ubuntu-2004 ubuntu-2204 debian-10 debian-11 centos-7 centos-8 opensuse-153
+PLATFORMS := ubuntu-1804 ubuntu-2004 ubuntu-2204 debian-10 debian-11 centos-7 centos-8 rhel-9 opensuse-153
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless
 
 deps:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ R binaries are built for the following Linux operating systems:
 - Ubuntu 18.04, 20.04, 22.04
 - Debian 10, 11
 - CentOS 7
-- Red Hat Enterprise Linux 7, 8
+- Red Hat Enterprise Linux 7, 8, 9
 - openSUSE 15.3
 - SUSE Linux Enterprise 15 SP3
 
@@ -81,21 +81,39 @@ sudo gdebi r-${R_VERSION}_1_amd64.deb
 #### RHEL/CentOS Linux
 
 Enable the [Extra Packages for Enterprise Linux](https://fedoraproject.org/wiki/EPEL)
-repository (RHEL/CentOS 7 only):
+repository (RHEL/CentOS 7 and RHEL 9 only):
 
 ```bash
 # CentOS / RHEL 7
 sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+# Rocky Linux 9 / AlmaLinux 9
+sudo dnf install dnf-plugins-core
+sudo dnf config-manager --set-enabled crb
+sudo dnf install epel-release
+
+# RHEL 9
+sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 ```
 
-> Note that on RHEL 7, you may also need to enable the Optional repository:
+> On RHEL 7, you may also need to enable the Optional repository:
 > ```bash
-> # For RHEL 7 users with certificate subscriptions:
 > sudo subscription-manager repos --enable "rhel-*-optional-rpms"
 >
-> # Or alternatively, using yum:
+> # If running RHEL 7 in a public cloud, such as Amazon EC2, enable the
+> # Optional repository from Red Hat Update Infrastructure (RHUI) instead
 > sudo yum install yum-utils
 > sudo yum-config-manager --enable "rhel-*-optional-rpms"
+> ```
+
+> On RHEL 9, you may also need to enable the CodeReady Linux Builder repository:
+> ```bash
+> sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
+> 
+> # If running RHEL 9 in a public cloud, such as Amazon EC2, enable the CodeReady
+> # Linux Builder repository from Red Hat Update Infrastructure (RHUI) instead
+> sudo dnf install dnf-plugins-core
+> sudo dnf config-manager --enable codeready-builder-for-rhel-9-*-rpms
 > ```
 
 Download the rpm package:
@@ -103,8 +121,11 @@ Download the rpm package:
 # CentOS / RHEL 7
 wget https://cdn.rstudio.com/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
-# RHEL 8
+# RHEL 8 / Rocky Linux 8 / AlmaLinux 8
 wget https://cdn.rstudio.com/r/centos-8/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+
+# RHEL 9 / Rocky Linux 9 / AlmaLinux 9
+wget https://cdn.rstudio.com/r/rhel-9/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:

--- a/builder/Dockerfile.rhel-9
+++ b/builder/Dockerfile.rhel-9
@@ -1,0 +1,90 @@
+FROM rockylinux:9
+
+ENV OS_IDENTIFIER rhel-9
+
+RUN dnf -y upgrade \
+    && dnf -y install dnf-plugins-core \
+    && dnf config-manager --set-enabled crb \
+    && dnf install -y epel-release \
+    && dnf -y install \
+    autoconf \
+    automake \
+    bzip2-devel \
+    cairo-devel \
+    gcc-c++ \
+    gcc-gfortran \
+    java-11-openjdk-devel \
+    libICE-devel \
+    libSM-devel \
+    libX11-devel \
+    libXmu-devel \
+    libXt-devel \
+    libcurl-devel \
+    libicu-devel \
+    libjpeg-devel \
+    libpng-devel \
+    libtiff-devel \
+    libtool \
+    make \
+    ncurses-devel \
+    pango-devel \
+    pcre-devel \
+    pcre2-devel \
+    readline-devel \
+    rpm-build \
+    ruby \
+    ruby-devel \
+    tcl-devel \
+    tex \
+    texinfo-tex \
+    texlive-collection-latexrecommended \
+    tk-devel \
+    unzip \
+    valgrind-devel \
+    which \
+    wget \
+    xz-devel \
+    zlib-devel \
+    && dnf clean all
+
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+RUN gem install fpm
+
+RUN chmod 0777 /opt
+
+# Configure flags for RHEL 9 that don't use the defaults in build.sh
+ENV CONFIGURE_OPTIONS="\
+    --enable-R-shlib \
+    --with-tcltk \
+    --enable-memory-profiling \
+    --with-x \
+    --with-system-valgrind-headers \
+    --with-tcl-config=/usr/lib64/tclConfig.sh \
+    --with-tk-config=/usr/lib64/tkConfig.sh \
+    --enable-prebuilt-html"
+
+# RHEL 9 doesn't have the inconsolata font, so override the defaults.
+# This may be removed if RHEL ever adds the texlive-inconsolata package from Fedora.
+# Or check `dnf provides '*/inconsolata.sty'` for a package that provides it.
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Making-the-manuals
+ENV R_RD4PDF="times,hyper"
+
+# Make sure that patching Java does not break R.
+# R's default JAVA_HOME path includes the exact Java version on CentOS/RHEL, which
+# requires users to run `R CMD javareconf` even on minor/patch upgrades. Use the
+# major version symlink to avoid this.
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Java-support
+# https://solutions.rstudio.com/r/using-rjava/
+ENV JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+
+# R 3.x requires PCRE2 for Pango support on RHEL 9
+ENV INCLUDE_PCRE2_IN_R_3 yes
+
+COPY package.rhel-9 /package.sh
+COPY build.sh .
+ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -76,6 +76,17 @@ services:
     image: r-builds:centos-8
     volumes:
       - ./integration/tmp:/tmp/output
+  rhel-9:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.rhel-9
+    image: r-builds:rhel-9
+    volumes:
+      - ./integration/tmp:/tmp/output
   opensuse-153:
     command: ./build.sh
     environment:

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -1,0 +1,60 @@
+if [[ ! -d /tmp/output/rhel-9 ]]; then
+  mkdir -p /tmp/output/rhel-9
+fi
+
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
+# Create post-install script required for OpenBLAS
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
+# Create after-remove script to remove internal BLAS
+cat <<EOF >> /after-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n "R-${R_VERSION}" \
+  --vendor "RStudio, PBC" \
+  --url "https://www.r-project.org" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio, PBC <https://github.com/rstudio/r-builds>" \
+  --license "GPLv2+" \
+  --after-install /post-install.sh \
+  --after-remove /after-remove.sh \
+  -p /tmp/output/rhel-9/ \
+  -d bzip2-devel \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-gfortran \
+  -d libcurl-devel \
+  -d libicu-devel \
+  -d libSM \
+  -d libtiff \
+  -d libXmu \
+  -d libXt \
+  -d make \
+  -d openblas-devel \
+  -d pango \
+  -d ${pcre_lib} \
+  -d tcl \
+  -d tk \
+  -d unzip \
+  -d which \
+  -d xz-devel \
+  -d zip \
+  -d zlib-devel \
+  "/opt/R/${R_VERSION}"
+
+export PKG_FILE=$(ls /tmp/output/rhel-9/R-${R_VERSION}*.rpm | head -1)

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -8,13 +8,29 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='pcre-devel'
 fi
 
-# Create post-install script required for OpenBLAS
+# Create post-install script required for OpenBLAS.
+#
+# On RHEL and SUSE, we link R against the internal shared BLAS to make the
+# R binaries more portable and allow users to switch BLAS implementations without
+# having to recompile R. We default to OpenBLAS, but users may prefer other implementations.
+# 
+# Binary packages built against the shared BLAS are also more portable and may be used
+# with the default R distributed by RHEL/SUSE, or other R installations using
+# shared BLAS and configured with a different BLAS (such as Microsoft R Open with MKL).
+# This is especially important for RSPM's binary packages.
+#
+# On Ubuntu/Debian, we link R against the external BLAS instead (--with-blas/--with-lapack),
+# as those distributions use the alternatives system to swap BLAS libraries at runtime.
+# The default R distributions on Ubuntu/Debian use the external BLAS, so we do as well
+# for portability.
+#
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Shared-BLAS
 cat <<EOF >> /post-install.sh
 mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
 ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
 EOF
 
-# Create after-remove script to remove internal BLAS
+# Create after-remove script to remove internal BLAS, which won't be cleaned up automatically.
 cat <<EOF >> /after-remove.sh
 if [ -d /opt/R/${R_VERSION} ]; then
   rm -r /opt/R/${R_VERSION}

--- a/handler.py
+++ b/handler.py
@@ -128,17 +128,9 @@ def queue_builds(event, context):
         for platform in event['supported_platforms']:
             # In R 3.3.0, 3.3.1, and 3.3.2, the configure script check for the
             # zlib version fails to handle versions longer than 5 characters.
-            # Skip builds affected by this bug.
-            if platform in [
-                'ubuntu-2204',
-                'ubuntu-2004',
-                'ubuntu-1804',
-                'opensuse-153',
-                'centos-8',
-                'rhel-9',
-                'debian-10',
-                'debian-11',
-            ] and version in ['3.3.0', '3.3.1', '3.3.2']:
+            # Skip builds affected by this bug. Most newer distros will be affected.
+            # https://github.com/rstudio/r-builds/issues/76
+            if version in ['3.3.0', '3.3.1', '3.3.2'] and platform not in ['centos-7']:
                 continue
             job_ids.append(_submit_job(version, platform))
     event['jobIds'] = job_ids

--- a/handler.py
+++ b/handler.py
@@ -135,6 +135,7 @@ def queue_builds(event, context):
                 'ubuntu-1804',
                 'opensuse-153',
                 'centos-8',
+                'rhel-9',
                 'debian-10',
                 'debian-11',
             ] and version in ['3.3.0', '3.3.1', '3.3.2']:

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -228,6 +228,20 @@ rBuildsBatchJobDefinitionCentos8:
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:centos-8"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionRhel9:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:rhel-9"
+    Timeout:
+      AttemptDurationSeconds: 7200
 rBuildsBatchJobDefinitionOpensuse153:
   Type: AWS::Batch::JobDefinition
   Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,9 +49,11 @@ provider:
       Ref: rBuildsBatchJobDefinitionCentos7
     JOB_DEFINITION_ARN_centos_8:
       Ref: rBuildsBatchJobDefinitionCentos8
+    JOB_DEFINITION_ARN_rhel_9:
+      Ref: rBuildsBatchJobDefinitionRhel9
     JOB_DEFINITION_ARN_opensuse_153:
       Ref: rBuildsBatchJobDefinitionOpensuse153
-    SUPPORTED_PLATFORMS: ubuntu-1804,ubuntu-2004,ubuntu-2204,debian-10,debian-11,centos-7,centos-8,opensuse-153
+    SUPPORTED_PLATFORMS: ubuntu-1804,ubuntu-2004,ubuntu-2204,debian-10,debian-11,centos-7,centos-8,rhel-9,opensuse-153
 
 functions:
   queueBuilds:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -55,6 +55,14 @@ services:
       - R_VERSION=${R_VERSION}
     volumes:
       - ../:/r-builds
+  rhel-9:
+    image: rockylinux:9
+    command: /r-builds/test/test-yum.sh
+    environment:
+      - OS_IDENTIFIER=rhel-9
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ../:/r-builds
   opensuse-153:
     image: opensuse/leap:15.3
     command: /r-builds/test/test-zypper.sh


### PR DESCRIPTION
Add R builds for RHEL 9, based on Rocky Linux 9. This was mostly copied over from the centos-8 (Rocky 8) build, with a few differences to note:
- The platform name is now "rhel-9" since we officially only support RHEL, not the RHEL derivatives. Rocky Linux and AlmaLinux are still mentioned in the README because the installation steps differ vs. RHEL.
- EPEL is now required to install R again, for OpenBLAS and texinfo. Rocky/Alma have replaced PowerTools with the CodeReady Builder repo as a requirement to use EPEL.
- R is now configured with Java 11 instead of Java 8 by default, as Java 8 is EOL. `JAVA_HOME` is explicitly set to a major-versioned path to make Java configuration easier on users, based on @michaelmayer2's work in https://github.com/rstudio/r-builds/pull/113.
- Some RPM fields are corrected after checking with rpmlint, like #119 suggests:
  - added https to URL, https://www.r-project.org
  - wrapped maintainer field in brackets, `RStudio, PBC <https://github.com/rstudio/r-builds>`
  - corrected the invalid `GPL-2` license field to the RPM standard `GPLv2+`
- Added more doc comments to make future maintenance easier, like how we link against BLAS.

I've run a test workflow with the full matrix of R versions at https://github.com/rstudio/r-builds/actions/runs/2878921915