### PR TITLE
Update RStudio references to Posit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     stage('push images') {
       agent { label 'docker-4x' }
       when {
-        branch 'master'
+        branch 'main'
       }
       steps {
         sh 'make docker-push'
@@ -25,7 +25,7 @@ pipeline {
     stage('deploy') {
       agent none
       when {
-        branch 'master'
+        branch 'main'
       }
       steps {
         build(job: 'r-builds/deploy-r-builds', wait: true,

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # r-builds
 
 This repository orchestrates tools to produce R binaries. The binaries are available as a
-community resource, **they are not professionally supported by RStudio**. 
+community resource, **they are not professionally supported by Posit**. 
 The R language is open source, please see the official documentation at https://www.r-project.org/.
 
 These binaries are not a replacement to existing binary distributions for R.
 The binaries were built with the following considerations:
 - They use a minimal set of [build and runtime dependencies](builder).
-- They are designed to be used side-by-side, e.g., on [RStudio Server Pro](https://docs.rstudio.com/ide/server-pro/r-versions.html#using-multiple-versions-of-r-concurrently).
+- They are designed to be used side-by-side, e.g., on [Posit Workbench](https://docs.posit.co/ide/server-pro/r_versions/using_multiple_versions_of_r.html).
 - They give users a consistent option for accessing R across different Linux distributions.
 
 These binaries have been extensively tested, and are used in production everyday
-on [RStudio Cloud](https://rstudio.cloud) and
+on [Posit Cloud](https://posit.cloud) and
 [shinyapps.io](https://shinyapps.io). Please open an issue to report a specific
-bug, or ask questions on [RStudio Community](https://community.rstudio.com).
+bug, or ask questions on [Posit Community](https://community.rstudio.com).
 
 ## Supported Platforms
 
@@ -27,7 +27,7 @@ R binaries are built for the following Linux operating systems:
 - SUSE Linux Enterprise 15 SP3, 15 SP4
 
 Operating systems are supported until their vendor end-of-support dates, which
-can be found on the [RStudio Platform Support](https://www.rstudio.com/about/platform-support/)
+can be found on the [Posit Platform Support](https://posit.co/about/platform-support/)
 page. When an operating system has reached its end of support, builds for it
 will be discontinued, but existing binaries will continue to be available.
 
@@ -46,7 +46,7 @@ bash -c "$(curl -L https://rstd.io/r-install)"
 ### Specify R version
 
 Define the version of R that you want to install. Available versions
-of R can be found here: https://cdn.rstudio.com/r/versions.json
+of R can be found here: https://cdn.posit.co/r/versions.json
 ```bash
 R_VERSION=4.1.3
 ```
@@ -57,19 +57,19 @@ R_VERSION=4.1.3
 Download the deb package:
 ```bash
 # Ubuntu 18.04
-wget https://cdn.rstudio.com/r/ubuntu-1804/pkgs/r-${R_VERSION}_1_amd64.deb
+wget https://cdn.posit.co/r/ubuntu-1804/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Ubuntu 20.04
-wget https://cdn.rstudio.com/r/ubuntu-2004/pkgs/r-${R_VERSION}_1_amd64.deb
+wget https://cdn.posit.co/r/ubuntu-2004/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Ubuntu 22.04
-wget https://cdn.rstudio.com/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_amd64.deb
+wget https://cdn.posit.co/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Debian 10
-wget https://cdn.rstudio.com/r/debian-10/pkgs/r-${R_VERSION}_1_amd64.deb
+wget https://cdn.posit.co/r/debian-10/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Debian 11
-wget https://cdn.rstudio.com/r/debian-11/pkgs/r-${R_VERSION}_1_amd64.deb
+wget https://cdn.posit.co/r/debian-11/pkgs/r-${R_VERSION}_1_amd64.deb
 ```
 
 Then install the package:
@@ -119,13 +119,13 @@ sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noa
 Download the rpm package:
 ```bash
 # CentOS / RHEL 7
-wget https://cdn.rstudio.com/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+wget https://cdn.posit.co/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
 # RHEL 8 / Rocky Linux 8 / AlmaLinux 8
-wget https://cdn.rstudio.com/r/centos-8/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+wget https://cdn.posit.co/r/centos-8/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
 # RHEL 9 / Rocky Linux 9 / AlmaLinux 9
-wget https://cdn.rstudio.com/r/rhel-9/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+wget https://cdn.posit.co/r/rhel-9/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:
@@ -138,10 +138,10 @@ sudo yum install R-${R_VERSION}-1-1.x86_64.rpm
 Download the rpm package:
 ```bash
 # openSUSE 15.3 / SLES 15 SP3
-wget https://cdn.rstudio.com/r/opensuse-153/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+wget https://cdn.posit.co/r/opensuse-153/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
 # openSUSE 15.4 / SLES 15 SP4
-wget https://cdn.rstudio.com/r/opensuse-154/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+wget https://cdn.posit.co/r/opensuse-154/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:

--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ R_VERSION=4.1.3
 Download the deb package:
 ```bash
 # Ubuntu 18.04
-wget https://cdn.posit.co/r/ubuntu-1804/pkgs/r-${R_VERSION}_1_amd64.deb
+curl -O https://cdn.posit.co/r/ubuntu-1804/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Ubuntu 20.04
-wget https://cdn.posit.co/r/ubuntu-2004/pkgs/r-${R_VERSION}_1_amd64.deb
+curl -O https://cdn.posit.co/r/ubuntu-2004/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Ubuntu 22.04
-wget https://cdn.posit.co/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_amd64.deb
+curl -O https://cdn.posit.co/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Debian 10
-wget https://cdn.posit.co/r/debian-10/pkgs/r-${R_VERSION}_1_amd64.deb
+curl -O https://cdn.posit.co/r/debian-10/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Debian 11
-wget https://cdn.posit.co/r/debian-11/pkgs/r-${R_VERSION}_1_amd64.deb
+curl -O https://cdn.posit.co/r/debian-11/pkgs/r-${R_VERSION}_1_amd64.deb
 ```
 
 Then install the package:
@@ -119,13 +119,13 @@ sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noa
 Download the rpm package:
 ```bash
 # CentOS / RHEL 7
-wget https://cdn.posit.co/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+curl -O https://cdn.posit.co/r/centos-7/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
 # RHEL 8 / Rocky Linux 8 / AlmaLinux 8
-wget https://cdn.posit.co/r/centos-8/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+curl -O https://cdn.posit.co/r/centos-8/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
 # RHEL 9 / Rocky Linux 9 / AlmaLinux 9
-wget https://cdn.posit.co/r/rhel-9/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+curl -O https://cdn.posit.co/r/rhel-9/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:
@@ -138,10 +138,10 @@ sudo yum install R-${R_VERSION}-1-1.x86_64.rpm
 Download the rpm package:
 ```bash
 # openSUSE 15.3 / SLES 15 SP3
-wget https://cdn.posit.co/r/opensuse-153/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+curl -O https://cdn.posit.co/r/opensuse-153/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 
 # openSUSE 15.4 / SLES 15 SP4
-wget https://cdn.posit.co/r/opensuse-154/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+curl -O https://cdn.posit.co/r/opensuse-154/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:

--- a/builder/Dockerfile.opensuse-154
+++ b/builder/Dockerfile.opensuse-154
@@ -92,7 +92,7 @@ ENV CONFIGURE_OPTIONS="\
 # but the JDK path is chosen by default. We change this to the JRE path to
 # support users who only want to install the JRE (non-devel) package.
 # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Java-support
-# https://solutions.rstudio.com/r/using-rjava/
+# https://solutions.posit.co/envs-pkgs/using-rjava/
 ENV JAVA_HOME=/usr/lib64/jvm/jre-11-openjdk
 
 COPY package.opensuse-154 /package.sh

--- a/builder/Dockerfile.rhel-9
+++ b/builder/Dockerfile.rhel-9
@@ -79,7 +79,7 @@ ENV R_RD4PDF="times,hyper"
 # requires users to run `R CMD javareconf` even on minor/patch upgrades. Use the
 # major version symlink to avoid this.
 # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Java-support
-# https://solutions.rstudio.com/r/using-rjava/
+# https://solutions.posit.co/envs-pkgs/using-rjava/
 ENV JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
 
 # R 3.x requires PCRE2 for Pango support on RHEL 9

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -28,10 +28,10 @@ name: R-${R_VERSION}
 version: 1
 version_schema: none
 release: 1
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPLv2+
 depends:

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -28,10 +28,10 @@ name: R-${R_VERSION}
 version: 1
 version_schema: none
 release: 1
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPLv2+
 depends:

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -16,10 +16,10 @@ version: 1
 version_schema: none
 section: gnu-r
 priority: optional
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPL-2
 deb:

--- a/builder/package.debian-11
+++ b/builder/package.debian-11
@@ -17,10 +17,10 @@ version: 1
 version_schema: none
 section: gnu-r
 priority: optional
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPL-2
 deb:

--- a/builder/package.opensuse-153
+++ b/builder/package.opensuse-153
@@ -28,10 +28,10 @@ name: R-${R_VERSION}
 version: 1
 version_schema: none
 release: 1
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPLv2+
 depends:

--- a/builder/package.opensuse-154
+++ b/builder/package.opensuse-154
@@ -44,10 +44,10 @@ name: R-${R_VERSION}
 version: 1
 version_schema: none
 release: 1
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPLv2+
 depends:

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -45,10 +45,10 @@ name: R-${R_VERSION}
 version: 1
 version_schema: none
 release: 1
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPLv2+
 depends:

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -16,10 +16,10 @@ version: 1
 version_schema: none
 section: universe/math
 priority: optional
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPL-2
 deb:

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -16,10 +16,10 @@ version: 1
 version_schema: none
 section: universe/math
 priority: optional
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPL-2
 deb:

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -17,10 +17,10 @@ version: 1
 version_schema: none
 section: universe/math
 priority: optional
-maintainer: RStudio, PBC <https://github.com/rstudio/r-builds>
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
 description: |
   GNU R statistical computation and graphics system
-vendor: RStudio, PBC
+vendor: Posit Software, PBC
 homepage: https://www.r-project.org
 license: GPL-2
 deb:

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ if [[ $(id -u) != "0" ]]; then
 fi
 
 # The root of the S3 URL for downloads
-CDN_URL='https://cdn.rstudio.com/r'
+CDN_URL='https://cdn.posit.co/r'
 
 # The URL for listing available R versions
 VERSIONS_URL="${CDN_URL}/versions.json"

--- a/test/get_r_versions.py
+++ b/test/get_r_versions.py
@@ -3,7 +3,7 @@ import json
 import re
 import urllib.request
 
-VERSIONS_URL = 'https://cdn.rstudio.com/r/versions.json'
+VERSIONS_URL = 'https://cdn.posit.co/r/versions.json'
 
 # Minimum R version for "all"
 MIN_ALL_VERSION = '3.1.0'


### PR DESCRIPTION
- Update RStudio references to Posit
- Update default branch to `main`. Closes https://github.com/rstudio/r-builds/issues/109
- Use curl over wget in docs