### PR TITLE
Use gcc-8 on Ubuntu 18.04

### DIFF
--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -7,7 +7,8 @@ RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
   && apt-get install -y curl libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python-pip \
-  && apt-get build-dep -y r-base
+  && apt-get build-dep -y r-base \
+  && apt-get install -y gcc-8 g++-8 gfortran-8
 
 RUN pip install awscli
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -120,6 +120,13 @@ compile_r() {
     --with-blas \
     --with-lapack"
 
+  if _version_is_greater_than ${R_VERSION} 4.2.10; then
+      if [[ "${OS_IDENTIFIER}" = "ubuntu-1804" ]]; then
+          default_configure_options="$default_configure_options \
+            CC=gcc-8 CXX=g++-8 FC=gfortran-8"
+      fi
+  fi
+
   CONFIGURE_OPTIONS=${CONFIGURE_OPTIONS:-$default_configure_options}
 
   # set some common environment variables for the configure step

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -124,6 +124,9 @@ compile_r() {
       if [[ "${OS_IDENTIFIER}" = "ubuntu-1804" ]]; then
           default_configure_options="$default_configure_options \
             CC=gcc-8 CXX=g++-8 FC=gfortran-8"
+          gcc_package=gcc-8
+          gxx_package=g++-8
+          gfortran_package=gfortran-8
       fi
   fi
 
@@ -172,6 +175,7 @@ EOF
 package_r() {
   if [[ -f /package.sh ]]; then
     export R_VERSION=${1}
+    export gcc_package gxx_package gfortran_package
     source /package.sh
   fi
 }

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -27,9 +27,9 @@ deb:
   fields:
     Bugs: https://github.com/rstudio/r-builds/issues
 depends:
-- g++-8
-- gcc-8
-- gfortran-8
+- ${gxx_package-g++}
+- ${gcc_package-gcc}
+- ${gfortran_package-gfortran}
 - libbz2-dev
 - libc6
 - libcairo2

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -27,9 +27,9 @@ deb:
   fields:
     Bugs: https://github.com/rstudio/r-builds/issues
 depends:
-- g++
-- gcc
-- gfortran
+- g++-8
+- gcc-8
+- gfortran-8
 - libbz2-dev
 - libc6
 - libcairo2

--- a/test/test-r.sh
+++ b/test/test-r.sh
@@ -8,9 +8,9 @@ R_HOME=/opt/R/${R_VERSION}/lib/R
 "${R_HOME}/bin/Rscript" -e 'sessionInfo()'
 
 # List R devel dependencies
-gcc --version
-g++ --version
-gfortran --version
+$("${R_HOME}/bin/R" CMD config CC)  --version
+$("${R_HOME}/bin/R" CMD config CXX) --version
+$("${R_HOME}/bin/R" CMD config FC)  --version
 
 # List shared library dependencies (e.g. BLAS/LAPACK)
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${R_HOME}/lib ldd "${R_HOME}/lib/libR.so"


### PR DESCRIPTION
To address #153 on Ubuntu 18.04.

If this the way we are going, then we can do a similar exception for OpenSUSE. CentOS 7 is a bit trickier because it needs an extra repository first.