### PR TITLE
Don't install prerelease R versions by default in quickinstall script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,20 +32,17 @@ CDN_URL='https://cdn.rstudio.com/r'
 # The URL for listing available R versions
 VERSIONS_URL="${CDN_URL}/versions.json"
 
-R_VERSIONS=$(curl -s ${VERSIONS_URL} | \
+R_VERSIONS=$(curl -s ${VERSIONS_URL} |
   # Matches the JSON line that contains the r versions
-  grep r_versions | \
+  grep r_versions |
   # Gets the value of the `r_version` property (e.g., "[ 3.0.0, 3.0.3, ... ]")
-  cut -f2 -d ":" | \
+  cut -f2 -d ":" |
   # Removes the opening and closing brackets of the array
-  cut -f2 -d "[" | cut -f1 -d "]" | \
+  cut -f2 -d "[" | cut -f1 -d "]" |
   # Removes the quotes and commas from the values
-  sed -e 's/\"//g' | sed -e 's/\,//g' | \
-  # Appends a placeholder to the end of the string. Without an extra element at the
-  # end, the last version will be missing after we reverse the order.
-  { IFS= read -r vers; printf '%s placeholder' "$vers"; } | \
-  # Reverses the order of the list
-  ( while read -d ' ' f;do g="$f${g+ }$g" ;done;echo "$g" ))
+  sed -e 's/\"//g' | sed -e 's/\,//g' |
+  # Convert to newlines and sort in descending order, with devel/next at the bottom
+  tr ' ' '\n' | sort --numeric-sort --reverse)
 
 # Returns the OS
 detect_os () {


### PR DESCRIPTION
@jonyoder noticed the quickinstall script was installing R devel as the default "latest" R version, which is probably not what most users would expect. This tweaks the R version sorting so that prerelease `devel`/`next` versions are sorted to the bottom but still available to install.

It also simplifies the sorting a bit, switching to the built-in `sort` command to do the sorting.

Old versions list:
```sh
 $ ./install.sh 
Available Versions
  devel
  next
  4.2.1
  4.2.0
  4.1.3
  4.1.2
  4.1.1
  4.1.0
  4.0.5
  4.0.4
  4.0.3
  4.0.2
  4.0.1
  4.0.0
  3.6.3
  3.6.2
  3.6.1
  3.6.0
  3.5.3
  3.5.2
  3.5.1
  3.5.0
  3.4.4
  3.4.3
  3.4.2
  3.4.1
  3.4.0
  3.3.3
  3.3.2
  3.3.1
  3.3.0
  3.2.5
  3.2.4
  3.2.3
  3.2.2
  3.2.1
  3.2.0
  3.1.3
  3.1.2
  3.1.1
  3.1.0
  3.0.3
  3.0.2
  3.0.1
  3.0.0
Enter version to install: (<ENTER> for latest)
```

New versions list:
```sh
$ ./install.sh 
Available Versions
  4.2.1
  4.2.0
  4.1.3
  4.1.2
  4.1.1
  4.1.0
  4.0.5
  4.0.4
  4.0.3
  4.0.2
  4.0.1
  4.0.0
  3.6.3
  3.6.2
  3.6.1
  3.6.0
  3.5.3
  3.5.2
  3.5.1
  3.5.0
  3.4.4
  3.4.3
  3.4.2
  3.4.1
  3.4.0
  3.3.3
  3.3.2
  3.3.1
  3.3.0
  3.2.5
  3.2.4
  3.2.3
  3.2.2
  3.2.1
  3.2.0
  3.1.3
  3.1.2
  3.1.1
  3.1.0
  3.0.3
  3.0.2
  3.0.1
  3.0.0
  next
  devel
Enter version to install: (<ENTER> for latest)
```