### PR TITLE
Limit instance sizes to mitigate Docker timeout failures

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -106,12 +106,22 @@ rBuildsBatchComputeEnvironment:
       InstanceRole:
         "Fn::GetAtt": [ rBuildsIamInstanceProfile, Arn ]
       InstanceTypes:
-        - m6i
-        - m5
-        - m5a
-        - c6i
-        - c5
-        - c5a
+        - m6i.xlarge
+        - m6i.2xlarge
+        - m5.xlarge
+        - m5.2xlarge
+        - m5a.xlarge
+        - m5a.2xlarge
+        - r5.xlarge
+        - r5.2xlarge
+        - r5a.xlarge
+        - r5a.2xlarge
+        - c6i.xlarge
+        - c6i.2xlarge
+        - c5.xlarge
+        - c5.2xlarge
+        - c5a.xlarge
+        - c5a.2xlarge
       Ec2KeyPair: ${self:custom.ec2KeyPair}
       Tags: ${self:provider.stackTags}
       MinvCpus: 0


### PR DESCRIPTION
More follow-up for #140, #142, #143,

Since there's a problem with configuring `UserData`, and the `ECS_CONTAINER_CREATE_TIMEOUT` setting is kind of hard to maintain, being partially undocumented and unable to trigger an infrastructure update by itself, try limiting instance sizes instead:

* Limit InstanceTypes to specific sizes (xlarge-2xlarge for 4-8 vCPUs) so only 1-2 jobs can run at a time, instead of potentially 10+. Reduce the number of Docker images being pulled at one time to mitigate the 4m Docker image pull timeout failures from ECS.
* Restore the r5/r5a instance families for consistency with other serverless projects, and because their removal was arbitrary in the first place.