### PR TITLE
Mitigate EC2 Spot instance interruptions

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -102,22 +102,15 @@ rBuildsBatchComputeEnvironment:
       SecurityGroupIds: ${self:custom.securityGroupIds}
       Subnets: ${self:custom.subnets}
       Type: SPOT
-      BidPercentage: 85
+      BidPercentage: 100
       InstanceRole:
         "Fn::GetAtt": [ rBuildsIamInstanceProfile, Arn ]
       InstanceTypes:
-        - m6i.xlarge
-        - m6i.2xlarge
-        - m5.xlarge
-        - m5.2xlarge
-        - m5a.xlarge
-        - m5a.2xlarge
         - r5.xlarge
         - r5.2xlarge
         - r5a.xlarge
         - r5a.2xlarge
         - c6i.xlarge
-        - c6i.2xlarge
         - c5.xlarge
         - c5.2xlarge
         - c5a.xlarge


### PR DESCRIPTION
Some jobs are failing because EC2 is terminating Spot instances from being outbid (BidEvictedEvents in CloudTrail).

* Increase bid percentage to 100%
* Remove highly interrupted instance types, leaving only instance types with <5% frequency of interruption. https://aws.amazon.com/ec2/spot/instance-advisor/

These are the interruption frequencies of the instance types we had before:

```yaml
        - m6i.xlarge  # 5-10
        - m6i.2xlarge # 10-15
        - m5.xlarge   # >20
        - m5.2xlarge  # >20 
        - m5a.xlarge  # 5-10
        - m5a.2xlarge # >20
        - r5.xlarge   # <5
        - r5.2xlarge  # <5
        - r5a.xlarge  # <5
        - r5a.2xlarge # <5
        - c6i.xlarge  # <5
        - c6i.2xlarge # 5-10
        - c5.xlarge   # <5
        - c5.2xlarge  # <5
        - c5a.xlarge  # <5
        - c5a.2xlarge # <5
```
