### PR TITLE
Increase ECS volume size to 96 GiB

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -83,7 +83,7 @@ rBuildsEcsLaunchTemplate:
         - DeviceName: /dev/xvdcz
           Ebs:
             VolumeType: gp3
-            VolumeSize: 64
+            VolumeSize: 96
 
 rBuildsBatchComputeEnvironment:
   Type: AWS::Batch::ComputeEnvironment


### PR DESCRIPTION
On staging, we're running into disk space issues with most of the Batch builds:

```sh
connections.c:6530:1: fatal error: error writing to /tmp/ccuAOxFc.s: No space left on device
```

On production, which we haven't updated for RHEL 9/SUSE 15.4 yet, we're also running into many failing builds that never run because of an error:
```
DockerTimeoutError: Could not transition to created; timed out after waiting 4m0s
```
@jforest thinks it could be related to the same disk space issues.

So trying out a bump of the ECS volume size from 64 to 96 GiB.