### PR TITLE
Increase ECS_CONTAINER_CREATE_TIMEOUT to 10m to mitigate Docker timeouts

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -84,6 +84,11 @@ rBuildsEcsLaunchTemplate:
           Ebs:
             VolumeType: gp3
             VolumeSize: 96
+      UserData:
+        Fn::Base64: |
+          #!/bin/bash
+          # Mitigate DockerTimeoutError errors from the default timeout of 4m
+          echo "ECS_CONTAINER_CREATE_TIMEOUT=10m" >> /etc/ecs/ecs.config
 
 rBuildsBatchComputeEnvironment:
   Type: AWS::Batch::ComputeEnvironment


### PR DESCRIPTION
After https://github.com/rstudio/r-builds/pull/139, most builds are now working, but many jobs are still failing to start from an error:
```sh
DockerTimeoutError: Could not transition to created; timed out after waiting 4m0s
```
This error seems to happen for just the first few jobs, suggesting that the initial image pulls might be timing out, but subsequent job succeed because the images are already pulled.

Try to mitigate this by increasing the Docker timeout from the default 4m to 10m. `ECS_CONTAINER_CREATE_TIMEOUT` is not documented in the [AWS developer guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html), but it does seem to be a real setting from the ECS agent repo README:
> ECS_CONTAINER_CREATE_TIMEOUT | 10m | Timeout before giving up on creating a container. Minimum value is 1m. If user sets a value below minimum it will be set to min. | 4m | 4m
https://github.com/aws/amazon-ecs-agent/blob/a5f8d25f66fbf4f8839d5e7e5fcbc635a4d75c5e/README.md

