### PR TITLE
Add R builds for openSUSE 15.4/SLES 15 SP4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-1804 ubuntu-2004 ubuntu-2204 debian-10 debian-11 centos-7 centos-8 rhel-9 opensuse-153
+PLATFORMS := ubuntu-1804 ubuntu-2004 ubuntu-2204 debian-10 debian-11 centos-7 centos-8 rhel-9 opensuse-153 opensuse-154
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless
 
 deps:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ R binaries are built for the following Linux operating systems:
 - Debian 10, 11
 - CentOS 7
 - Red Hat Enterprise Linux 7, 8, 9
-- openSUSE 15.3
-- SUSE Linux Enterprise 15 SP3
+- openSUSE 15.3, 15.4
+- SUSE Linux Enterprise 15 SP3, 15 SP4
 
 Operating systems are supported until their vendor end-of-support dates, which
 can be found on the [RStudio Platform Support](https://www.rstudio.com/about/platform-support/)
@@ -139,6 +139,9 @@ Download the rpm package:
 ```bash
 # openSUSE 15.3 / SLES 15 SP3
 wget https://cdn.rstudio.com/r/opensuse-153/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+
+# openSUSE 15.4 / SLES 15 SP4
+wget https://cdn.rstudio.com/r/opensuse-154/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:

--- a/builder/Dockerfile.opensuse-154
+++ b/builder/Dockerfile.opensuse-154
@@ -1,0 +1,101 @@
+FROM opensuse/leap:15.4
+
+ENV OS_IDENTIFIER opensuse-154
+
+# Most of these packages, and also the configure options that follow were determined
+# by reviewing "R-base.spec" from the following OpenSUSE RPM:
+# https://download.opensuse.org/repositories/devel:/languages:/R:/released/openSUSE_Leap_42.3/src/R-base-3.5.3-103.1.src.rpm
+
+RUN zypper --non-interactive update
+RUN zypper --non-interactive --gpg-auto-import-keys -n install \
+    bzip2 \
+    cairo-devel \
+    curl \
+    fdupes \
+    gcc \
+    gcc-c++ \
+    gcc-fortran \
+    glib2-devel \
+    glibc-locale \
+    help2man \
+    # Like openSUSE/SLES 15.3, SUSE 15.4 ships with both ICU 65 (libicu-devel) and
+    # ICU 69 (icu.691-devel). Prefer ICU 69 because the devel packages can't coexist, and
+    # zypper resolves libicu-devel to icu.691-devel when installing RPMs.
+    icu.691-devel \
+    java-11-openjdk-devel \
+    libX11-devel \
+    libXScrnSaver-devel \
+    libXmu-devel \
+    libXt-devel \
+    libbz2-devel \
+    libcurl-devel \
+    libjpeg-devel \
+    libpng-devel \
+    libtiff-devel \
+    make \
+    pango-devel \
+    pcre-devel \
+    pcre2-devel \
+    perl \
+    perl-macros \
+    readline-devel \
+    rpm-build \
+    ruby \
+    ruby-devel \
+    shadow \
+    tcl-devel \
+    texinfo \
+    texlive-ae \
+    texlive-bibtex \
+    texlive-cm-super \
+    texlive-dvips \
+    texlive-fancyvrb \
+    texlive-helvetic \
+    texlive-inconsolata \
+    texlive-latex \
+    texlive-makeindex \
+    texlive-metafont \
+    texlive-psnfss \
+    texlive-tex \
+    texlive-times \
+    tk-devel \
+    unzip \
+    wget \
+    xdg-utils \
+    xorg-x11-devel \
+    xz-devel \
+    zip \
+    zlib-devel \
+    && zypper clean
+
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+RUN gem install fpm && \
+    ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
+
+RUN chmod 0777 /opt
+
+# Configure flags for SUSE that don't use the defaults in build.sh
+ENV CONFIGURE_OPTIONS="\
+    --enable-R-shlib \
+    --with-tcltk \
+    --with-x \
+    --enable-memory-profiling \
+    --with-tcl-config=/usr/lib64/tclConfig.sh \
+    --with-tk-config=/usr/lib64/tkConfig.sh"
+
+# Make sure that patching Java does not break R.
+# On SUSE, the default JAVA_HOME path always uses the major Java version only,
+# but the JDK path is chosen by default. We change this to the JRE path to
+# support users who only want to install the JRE (non-devel) package.
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Java-support
+# https://solutions.rstudio.com/r/using-rjava/
+ENV JAVA_HOME=/usr/lib64/jvm/jre-11-openjdk
+
+COPY package.opensuse-154 /package.sh
+COPY build.sh .
+ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -98,3 +98,14 @@ services:
     image: r-builds:opensuse-153
     volumes:
       - ./integration/tmp:/tmp/output
+  opensuse-154:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.opensuse-154
+    image: r-builds:opensuse-154
+    volumes:
+      - ./integration/tmp:/tmp/output

--- a/builder/package.opensuse-154
+++ b/builder/package.opensuse-154
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/opensuse-154 ]]; then
+  mkdir -p /tmp/output/opensuse-154
+fi
+
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
+# Create post-install script required for OpenBLAS.
+#
+# On RHEL and SUSE, we link R against the internal shared BLAS to make the
+# R binaries more portable and allow users to switch BLAS implementations without
+# having to recompile R. We default to OpenBLAS, but users may prefer other implementations.
+# 
+# Binary packages built against the shared BLAS are also more portable and may be used
+# with the default R distributed by RHEL/SUSE, or other R installations using
+# shared BLAS and configured with a different BLAS (such as Microsoft R Open with MKL).
+# This is especially important for RSPM's binary packages.
+#
+# On Ubuntu/Debian, we link R against the external BLAS instead (--with-blas/--with-lapack),
+# as those distributions use the alternatives system to swap BLAS libraries at runtime.
+# The default R distributions on Ubuntu/Debian use the external BLAS, so we do as well
+# for portability.
+#
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Shared-BLAS
+cat <<EOF >> /post-install.sh
+mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+EOF
+
+# Create after-remove script to remove internal BLAS, which won't be cleaned up automatically.
+cat <<EOF >> /after-remove.sh
+if [ -d /opt/R/${R_VERSION} ]; then
+  rm -r /opt/R/${R_VERSION}
+fi
+EOF
+
+fpm \
+  -s dir \
+  -t rpm \
+  -v 1 \
+  -n "R-${R_VERSION}" \
+  --vendor "RStudio, PBC" \
+  --url "http://www.r-project.org/" \
+  --description "GNU R statistical computation and graphics system" \
+  --maintainer "RStudio, PBC <https://github.com/rstudio/r-builds>" \
+  --license "GPLv2" \
+  --after-install /post-install.sh \
+  --after-remove /after-remove.sh \
+  -p /tmp/output/opensuse-154/ \
+  -d fontconfig \
+  -d gcc \
+  -d gcc-c++ \
+  -d gcc-fortran \
+  -d glibc-locale \
+  -d gzip \
+  -d icu.691-devel \
+  -d libbz2-devel \
+  -d libcairo2 \
+  -d libcurl-devel \
+  -d libfreetype6 \
+  -d libgomp1 \
+  -d libjpeg62 \
+  -d libopenblas_pthreads-devel \
+  -d libpango-1_0-0 \
+  -d libreadline7 \
+  -d libtiff5 \
+  -d make \
+  -d ${pcre_lib} \
+  -d tar \
+  -d tcl \
+  -d tk \
+  -d unzip \
+  -d which \
+  -d xorg-x11 \
+  -d xorg-x11-fonts-100dpi \
+  -d xorg-x11-fonts-75dpi \
+  -d xz-devel \
+  -d zip \
+  -d zlib-devel \
+  "/opt/R/${R_VERSION}"
+
+export PKG_FILE=$(ls /tmp/output/opensuse-154/R-${R_VERSION}*.rpm | head -1)

--- a/install.sh
+++ b/install.sh
@@ -194,7 +194,9 @@ download_url () {
         echo "${CDN_URL}/opensuse-42/pkgs/${name}"
         ;;
       "LEAP15" | "SLES15")
-        if [ "${ver}" -ge 153 ]; then
+        if [ "${ver}" -ge 154 ]; then
+          echo "${CDN_URL}/opensuse-154/pkgs/${name}"
+        elif [ "${ver}" -ge 153 ]; then
           echo "${CDN_URL}/opensuse-153/pkgs/${name}"
         elif [ "${ver}" -eq 152 ]; then
           echo "${CDN_URL}/opensuse-152/pkgs/${name}"

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -256,6 +256,20 @@ rBuildsBatchJobDefinitionOpensuse153:
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:opensuse-153"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionOpensuse154:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:opensuse-154"
+    Timeout:
+      AttemptDurationSeconds: 7200
 
 # step function cloudwatch event trigger resources
 rBuildsEventRuleIamRole:

--- a/serverless.yml
+++ b/serverless.yml
@@ -53,7 +53,9 @@ provider:
       Ref: rBuildsBatchJobDefinitionRhel9
     JOB_DEFINITION_ARN_opensuse_153:
       Ref: rBuildsBatchJobDefinitionOpensuse153
-    SUPPORTED_PLATFORMS: ubuntu-1804,ubuntu-2004,ubuntu-2204,debian-10,debian-11,centos-7,centos-8,rhel-9,opensuse-153
+    JOB_DEFINITION_ARN_opensuse_154:
+      Ref: rBuildsBatchJobDefinitionOpensuse154
+    SUPPORTED_PLATFORMS: ubuntu-1804,ubuntu-2004,ubuntu-2204,debian-10,debian-11,centos-7,centos-8,rhel-9,opensuse-153,opensuse-154
 
 functions:
   queueBuilds:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -71,3 +71,11 @@ services:
       - R_VERSION=${R_VERSION}
     volumes:
       - ../:/r-builds
+  opensuse-154:
+    image: opensuse/leap:15.4
+    command: /r-builds/test/test-zypper.sh
+    environment:
+      - OS_IDENTIFIER=opensuse-154
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ../:/r-builds


### PR DESCRIPTION
Add R builds for openSUSE 15.4 / SLES 15 SP4. This was nearly identical to the openSUSE 15.3 build, but with the same changes made for RHEL 9 at https://github.com/rstudio/r-builds/pull/133:
- Use Java 11 over the EOL Java 8 and explicitly set `JAVA_HOME`. On SUSE, the Java packages always install to a major-versioned path, but R uses the JDK path which won't exist if a user only installs the JRE. So to accommodate that, we explicitly set JAVA_HOME to the JRE path which exists with both the `java-11-openjdk` (JRE) and `java-11-openjdk-devel` packages.
- Fix invalid RPM fields
- Add better doc comments

For testing, here's a manual run of the full R version matrix: https://github.com/rstudio/r-builds/actions/runs/2884443994