### PR TITLE
Migrate remaining platforms to nFPM

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -33,8 +33,6 @@ RUN yum -y update \
     python3-pip \
     readline-devel \
     rpm-build \
-    ruby \
-    ruby-devel \
     tcl-devel \
     tex \
     texinfo-tex \
@@ -51,8 +49,9 @@ RUN yum -y update \
 RUN pip3 install awscli --upgrade --user && \
     ln -s /root/.local/bin/aws /usr/bin/aws
 
-# Pin fpm for compatibility with Ruby < 2.3
-RUN gem install ffi:1.12.2 fpm:1.11.0
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.rpm && \
+    yum install -y nfpm_amd64.rpm && \
+    rm nfpm_amd64.rpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -34,8 +34,6 @@ RUN dnf -y upgrade \
     python3-pip \
     readline-devel \
     rpm-build \
-    ruby \
-    ruby-devel \
     tcl-devel \
     tex \
     texinfo-tex \
@@ -52,8 +50,9 @@ RUN dnf -y upgrade \
 RUN pip3 install awscli --upgrade --user \
     && ln -s /root/.local/bin/aws /usr/bin/aws
 
-# Pin fpm to avoid git dependency in 1.12.0
-RUN gem install fpm:1.11.0
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.rpm && \
+    dnf install -y nfpm_amd64.rpm && \
+    rm nfpm_amd64.rpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.debian-10
+++ b/builder/Dockerfile.debian-10
@@ -6,16 +6,17 @@ RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && echo 'deb-src http://deb.debian.org/debian buster main' >> /etc/apt/sources.list \
   && apt-get update \
-  && apt-get install -y gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas-base libpcre2-dev make python3-pip ruby ruby-dev wget \
+  && apt-get install -y curl gcc libcurl4-openssl-dev libicu-dev \
+     libopenblas-base libpcre2-dev make python3-pip wget \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
 
 RUN chmod 0777 /opt
 
-# Pin fpm to avoid git dependency in 1.12.0
-RUN gem install fpm:1.11.0
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.deb && \
+    apt install -y ./nfpm_amd64.deb && \
+    rm nfpm_amd64.deb
 
 # Override the default pager used by R
 ENV PAGER /usr/bin/pager

--- a/builder/Dockerfile.opensuse-153
+++ b/builder/Dockerfile.opensuse-153
@@ -10,6 +10,7 @@ RUN zypper --non-interactive update
 RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     bzip2 \
     cairo-devel \
+    curl \
     fdupes \
     gcc \
     gcc-c++ \
@@ -41,8 +42,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     python-pip \
     readline-devel \
     rpm-build \
-    ruby \
-    ruby-devel \
     shadow \
     tcl-devel \
     texinfo \
@@ -71,9 +70,9 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
 
 RUN pip install awscli
 
-# Pin fpm to avoid git dependency in 1.12.0
-RUN gem install fpm:1.11.0 && \
-    ln -s /usr/bin/fpm.ruby2.5 /usr/local/bin/fpm
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.rpm && \
+    zypper --non-interactive --no-gpg-checks install nfpm_amd64.rpm && \
+    rm nfpm_amd64.rpm
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -6,13 +6,14 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python-pip ruby ruby-dev \
+  && apt-get install -y curl libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python-pip \
   && apt-get build-dep -y r-base
 
 RUN pip install awscli
 
-# Pin fpm to avoid git dependency in 1.12.0
-RUN gem install fpm:1.11.0
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.deb && \
+    apt install -y ./nfpm_amd64.deb && \
+    rm nfpm_amd64.deb
 
 RUN chmod 0777 /opt
 

--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -6,13 +6,14 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y libblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip ruby ruby-dev \
+  && apt-get install -y curl libblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli
 
-# Pin fpm to avoid git dependency in 1.12.0
-RUN gem install fpm:1.11.0
+RUN curl -LO https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.deb && \
+    apt install -y ./nfpm_amd64.deb && \
+    rm nfpm_amd64.deb
 
 RUN chmod 0777 /opt
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -157,7 +157,7 @@ EOF
 }
 
 # check for packager script
-## If it exists this build is ready for packaging with fpm, so run the script
+## If it exists this build is ready for packaging with nFPM, so run the script
 ## else do nothing
 package_r() {
   if [[ -f /package.sh ]]; then

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/centos-7 ]]; then
-  mkdir -p /tmp/output/centos-7
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -17,50 +17,56 @@ ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
 EOF
 
 # create after-remove script to remove internal blas
-cat <<EOF >> /before-remove.sh
+cat <<EOF >> /after-remove.sh
 if [ -d /opt/R/${R_VERSION} ]; then
   rm -r /opt/R/${R_VERSION}
 fi
 EOF
 
-fpm \
-  -s dir \
-  -t rpm \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  --after-install /post-install.sh \
-  --after-remove /before-remove.sh \
-  -p /tmp/output/centos-7/ \
-  -d bzip2-devel \
-  -d gcc \
-  -d gcc-c++ \
-  -d gcc-gfortran \
-  -d libcurl-devel \
-  -d libicu-devel \
-  -d libSM \
-  -d libtiff \
-  -d libXmu \
-  -d libXt \
-  -d make \
-  -d openblas-devel \
-  -d pango \
-  -d ${pcre_lib} \
-  -d tcl \
-  -d tk \
-  -d unzip \
-  -d which \
-  -d xz-devel \
-  -d zip \
-  -d zlib-devel \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: R-${R_VERSION}
+version: 1
+version_schema: none
+release: 1
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPLv2+
+depends:
+- bzip2-devel
+- gcc
+- gcc-c++
+- gcc-gfortran
+- libcurl-devel
+- libicu-devel
+- libSM
+- libtiff
+- libXmu
+- libXt
+- make
+- openblas-devel
+- pango
+- ${pcre_lib}
+- tcl
+- tk
+- unzip
+- which
+- xz-devel
+- zip
+- zlib-devel
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+scripts:
+  postinstall: /post-install.sh
+  postremove: /after-remove.sh
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/centos-7/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p rpm \
+  -t "/tmp/output/${OS_IDENTIFIER}"
 
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm | head -1)

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -1,5 +1,7 @@
-if [[ ! -d /tmp/output/centos-8 ]]; then
-  mkdir -p /tmp/output/centos-8
+#!/bin/bash
+
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -15,50 +17,56 @@ ln -s /usr/lib64/libopenblasp.so.0 /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
 EOF
 
 # create after-remove script to remove internal blas
-cat <<EOF >> /before-remove.sh
+cat <<EOF >> /after-remove.sh
 if [ -d /opt/R/${R_VERSION} ]; then
   rm -r /opt/R/${R_VERSION}
 fi
 EOF
 
-fpm \
-  -s dir \
-  -t rpm \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  --after-install /post-install.sh \
-  --after-remove /before-remove.sh \
-  -p /tmp/output/centos-8/ \
-  -d bzip2-devel \
-  -d gcc \
-  -d gcc-c++ \
-  -d gcc-gfortran \
-  -d libcurl-devel \
-  -d libicu-devel \
-  -d libSM \
-  -d libtiff \
-  -d libXmu \
-  -d libXt \
-  -d make \
-  -d openblas-threads \
-  -d pango \
-  -d ${pcre_lib} \
-  -d tcl \
-  -d tk \
-  -d unzip \
-  -d which \
-  -d xz-devel \
-  -d zip \
-  -d zlib-devel \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: R-${R_VERSION}
+version: 1
+version_schema: none
+release: 1
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPLv2+
+depends:
+- bzip2-devel
+- gcc
+- gcc-c++
+- gcc-gfortran
+- libcurl-devel
+- libicu-devel
+- libSM
+- libtiff
+- libXmu
+- libXt
+- make
+- openblas-threads
+- pango
+- ${pcre_lib}
+- tcl
+- tk
+- unzip
+- which
+- xz-devel
+- zip
+- zlib-devel
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+scripts:
+  postinstall: /post-install.sh
+  postremove: /after-remove.sh
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/centos-8/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p rpm \
+  -t "/tmp/output/${OS_IDENTIFIER}"
 
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm | head -1)

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/debian-10 ]]; then
-  mkdir -p /tmp/output/debian-10
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -10,50 +10,59 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='libpcre3-dev'
 fi
 
-fpm \
-  -s dir \
-  -t deb \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  -p /tmp/output/debian-10/ \
-  -d ca-certificates \
-  -d g++ \
-  -d gcc \
-  -d gfortran \
-  -d libbz2-dev \
-  -d libc6 \
-  -d libcairo2 \
-  -d libcurl4-openssl-dev \
-  -d libglib2.0-0 \
-  -d libgomp1 \
-  -d libicu-dev \
-  -d liblzma-dev \
-  -d libopenblas-dev \
-  -d libpango-1.0-0 \
-  -d libpangocairo-1.0-0 \
-  -d libpaper-utils \
-  -d ${pcre_lib} \
-  -d libpng16-16 \
-  -d libreadline7 \
-  -d libtcl8.6 \
-  -d libtiff5 \
-  -d libtk8.6 \
-  -d libx11-6 \
-  -d libxt6 \
-  -d make \
-  -d ucf \
-  -d unzip \
-  -d zip \
-  -d zlib1g-dev \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: r-${R_VERSION}
+version: 1
+version_schema: none
+section: gnu-r
+priority: optional
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPL-2
+deb:
+  fields:
+    Bugs: https://github.com/rstudio/r-builds/issues
+depends:
+- ca-certificates
+- g++
+- gcc
+- gfortran
+- libbz2-dev
+- libc6
+- libcairo2
+- libcurl4-openssl-dev
+- libglib2.0-0
+- libgomp1
+- libicu-dev
+- liblzma-dev
+- libopenblas-dev
+- libpango-1.0-0
+- libpangocairo-1.0-0
+- libpaper-utils
+- ${pcre_lib}
+- libpng16-16
+- libreadline7
+- libtcl8.6
+- libtiff5
+- libtk8.6
+- libx11-6
+- libxt6
+- make
+- ucf
+- unzip
+- zip
+- zlib1g-dev
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/debian-10/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p deb \
+  -t "/tmp/output/${OS_IDENTIFIER}"
 
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/r-${R_VERSION}*.deb | head -1)

--- a/builder/package.opensuse-153
+++ b/builder/package.opensuse-153
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/opensuse-153 ]]; then
-  mkdir -p /tmp/output/opensuse-153
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -17,58 +17,65 @@ ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
 EOF
 
 # create after-remove script to remove internal blas
-cat <<EOF >> /before-remove.sh
+cat <<EOF >> /after-remove.sh
 if [ -d /opt/R/${R_VERSION} ]; then
   rm -r /opt/R/${R_VERSION}
 fi
 EOF
 
-fpm \
-  -s dir \
-  -t rpm \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  --after-install /post-install.sh \
-  --after-remove /before-remove.sh \
-  -p /tmp/output/opensuse-153/ \
-  -d fontconfig \
-  -d gcc \
-  -d gcc-c++ \
-  -d gcc-fortran \
-  -d glibc-locale \
-  -d gzip \
-  -d icu.691-devel \
-  -d libbz2-devel \
-  -d libcairo2 \
-  -d libcurl-devel \
-  -d libfreetype6 \
-  -d libgomp1 \
-  -d libjpeg62 \
-  -d libpango-1_0-0 \
-  -d libreadline7 \
-  -d libtiff5 \
-  -d make \
-  -d openblas-devel \
-  -d ${pcre_lib} \
-  -d tar \
-  -d tcl \
-  -d tk \
-  -d unzip \
-  -d which \
-  -d xorg-x11 \
-  -d xorg-x11-fonts-100dpi \
-  -d xorg-x11-fonts-75dpi \
-  -d xz-devel \
-  -d zip \
-  -d zlib-devel \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: R-${R_VERSION}
+version: 1
+version_schema: none
+release: 1
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPLv2+
+depends:
+- fontconfig
+- gcc
+- gcc-c++
+- gcc-fortran
+- glibc-locale
+- gzip
+- icu.691-devel
+- libbz2-devel
+- libcairo2
+- libcurl-devel
+- libfreetype6
+- libgomp1
+- libjpeg62
+- libpango-1_0-0
+- libreadline7
+- libtiff5
+- make
+- openblas-devel
+- ${pcre_lib}
+- tar
+- tcl
+- tk
+- unzip
+- which
+- xorg-x11
+- xorg-x11-fonts-100dpi
+- xorg-x11-fonts-75dpi
+- xz-devel
+- zip
+- zlib-devel
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+scripts:
+  postinstall: /post-install.sh
+  postremove: /after-remove.sh
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/opensuse-153/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p rpm \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm | head -1)

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/ubuntu-1804 ]]; then
-  mkdir -p /tmp/output/ubuntu-1804
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -10,50 +10,59 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='libpcre3-dev'
 fi
 
-fpm \
-  -s dir \
-  -t deb \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  -p /tmp/output/ubuntu-1804/ \
-  -d g++ \
-  -d gcc \
-  -d gfortran \
-  -d libbz2-dev \
-  -d libc6 \
-  -d libcairo2 \
-  -d libcurl4 \
-  -d libglib2.0-0 \
-  -d libgomp1 \
-  -d libicu-dev \
-  -d libjpeg8 \
-  -d liblzma-dev \
-  -d libopenblas-dev \
-  -d libpango-1.0-0 \
-  -d libpangocairo-1.0-0 \
-  -d libpaper-utils \
-  -d ${pcre_lib} \
-  -d libpng16-16 \
-  -d libreadline7 \
-  -d libtcl8.6 \
-  -d libtiff5 \
-  -d libtk8.6 \
-  -d libx11-6 \
-  -d libxt6 \
-  -d make \
-  -d ucf \
-  -d unzip \
-  -d zip \
-  -d zlib1g-dev \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: r-${R_VERSION}
+version: 1
+version_schema: none
+section: universe/math
+priority: optional
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPL-2
+deb:
+  fields:
+    Bugs: https://github.com/rstudio/r-builds/issues
+depends:
+- g++
+- gcc
+- gfortran
+- libbz2-dev
+- libc6
+- libcairo2
+- libcurl4
+- libglib2.0-0
+- libgomp1
+- libicu-dev
+- libjpeg8
+- liblzma-dev
+- libopenblas-dev
+- libpango-1.0-0
+- libpangocairo-1.0-0
+- libpaper-utils
+- ${pcre_lib}
+- libpng16-16
+- libreadline7
+- libtcl8.6
+- libtiff5
+- libtk8.6
+- libx11-6
+- libxt6
+- make
+- ucf
+- unzip
+- zip
+- zlib1g-dev
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/ubuntu-1804/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p deb \
+  -t "/tmp/output/${OS_IDENTIFIER}"
 
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/r-${R_VERSION}*.deb | head -1)

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ ! -d /tmp/output/ubuntu-2004 ]]; then
-  mkdir -p /tmp/output/ubuntu-2004
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
 # R 3.x requires PCRE1
@@ -10,50 +10,60 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='libpcre3-dev'
 fi
 
-fpm \
-  -s dir \
-  -t deb \
-  -v 1 \
-  -n R-${R_VERSION} \
-  --vendor "RStudio, PBC" \
-  --deb-priority "optional" \
-  --deb-field 'Bugs: https://github.com/rstudio/r-builds/issues' \
-  --url "http://www.r-project.org/" \
-  --description "GNU R statistical computation and graphics system" \
-  --maintainer "RStudio, PBC https://github.com/rstudio/r-builds" \
-  --license "GPL-2" \
-  -p /tmp/output/ubuntu-2004/ \
-  -d g++ \
-  -d gcc \
-  -d gfortran \
-  -d libbz2-dev \
-  -d libblas-dev \
-  -d libc6 \
-  -d libcairo2 \
-  -d libcurl4 \
-  -d libglib2.0-0 \
-  -d libgomp1 \
-  -d libicu-dev \
-  -d libjpeg8 \
-  -d liblapack-dev \
-  -d liblzma-dev \
-  -d libpango-1.0-0 \
-  -d libpangocairo-1.0-0 \
-  -d libpaper-utils \
-  -d ${pcre_lib} \
-  -d libpng16-16 \
-  -d libreadline8 \
-  -d libtcl8.6 \
-  -d libtiff5 \
-  -d libtk8.6 \
-  -d libx11-6 \
-  -d libxt6 \
-  -d make \
-  -d ucf \
-  -d unzip \
-  -d zip \
-  -d zlib1g-dev \
-  /opt/R/${R_VERSION}
+cat <<EOF > /tmp/nfpm.yml
+name: r-${R_VERSION}
+version: 1
+version_schema: none
+section: universe/math
+priority: optional
+maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: RStudio, PBC
+homepage: https://www.r-project.org
+license: GPL-2
+deb:
+  fields:
+    Bugs: https://github.com/rstudio/r-builds/issues
+depends:
+- g++
+- gcc
+- gfortran
+- libbz2-dev
+- libblas-dev
+- libc6
+- libcairo2
+- libcurl4
+- libglib2.0-0
+- libgomp1
+- libicu-dev
+- libjpeg8
+- liblapack-dev
+- liblzma-dev
+- libpango-1.0-0
+- libpangocairo-1.0-0
+- libpaper-utils
+- ${pcre_lib}
+- libpng16-16
+- libreadline8
+- libtcl8.6
+- libtiff5
+- libtk8.6
+- libx11-6
+- libxt6
+- make
+- ucf
+- unzip
+- zip
+- zlib1g-dev
+contents:
+- src: /opt/R/${R_VERSION}
+  dst: /opt/R/${R_VERSION}
+EOF
 
-shopt -s extglob
-export PKG_FILE=$(ls /tmp/output/ubuntu-2004/[rR]-${R_VERSION}*.@(deb|rpm) | head -1)
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p deb \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/r-${R_VERSION}*.deb | head -1)


### PR DESCRIPTION
A follow-up of https://github.com/rstudio/r-builds/pull/136: replace fpm with nFPM for all other platforms. These are the same changes from https://github.com/rstudio/r-builds/pull/136 applied to the remaining platforms, so see that PR for more details. So far, the packages built using nFPM for RHEL 9 and SUSE 15.4 seem to be working just fine.