### PR TITLE
Support custom installation paths for R

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,51 @@ This repository orchestrates builds using a variety of tools. The
 instructions below outline the components in the stack and describe how to add a
 new platform or inspect an existing platform.
 
+## Building from source
+
+To build the R binaries from source, you will need to have [Git](https://git-scm.com/),
+[Docker](https://docs.docker.com/get-docker/), and `make` installed.
+
+First, clone the Git repository locally and navigate to it.
+
+```bash
+git clone https://github.com/rstudio/R-builds
+cd R-builds
+```
+
+Then, run the `build-r-$PLATFORM` Make target with the `R_VERSION` environment variable
+set to your desired R version, where `$PLATFORM` is one of the supported platform
+identifiers, such as `ubuntu-2204` or `rhel-9`.
+
+```bash
+export PLATFORM=ubuntu-2204
+export R_VERSION=4.1.3
+
+make build-r-$PLATFORM
+```
+
+The built DEB or RPM package will be available in the `builder/integration/tmp/$PLATFORM`
+directory.
+
+```bash
+$ ls builder/integration/tmp/$PLATFORM
+r-4.1.3_1_amd64.deb
+```
+
+### Custom installation path
+
+R is installed to `/opt/R/${R_VERSION}` by default. If you want to customize the
+installation path, set the optional `R_INSTALL_PATH` environment variable to a
+custom location such as `/opt/custom/R-4.1.3`.
+
+```bash
+export PLATFORM=rhel-9
+export R_VERSION=4.1.3
+export R_INSTALL_PATH=/opt/custom/R-4.1.3
+
+make build-r-$PLATFORM
+```
+
 ## Adding a new platform.
 
 ### Dockerfile

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -14,6 +15,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -25,6 +27,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -36,6 +39,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -47,6 +51,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -58,6 +63,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -69,6 +75,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -80,6 +87,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -91,6 +99,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -102,6 +111,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
       - LOCAL_STORE=/tmp/output
     build:
       context: .

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -12,14 +12,14 @@ fi
 
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep 
-ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep 
+ln -s /usr/lib64/libopenblasp.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
 EOF
 
 # create after-remove script to remove internal blas
 cat <<EOF >> /after-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
+if [ -d ${R_INSTALL_PATH} ]; then
+  rm -r ${R_INSTALL_PATH}
 fi
 EOF
 
@@ -57,8 +57,8 @@ depends:
 - zip
 - zlib-devel
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 scripts:
   postinstall: /post-install.sh
   postremove: /after-remove.sh

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -12,14 +12,14 @@ fi
 
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblasp.so.0 /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblasp.so.0 ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
 EOF
 
 # create after-remove script to remove internal blas
 cat <<EOF >> /after-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
+if [ -d ${R_INSTALL_PATH} ]; then
+  rm -r ${R_INSTALL_PATH}
 fi
 EOF
 
@@ -57,8 +57,8 @@ depends:
 - zip
 - zlib-devel
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 scripts:
   postinstall: /post-install.sh
   postremove: /after-remove.sh

--- a/builder/package.debian-10
+++ b/builder/package.debian-10
@@ -56,8 +56,8 @@ depends:
 - zip
 - zlib1g-dev
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 EOF
 
 nfpm package \

--- a/builder/package.debian-11
+++ b/builder/package.debian-11
@@ -57,8 +57,8 @@ ${pcre_libs}
 - zip
 - zlib1g-dev
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 EOF
 
 nfpm package \

--- a/builder/package.opensuse-153
+++ b/builder/package.opensuse-153
@@ -12,14 +12,14 @@ fi
 
 # create post-install script required for openblas
 cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
 EOF
 
 # create after-remove script to remove internal blas
 cat <<EOF >> /after-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
+if [ -d ${R_INSTALL_PATH} ]; then
+  rm -r ${R_INSTALL_PATH}
 fi
 EOF
 
@@ -66,8 +66,8 @@ depends:
 - zip
 - zlib-devel
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 scripts:
   postinstall: /post-install.sh
   postremove: /after-remove.sh

--- a/builder/package.opensuse-154
+++ b/builder/package.opensuse-154
@@ -28,14 +28,14 @@ fi
 #
 # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Shared-BLAS
 cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
 EOF
 
 # Create after-remove script to remove internal BLAS, which won't be cleaned up automatically.
 cat <<EOF >> /after-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
+if [ -d ${R_INSTALL_PATH} ]; then
+  rm -r ${R_INSTALL_PATH}
 fi
 EOF
 
@@ -82,8 +82,8 @@ depends:
 - zip
 - zlib-devel
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 scripts:
   postinstall: /post-install.sh
   postremove: /after-remove.sh

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -29,14 +29,14 @@ fi
 #
 # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Shared-BLAS
 cat <<EOF >> /post-install.sh
-mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblasp.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
 EOF
 
 # Create after-remove script to remove internal BLAS, which won't be cleaned up automatically.
 cat <<EOF >> /after-remove.sh
-if [ -d /opt/R/${R_VERSION} ]; then
-  rm -r /opt/R/${R_VERSION}
+if [ -d ${R_INSTALL_PATH} ]; then
+  rm -r ${R_INSTALL_PATH}
 fi
 EOF
 
@@ -74,8 +74,8 @@ ${pcre_libs}
 - zip
 - zlib-devel
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 scripts:
   postinstall: /post-install.sh
   postremove: /after-remove.sh

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -56,8 +56,8 @@ depends:
 - zip
 - zlib1g-dev
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 EOF
 
 nfpm package \

--- a/builder/package.ubuntu-2004
+++ b/builder/package.ubuntu-2004
@@ -57,8 +57,8 @@ depends:
 - zip
 - zlib1g-dev
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 EOF
 
 nfpm package \

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -57,8 +57,8 @@ ${pcre_libs}
 - zip
 - zlib1g-dev
 contents:
-- src: /opt/R/${R_VERSION}
-  dst: /opt/R/${R_VERSION}
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
 EOF
 
 nfpm package \

--- a/test/test.R
+++ b/test/test.R
@@ -101,3 +101,8 @@ if (getRversion() >= "3.5.0" && getRversion() < "4.0.0") {
 } else if (getRversion() >= "4.0.0") {
   stopifnot(has_pcre2 && !has_pcre1)
 }
+
+# Check that the custom HTTP user agent was configured
+if (!grepl(sprintf("^R/%s", getRversion()), getOption("HTTPUserAgent"))) {
+  stop("unexpected HTTPUserAgent")
+}


### PR DESCRIPTION
- Add an optional `R_INSTALL_PATH` environment variable to allow the R installation path to be changed from the default `/opt/R/${R_VERSION}`
- Start on new user-facing documentation for building R from source locally

These changes are meant to address two types of support issues we get with the precompiled R binaries:
- Some customers want to change the R installation path, but there's no easy way to relocate an R install without sketchy hacks. The only way to change the R install path is to install R from source with a custom `--prefix`.
- The [Install R from Source](https://docs.posit.co/resources/install-r-source/) docs are now outdated and no longer match how we install R here. The install steps for each platform have gotten very complicated, so we'll likely begin pointing users to this repo to install R from source when they need custom configuration like a different install path.