### PR TITLE
Use latest version of the launch template

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -96,6 +96,7 @@ rBuildsBatchComputeEnvironment:
       LaunchTemplate:
         LaunchTemplateId:
           Ref: rBuildsEcsLaunchTemplate
+        Version: '$Latest'
       SpotIamFleetRole:
         "Fn::GetAtt": [ rBuildsSpotFleetIamRole, Arn ]
       SecurityGroupIds: ${self:custom.securityGroupIds}


### PR DESCRIPTION
Changes to the launch template (e.g., ECS volume type/size at https://github.com/rstudio/r-builds/pull/137) were not being applied because the launch template was set to the default version 1 rather than the latest changed version.