### PR TITLE
Update block device name for Amazon Linux 2

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -80,7 +80,7 @@ rBuildsEcsLaunchTemplate:
     LaunchTemplateName: r-builds-${self:provider.stage}-batch-managed-ecs-larger-volume
     LaunchTemplateData:
       BlockDeviceMappings:
-        - DeviceName: /dev/xvdcz
+        - DeviceName: /dev/xvda
           Ebs:
             VolumeType: gp3
             VolumeSize: 96


### PR DESCRIPTION
Follow-up of #137 and #138: the `/dev/xvdcz` volume is now updated to gp3 and 96 GiB, but builds are still failing from lack of disk space.

Amazon Linux 1 AMIs had a separate `/dev/xvdcz` volume used for Docker storage. Amazon Linux 2 AMIs now only have a single root volume at `/dev/xvda`. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-storage-config.html

While looking at the ECS instance during the builds, I noticed there was almost no write activity on the `/dev/xvdcz` volume, and that the current AMI is Amazon Linux 2 (`amzn2-ami-ecs-hvm-2.0.20220627-x86_64-ebs`), so I guess we need to use `/dev/xvda` now. The root volume also showed up as gp2, so it would be good to change that as well.