### PR TITLE
Fix openSUSE 15.4 image build; begin replacing fpm with nFPM

### DIFF
--- a/builder/Dockerfile.debian-11
+++ b/builder/Dockerfile.debian-11
@@ -6,15 +6,17 @@ RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && echo 'deb-src http://deb.debian.org/debian bullseye main' >> /etc/apt/sources.list \
   && apt-get update \
-  && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas-base libpcre2-dev make python3-pip ruby ruby-dev wget \
+  && apt-get install -y curl gcc libcurl4-openssl-dev libicu-dev \
+     libopenblas-base libpcre2-dev make python3-pip wget \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
 
 RUN chmod 0777 /opt
 
-RUN gem install fpm
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.deb && \
+    apt install -y ./nfpm_amd64.deb && \
+    rm nfpm_amd64.deb
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.opensuse-154
+++ b/builder/Dockerfile.opensuse-154
@@ -40,8 +40,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     perl-macros \
     readline-devel \
     rpm-build \
-    ruby \
-    ruby-devel \
     shadow \
     tcl-devel \
     texinfo \
@@ -74,8 +72,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install && \
     rm -rf aws awscliv2.zip
 
-RUN gem install fpm && \
-    ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.rpm && \
+    zypper --non-interactive --no-gpg-checks install nfpm_amd64.rpm && \
+    rm nfpm_amd64.rpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.rhel-9
+++ b/builder/Dockerfile.rhel-9
@@ -32,8 +32,6 @@ RUN dnf -y upgrade \
     pcre2-devel \
     readline-devel \
     rpm-build \
-    ruby \
-    ruby-devel \
     tcl-devel \
     tex \
     texinfo-tex \
@@ -53,7 +51,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install && \
     rm -rf aws awscliv2.zip
 
-RUN gem install fpm
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.rpm && \
+    dnf install -y nfpm_amd64.rpm && \
+    rm nfpm_amd64.rpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -6,12 +6,14 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get install -y curl libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python3-pip \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
 
-RUN gem install fpm
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.deb && \
+    apt install -y ./nfpm_amd64.deb && \
+    rm nfpm_amd64.deb
 
 RUN chmod 0777 /opt
 

--- a/builder/package.debian-11
+++ b/builder/package.debian-11
@@ -1,59 +1,69 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/debian-11 ]]; then
-  mkdir -p /tmp/output/debian-11
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1. On Debian 11, R 3.x also requires PCRE2 for Pango support.
-pcre_lib_flags='-d libpcre2-dev'
+pcre_libs='- libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib_flags='-d libpcre2-dev -d libpcre3-dev'
+  pcre_libs='- libpcre2-dev
+- libpcre3-dev'
 fi
 
-fpm \
-  -s dir \
-  -t deb \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  -p /tmp/output/debian-11/ \
-  -d ca-certificates \
-  -d g++ \
-  -d gcc \
-  -d gfortran \
-  -d libbz2-dev \
-  -d libc6 \
-  -d libcairo2 \
-  -d libcurl4-openssl-dev \
-  -d libglib2.0-0 \
-  -d libgomp1 \
-  -d libicu-dev \
-  -d liblzma-dev \
-  -d libopenblas-dev \
-  -d libpango-1.0-0 \
-  -d libpangocairo-1.0-0 \
-  -d libpaper-utils \
-  ${pcre_lib_flags} \
-  -d libpng16-16 \
-  -d libreadline8 \
-  -d libtcl8.6 \
-  -d libtiff5 \
-  -d libtk8.6 \
-  -d libx11-6 \
-  -d libxt6 \
-  -d make \
-  -d ucf \
-  -d unzip \
-  -d zip \
-  -d zlib1g-dev \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: r-${R_VERSION}
+version: 1
+version_schema: none
+section: gnu-r
+priority: optional
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPL-2
+deb:
+  fields:
+    Bugs: https://github.com/rstudio/r-builds/issues
+depends:
+- ca-certificates
+- g++
+- gcc
+- gfortran
+- libbz2-dev
+- libc6
+- libcairo2
+- libcurl4-openssl-dev
+- libglib2.0-0
+- libgomp1
+- libicu-dev
+- liblzma-dev
+- libopenblas-dev
+- libpango-1.0-0
+- libpangocairo-1.0-0
+- libpaper-utils
+${pcre_libs}
+- libpng16-16
+- libreadline8
+- libtcl8.6
+- libtiff5
+- libtk8.6
+- libx11-6
+- libxt6
+- make
+- ucf
+- unzip
+- zip
+- zlib1g-dev
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/debian-11/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p deb \
+  -t "/tmp/output/${OS_IDENTIFIER}"
 
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/r-${R_VERSION}*.deb | head -1)

--- a/builder/package.opensuse-154
+++ b/builder/package.opensuse-154
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/opensuse-154 ]]; then
-  mkdir -p /tmp/output/opensuse-154
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -39,49 +39,59 @@ if [ -d /opt/R/${R_VERSION} ]; then
 fi
 EOF
 
-fpm \
-  -s dir \
-  -t rpm \
-  -v 1 \
-  -n "R-${R_VERSION}" \
-  --vendor "RStudio, PBC" \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC <https://github.com/rstudio/r-builds>" \
-  --license "GPLv2" \
-  --after-install /post-install.sh \
-  --after-remove /after-remove.sh \
-  -p /tmp/output/opensuse-154/ \
-  -d fontconfig \
-  -d gcc \
-  -d gcc-c++ \
-  -d gcc-fortran \
-  -d glibc-locale \
-  -d gzip \
-  -d icu.691-devel \
-  -d libbz2-devel \
-  -d libcairo2 \
-  -d libcurl-devel \
-  -d libfreetype6 \
-  -d libgomp1 \
-  -d libjpeg62 \
-  -d libopenblas_pthreads-devel \
-  -d libpango-1_0-0 \
-  -d libreadline7 \
-  -d libtiff5 \
-  -d make \
-  -d ${pcre_lib} \
-  -d tar \
-  -d tcl \
-  -d tk \
-  -d unzip \
-  -d which \
-  -d xorg-x11 \
-  -d xorg-x11-fonts-100dpi \
-  -d xorg-x11-fonts-75dpi \
-  -d xz-devel \
-  -d zip \
-  -d zlib-devel \
-  "/opt/R/${R_VERSION}"
+cat <<EOF > /tmp/nfpm.yml
+name: R-${R_VERSION}
+version: 1
+version_schema: none
+release: 1
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPLv2+
+depends:
+- fontconfig
+- gcc
+- gcc-c++
+- gcc-fortran
+- glibc-locale
+- gzip
+- icu.691-devel
+- libbz2-devel
+- libcairo2
+- libcurl-devel
+- libfreetype6
+- libgomp1
+- libjpeg62
+- libopenblas_pthreads-devel
+- libpango-1_0-0
+- libreadline7
+- libtiff5
+- make
+- ${pcre_lib}
+- tar
+- tcl
+- tk
+- unzip
+- which
+- xorg-x11
+- xorg-x11-fonts-100dpi
+- xorg-x11-fonts-75dpi
+- xz-devel
+- zip
+- zlib-devel
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+scripts:
+  postinstall: /post-install.sh
+  postremove: /after-remove.sh
+EOF
 
-export PKG_FILE=$(ls /tmp/output/opensuse-154/R-${R_VERSION}*.rpm | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p rpm \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm | head -1)

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -1,5 +1,7 @@
-if [[ ! -d /tmp/output/rhel-9 ]]; then
-  mkdir -p /tmp/output/rhel-9
+#!/bin/bash
+
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -37,40 +39,50 @@ if [ -d /opt/R/${R_VERSION} ]; then
 fi
 EOF
 
-fpm \
-  -s dir \
-  -t rpm \
-  -v 1 \
-  -n "R-${R_VERSION}" \
-  --vendor "RStudio, PBC" \
-  --url "https://www.r-project.org" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC <https://github.com/rstudio/r-builds>" \
-  --license "GPLv2+" \
-  --after-install /post-install.sh \
-  --after-remove /after-remove.sh \
-  -p /tmp/output/rhel-9/ \
-  -d bzip2-devel \
-  -d gcc \
-  -d gcc-c++ \
-  -d gcc-gfortran \
-  -d libcurl-devel \
-  -d libicu-devel \
-  -d libSM \
-  -d libtiff \
-  -d libXmu \
-  -d libXt \
-  -d make \
-  -d openblas-devel \
-  -d pango \
-  -d ${pcre_lib} \
-  -d tcl \
-  -d tk \
-  -d unzip \
-  -d which \
-  -d xz-devel \
-  -d zip \
-  -d zlib-devel \
-  "/opt/R/${R_VERSION}"
+cat <<EOF > /tmp/nfpm.yml
+name: R-${R_VERSION}
+version: 1
+version_schema: none
+release: 1
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPLv2+
+depends:
+- bzip2-devel
+- gcc
+- gcc-c++
+- gcc-gfortran
+- libcurl-devel
+- libicu-devel
+- libSM
+- libtiff
+- libXmu
+- libXt
+- make
+- openblas-devel
+- pango
+- ${pcre_lib}
+- tcl
+- tk
+- unzip
+- which
+- xz-devel
+- zip
+- zlib-devel
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+scripts:
+  postinstall: /post-install.sh
+  postremove: /after-remove.sh
+EOF
 
-export PKG_FILE=$(ls /tmp/output/rhel-9/R-${R_VERSION}*.rpm | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p rpm \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm | head -1)

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -1,58 +1,69 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/ubuntu-2204 ]]; then
-  mkdir -p /tmp/output/ubuntu-2204
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1. On Ubuntu 22, R 3.x also requires PCRE2 for Pango support.
-pcre_lib_flags='-d libpcre2-dev'
+pcre_libs='- libpcre2-dev'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib_flags='-d libpcre2-dev -d libpcre3-dev'
+  pcre_libs='- libpcre2-dev
+- libpcre3-dev'
 fi
 
-fpm \
-  -s dir \
-  -t deb \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  -p /tmp/output/ubuntu-2204/ \
-  -d g++ \
-  -d gcc \
-  -d gfortran \
-  -d libbz2-dev \
-  -d libc6 \
-  -d libcairo2 \
-  -d libcurl4 \
-  -d libglib2.0-0 \
-  -d libgomp1 \
-  -d libicu-dev \
-  -d libjpeg8 \
-  -d liblzma-dev \
-  -d libopenblas-dev \
-  -d libpango-1.0-0 \
-  -d libpangocairo-1.0-0 \
-  -d libpaper-utils \
-  ${pcre_lib_flags} \
-  -d libpng16-16 \
-  -d libreadline8 \
-  -d libtcl8.6 \
-  -d libtiff5 \
-  -d libtk8.6 \
-  -d libx11-6 \
-  -d libxt6 \
-  -d make \
-  -d ucf \
-  -d unzip \
-  -d zip \
-  -d zlib1g-dev \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: r-${R_VERSION}
+version: 1
+version_schema: none
+section: universe/math
+priority: optional
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPL-2
+deb:
+  fields:
+    Bugs: https://github.com/rstudio/r-builds/issues
+depends:
+- g++
+- gcc
+- gfortran
+- libbz2-dev
+- libc6
+- libcairo2
+- libcurl4
+- libglib2.0-0
+- libgomp1
+- libicu-dev
+- libjpeg8
+- liblzma-dev
+- libopenblas-dev
+- libpango-1.0-0
+- libpangocairo-1.0-0
+- libpaper-utils
+${pcre_libs}
+- libpng16-16
+- libreadline8
+- libtcl8.6
+- libtiff5
+- libtk8.6
+- libx11-6
+- libxt6
+- make
+- ucf
+- unzip
+- zip
+- zlib1g-dev
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/ubuntu-2204/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p deb \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/r-${R_VERSION}*.deb | head -1)


### PR DESCRIPTION
The SUSE 15.4 image build failed as soon as I merged https://github.com/rstudio/r-builds/pull/134 due to a Ruby gem dependency issue with fpm, the DEB/RPM packaging tool:
https://github.com/rstudio/r-builds/runs/7924309239?check_suite_focus=true
```sh
Step 6/12 : RUN gem install fpm &&     ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
 ---> Running in 6ac62b82d651
ERROR:  Error installing fpm:
	The last version of public_suffix (< 6.0, >= 2.0.2) to support your Ruby & RubyGems was 4.0.7. Try installing it with `gem install public_suffix -v 4.0.7` and then running the current command again
	public_suffix requires Ruby version >= 2.6. The current ruby version is 2.5.0.
```
The public_suffix gem depends on Ruby >= 2.6 which openSUSE doesn't provide, so we would've had to pin fpm to an older version or wait for a fix in fpm.

Instead, I've replaced fpm with a different tool called [nFPM](https://nfpm.goreleaser.com/), which @atheriel recommended a while back:
> nFPM is a simple, 0-dependencies, deb, rpm and apk packager.
>
> While [fpm](https://github.com/jordansissel/fpm) is great, for me, it is a bummer that it depends on ruby, tar and other software.
> I wanted something that could be used as a binary and/or as a library and that was really simple.
> So I decided to create nFPM: a simpler, 0-dependency, as-little-assumptions-as-possible alternative to fpm.

nFPM is a Go-based alternative to fpm that should be more reliable, has better support for code signing (https://github.com/rstudio/r-builds/issues/7), and still has all the features we need from fpm. fpm has had so many Ruby gem dependency issues over the years that have made it a pain to maintain:
https://github.com/rstudio/r-builds/issues/86
https://github.com/rstudio/r-builds/pull/110#discussion_r799052928
https://github.com/rstudio/r-builds/pull/83#issuecomment-767791975
https://github.com/rstudio/r-builds/pull/64#issuecomment-637677923

The migration was pretty straightforward, and there were just a few differences in the configs to account for:
- nFPM is configured through a YAML file instead of CLI args, and only supports environment variable values in some fields. [Templating is explicitly not supported](https://nfpm.goreleaser.com/configuration/#templating), and they recommend using envsubst from the gettext package instead. Here, I've just inlined the YAML into the packaging scripts since it's not too complicated and matches the old CLI args closely.
- nFPM adds empty `Epoch: 0` and `Distribution: (none)` fields to the RPMs, unlike fpm, which I couldn't figure out how to remove. I don't think this is a big deal.
- While migrating, I also addressed some of the DEB linting issues from https://github.com/rstudio/r-builds/issues/119:
  - Remove invalid `License`/`Vendor` fields from DEBs
  - Fix `Maintainer` formatting to `RStudio, PBC <https://github.com/rstudio/r-builds>`, although lintian still says this is invalid (because it's not an email perhaps)
  - Set `Section` to `universe/math` on Ubuntu and `gnu-r` on Debian to match the `r-base` packages

I only replaced fpm for the newest platforms here to get SUSE 15.4 fixed asap, and will migrate the other platforms later.

---

Here's what the RPM and DEB fields look like, before and after.

RPMs:
```sh
# fpm
$ rpm -qi R-4.2.1-1-1.x86_64.rpm
Name        : R-4.2.1
Version     : 1
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : default
Size        : 101532248
License     : GPL-2
Signature   : (none)
Source RPM  : R-4.2.1-1-1.src.rpm
Build Date  : Thu 23 Jun 2022 03:09:41 AM CDT
Build Host  : ip-172-16-135-66
Relocations : / 
Packager    : RStudio, PBC https://github.com/rstudio/r-builds
Vendor      : RStudio, PBC
URL         : http://www.r-project.org/
Summary     : GNU R statistical computation and graphics system
Description :
GNU R statistical computation and graphics system

# nFPM
$ rpm -qi R-4.2.1-1-1.x86_64.rpm 
Name        : R-4.2.1
Epoch       : 0
Version     : 1
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : 
Size        : 101534144
License     : GPLv2+
Signature   : (none)
Source RPM  : R-4.2.1-1-1.src.rpm
Build Date  : Mon Aug 22 22:51:31 2022
Build Host  : 3a8657e10c34
Relocations : (not relocatable)
Packager    : RStudio, PBC <https://github.com/rstudio/r-builds>
Vendor      : RStudio, PBC
URL         : https://www.r-project.org
Summary     : GNU R statistical computation and graphics system
Description :
GNU R statistical computation and graphics system

Distribution: (none)
```
DEBs:
```sh
# fpm
$ dpkg -f r-4.2.1_1_amd64.deb 
Package: r-4.2.1
Version: 1
License: GPL-2
Vendor: RStudio, PBC
Architecture: amd64
Maintainer: RStudio, PBC https://github.com/rstudio/r-builds
Installed-Size: 91012
Depends: g++, gcc, gfortran, libbz2-dev, libc6, libcairo2, libcurl4, libglib2.0-0, libgomp1, libicu-dev, libjpeg8, liblzma-dev, libopenblas-dev, libpango-1.0-0, libpangocairo-1.0-0, libpaper-utils, libpcre2-dev, libpng16-16, libreadline8, libtcl8.6, libtiff5, libtk8.6, libx11-6, libxt6, make, ucf, unzip, zip, zlib1g-dev
Section: default
Priority: optional
Homepage: http://www.r-project.org/
Description: GNU R statistical computation and graphics system
Bugs: https://github.com/rstudio/r-builds/issues

# nFPM
$ dpkg -f r-4.2.1_1_amd64.deb 
Package: r-4.2.1
Version: 1
Section: universe/math
Priority: optional
Architecture: amd64
Maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
Installed-Size: 91013
Depends: g++, gcc, gfortran, libbz2-dev, libc6, libcairo2, libcurl4, libglib2.0-0, libgomp1, libicu-dev, libjpeg8, liblzma-dev, libopenblas-dev, libpango-1.0-0, libpangocairo-1.0-0, libpaper-utils, libpcre2-dev, libpng16-16, libreadline8, libtcl8.6, libtiff5, libtk8.6, libx11-6, libxt6, make, ucf, unzip, zip, zlib1g-dev
Homepage: https://www.r-project.org
Description: GNU R statistical computation and graphics system
Bugs: https://github.com/rstudio/r-builds/issues
```
