### PR TITLE
Fix missing PCRE2 dependency in R 3.x builds for RHEL 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ docker-build-$(platform):
 	@cd builder && docker-compose build $(platform)
 
 build-r-$(platform):
-	@cd builder && R_VERSION=$(R_VERSION) docker-compose up $(platform)
+	@cd builder && R_VERSION=$(R_VERSION) docker-compose run --rm $(platform)
 
 test-r-$(platform):
-	@cd test && R_VERSION=$(R_VERSION) docker-compose up $(platform)
+	@cd test && R_VERSION=$(R_VERSION) docker-compose run --rm $(platform)
 
 bash-$(platform):
 	docker run -it --rm --entrypoint /bin/bash -v $(CURDIR):/r-builds r-builds:$(platform)

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -97,7 +97,7 @@ compile_r() {
   #
   # The INCLUDE_PCRE2_IN_R_3 environment variable can be set to include PCRE2
   # in R 3.x builds, for distributions where PCRE2 is always required.
-  # In Debian 11/Ubuntu 22, Pango now depends on PCRE2, so R 3.x will not be compiled with
+  # In Debian 11/Ubuntu 22/RHEL 9, Pango now depends on PCRE2, so R 3.x will not be compiled with
   # Pango support if the PCRE2 pkg-config file is missing.
   if [[ "${1}" =~ ^3 ]] && pkg-config --exists libpcre2-8 && [ -z "$INCLUDE_PCRE2_IN_R_3" ]; then
     mkdir -p /tmp/pcre2

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -4,10 +4,11 @@ if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
   mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
-# R 3.x requires PCRE1
-pcre_lib='pcre2-devel'
+# R 3.x requires PCRE1. On RHEL 9, R 3.x also requires PCRE2 for Pango support.
+pcre_libs='- pcre2-devel'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='pcre-devel'
+  pcre_libs='- pcre2-devel
+- pcre-devel'
 fi
 
 # Create post-install script required for OpenBLAS.
@@ -64,7 +65,7 @@ depends:
 - make
 - openblas-devel
 - pango
-- ${pcre_lib}
+${pcre_libs}
 - tcl
 - tk
 - unzip


### PR DESCRIPTION
In https://github.com/rstudio/r-builds/pull/133, I missed an update to the PCRE lib dependencies for RHEL 9. The R 3.5/3.6 builds require both PCRE1 and PCRE2, but only PCRE1 was a dependency, so the tests failed when installing the test package. 

But unfortunately, the exit codes from the tests weren't being propagated correctly, so CI wasn't catching this earlier. (I only realized this while adding the R Docker images in https://github.com/rstudio/r-docker/pull/85, which I also forgot to add CI support for, oops)
```sh
$ R_VERSION=3.5.3 make test-r-rhel-9
...
rhel-9_1        | * installing *source* package 'testpkg' ...
rhel-9_1        | ** libs
rhel-9_1        | gcc -I"/opt/R/3.5.3/lib/R/include" -DNDEBUG   -I/usr/local/include   -fpic  -g -O2 -fcommon  -c add.c -o add.o
rhel-9_1        | gcc -I"/opt/R/3.5.3/lib/R/include" -DNDEBUG   -I/usr/local/include   -fpic  -g -O2 -fcommon  -c init.c -o init.o
rhel-9_1        | f95   -fpic  -g -O2 -fallow-argument-mismatch  -c square.f -o square.o
rhel-9_1        | g++ -std=gnu++11 -I"/opt/R/3.5.3/lib/R/include" -DNDEBUG   -I/usr/local/include   -fpic  -g -O2 -c subtract.cpp -o subtract.o
rhel-9_1        | g++ -std=gnu++11 -shared -L/opt/R/3.5.3/lib/R/lib -L/usr/local/lib -o testpkg.so add.o init.o square.o subtract.o -Wl,--export-dynamic -fopenmp -L/usr/local/lib -L/opt/R/3.5.3/lib/R/lib -lR -lpcre2-8 -lpcre -llzma -lbz2 -lz -lrt -ldl -lm -licuuc -licui18n -L/opt/R/3.5.3/lib/R/lib -lRlapack -L/opt/R/3.5.3/lib/R/lib -lRblas -fopenmp -lgfortran -lm -lquadmath -L/opt/R/3.5.3/lib/R/lib -lR
rhel-9_1        | /usr/bin/ld: cannot find -lpcre2-8
rhel-9_1        | collect2: error: ld returned 1 exit status
rhel-9_1        | make: *** [/opt/R/3.5.3/lib/R/share/make/shlib.mk:6: testpkg.so] Error 1
rhel-9_1        | ERROR: compilation failed for package 'testpkg'
rhel-9_1        | * removing '/tmp/RtmpiCj8f5/testpkg'
rhel-9_1        | Warning message:
rhel-9_1        | In install.packages(file.path(curr_dir, "testpkg"), repos = NULL,  :
rhel-9_1        |   installation of package '/r-builds/test/testpkg' had non-zero exit status
rhel-9_1        | Error in library(testpkg) : there is no package called 'testpkg'
rhel-9_1        | Calls: source -> withVisible -> eval -> eval -> library
rhel-9_1        | Execution halted
test_rhel-9_1 exited with code 1

$ echo $?
0
```

- Fix exit code propagation by using `docker-compose run` instead of `docker-compose up`, which exits with a `0` even if the container exits with a non-zero exit code. `docker-compose up` has a `--abort-on-container-exit` flag to propagate the exit code I think, but `docker-compose run` makes more sense anyway, and can automatically clean up containers as well.

    With `docker-compose run`, a non-zero exit code is returned when the container errors out:
```sh
$ R_VERSION=3.5.3 make test-r-rhel-9
...
/usr/bin/ld: cannot find -lpcre2-8
collect2: error: ld returned 1 exit status
make: *** [/opt/R/3.5.3/lib/R/share/make/shlib.mk:6: testpkg.so] Error 1
ERROR: compilation failed for package 'testpkg'
* removing '/tmp/Rtmpp03xp3/testpkg'
Warning message:
In install.packages(file.path(curr_dir, "testpkg"), repos = NULL,  :
  installation of package '/r-builds/test/testpkg' had non-zero exit status
Error in library(testpkg) : there is no package called 'testpkg'
Calls: source -> withVisible -> eval -> eval -> library
Execution halted
ERROR: 1
make: *** [Makefile:58: test-r-rhel-9] Error 1

$ echo $?
2
```
- Fix the missing PCRE2 dependency for R 3.5/3.6 RHEL 9 builds