### PR TITLE
Fix R-devel build on CentOS 7

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -68,6 +68,8 @@ ENV CONFIGURE_OPTIONS="\
     --with-tk-config=/usr/lib64/tkConfig.sh \
     --enable-prebuilt-html"
 
+ENV CC17="gcc -std=gnu11"
+
 # RHEL 7 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"
 

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -48,12 +48,12 @@ RUN yum -y update \
 # Compile newer libcurl, for R 4.3.0 and newer. We don't install it,
 # so system libcurl is used for the rest of the R versions.
 RUN cd /tmp && \
-    curl -LO https://curl.se/download/curl-7.32.0.tar.gz && \
+    curl -LO https://curl.se/download/curl-7.87.0.tar.gz && \
     tar xzf curl-*.tar.gz && \
-    rm curl-*.tar.gz && \
+    rm -f curl-*.tar.gz && \
     yum install -y zlib-devel openssl-devel make groff && \
-    cd curl-7.32.0 && \
-    ./configure --disable-shared --with-pic && \
+    cd curl-* && \
+    ./configure --disable-shared --with-pic --with-openssl && \
     make
 
 # Install AWS CLI.

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -45,6 +45,17 @@ RUN yum -y update \
     zlib-devel \
     && yum clean all
 
+# Compile newer libcurl, for R 4.3.0 and newer. We don't install it,
+# so system libcurl is used for the rest of the R versions.
+RUN cd /tmp && \
+    curl -LO https://curl.se/download/curl-7.32.0.tar.gz && \
+    tar xzf curl-*.tar.gz && \
+    rm curl-*.tar.gz && \
+    yum install -y zlib-devel openssl-devel make groff && \
+    cd curl-7.32.0 && \
+    ./configure --disable-shared --with-pic && \
+    make
+
 # Install AWS CLI.
 RUN pip3 install awscli --upgrade --user && \
     ln -s /root/.local/bin/aws /usr/bin/aws

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -68,6 +68,10 @@ ENV CONFIGURE_OPTIONS="\
     --with-tk-config=/usr/lib64/tkConfig.sh \
     --enable-prebuilt-html"
 
+# In R 4.3.0 recommended packages are compiled with C17, but
+# Centos 7 does not have a C17 compiler, so we use C11 on Centos 7.
+# C17 is basically the same as C17 with some bug fixes, so it is
+# fine for our purposes.
 ENV CC17="gcc -std=gnu11"
 
 # RHEL 7 doesn't have the inconsolata font, so override the defaults.

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -64,6 +64,17 @@ fetch_r_source() {
   rm /tmp/R-${1}.tar.gz
 }
 
+install_libcurl() {
+    cd /tmp
+    curl -LO https://curl.se/download/curl-7.32.0.tar.gz
+    tar xzf curl-*.tar.gz
+    yum install -y zlib-devel openssl-devel make groff
+    cd curl-7.32.0
+    ./configure --disable-shared --with-pic
+    make
+    make install
+}
+
 # compile_r() - $1 as r version
 compile_r() {
   cd /tmp/R-${1}
@@ -181,7 +192,12 @@ package_r() {
 }
 
 set_up_environment() {
-  mkdir -p "$R_INSTALL_PATH"
+    mkdir -p "$R_INSTALL_PATH"
+    if _version_is_greater_than ${R_VERSION} 4.2.10; then
+        if [[ "${OS_IDENTIFIER}" = "centos-7" ]]; then
+            install_libcurl
+        fi
+    fi
 }
 
 _version_is_greater_than() {

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -193,6 +193,8 @@ package_r() {
 
 set_up_environment() {
     mkdir -p "$R_INSTALL_PATH"
+    # from R 4.3.0 we need at least libcurl 7.32.0, so we install that
+    # and link to it statically
     if _version_is_greater_than ${R_VERSION} 4.2.10; then
         if [[ "${OS_IDENTIFIER}" = "centos-7" ]]; then
             install_libcurl

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -65,13 +65,7 @@ fetch_r_source() {
 }
 
 install_libcurl() {
-    cd /tmp
-    curl -LO https://curl.se/download/curl-7.32.0.tar.gz
-    tar xzf curl-*.tar.gz
-    yum install -y zlib-devel openssl-devel make groff
-    cd curl-7.32.0
-    ./configure --disable-shared --with-pic
-    make
+    cd /tmp/curl-*
     make install
 }
 


### PR DESCRIPTION
- need to compile a newer (static) libcurl.
- need to set CC17, because recommended packages are now installed with a CC17
  compiler, although this is only temporary. The CC17 env var is not used by
  previous versions of R, only current R-devel.

One glitch is that we still depend on the libcurl-devel system package, and this is not necessary any more. I checked that R does not link to the system libcurl any more, and also reports the correct version for `libcurlVersion()`.