### PR TITLE
Update instance types; trigger infrastructure update for the compute environments

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -114,9 +114,6 @@ rBuildsBatchComputeEnvironment:
         - m6i
         - m5
         - m5a
-        - r6i
-        - r5
-        - r5a
         - c6i
         - c5
         - c5a


### PR DESCRIPTION
The changes from https://github.com/rstudio/r-builds/pull/140 didn't take effect because `LaunchTemplateData` changes apparently don't trigger an infrastructure update of the Batch compute environment: https://docs.aws.amazon.com/batch/latest/userguide/updating-compute-environments.html.

The device name change from https://github.com/rstudio/r-builds/pull/139 also didn't take effect on staging. It was only updated for production because I deployed both that and the launch template version change at the same time, I think.

This attempts to trigger an infrastructure update by changing the instance types. I wasn't totally sure what to change, but removing the memory optimized r5/r6 instances seems to make sense because there's a lot of unused memory on those when we ask for 4 vCPUs and 4 GB memory per job. Most instance types I've seen used recently have been from the c5/c6 family.