### PR TITLE
Revert gcc-8 patches for R-devel on Ubuntu 18, openSUSE 15.3/15.4

### DIFF
--- a/builder/Dockerfile.opensuse-153
+++ b/builder/Dockerfile.opensuse-153
@@ -15,9 +15,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     gcc \
     gcc-c++ \
     gcc-fortran \
-    gcc8 \
-    gcc8-c++ \
-    gcc8-fortran \
     glib2-devel \
     glibc-locale \
     help2man \

--- a/builder/Dockerfile.opensuse-154
+++ b/builder/Dockerfile.opensuse-154
@@ -15,9 +15,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     gcc \
     gcc-c++ \
     gcc-fortran \
-    gcc8 \
-    gcc8-c++ \
-    gcc8-fortran \
     glib2-devel \
     glibc-locale \
     help2man \

--- a/builder/Dockerfile.ubuntu-1804
+++ b/builder/Dockerfile.ubuntu-1804
@@ -7,8 +7,7 @@ RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
   && apt-get install -y curl libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python-pip \
-  && apt-get build-dep -y r-base \
-  && apt-get install -y gcc-8 g++-8 gfortran-8
+  && apt-get build-dep -y r-base
 
 RUN pip install awscli
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -129,29 +129,7 @@ compile_r() {
     --with-blas \
     --with-lapack"
 
-  if _version_is_greater_than ${R_VERSION} 4.2.10; then
-      if [[ "${OS_IDENTIFIER}" = "ubuntu-1804" ]]; then
-          default_configure_options="$default_configure_options \
-            CC=gcc-8 CXX=g++-8 FC=gfortran-8"
-          gcc_package=gcc-8
-          gxx_package=g++-8
-          gfortran_package=gfortran-8
-      fi
-  fi
-
   CONFIGURE_OPTIONS=${CONFIGURE_OPTIONS:-$default_configure_options}
-
-  # For OpenSUSE CONFIGURE_OPTIONS are custom, set in the Dockerfile
-  if _version_is_greater_than ${R_VERSION} 4.2.10; then
-      if [[ "${OS_IDENTIFIER}" = "opensuse-153" || \
-            "${OS_IDENTIFIER}" = "opensuse-154" ]]; then
-          CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS \
-            CC=gcc-8 CXX=g++-8 FC=gfortran-8"
-          gcc_package=gcc8
-          gxx_package=gcc8-c++
-          gfortran_package=gcc8-fortran
-      fi
-  fi
 
   # set some common environment variables for the configure step
   AWK=/usr/bin/awk \
@@ -196,7 +174,6 @@ EOF
 package_r() {
   if [[ -f /package.sh ]]; then
     export R_VERSION=${1}
-    export gcc_package gxx_package gfortran_package
     source /package.sh
   fi
 }

--- a/builder/package.opensuse-153
+++ b/builder/package.opensuse-153
@@ -39,9 +39,9 @@ homepage: https://www.r-project.org
 license: GPLv2+
 depends:
 - fontconfig
-- ${gcc_package-gcc}
-- ${gxx_package-gcc-c++}
-- ${gfortran_package-gcc-fortran}
+- gcc
+- gcc-c++
+- gcc-fortran
 - glibc-locale
 - gzip
 - icu.691-devel

--- a/builder/package.opensuse-154
+++ b/builder/package.opensuse-154
@@ -55,9 +55,9 @@ homepage: https://www.r-project.org
 license: GPLv2+
 depends:
 - fontconfig
-- ${gcc_package-gcc}
-- ${gxx_package-gcc-c++}
-- ${gfortran_package-gcc-fortran}
+- gcc
+- gcc-c++
+- gcc-fortran
 - glibc-locale
 - gzip
 - icu.691-devel

--- a/builder/package.ubuntu-1804
+++ b/builder/package.ubuntu-1804
@@ -27,9 +27,9 @@ deb:
   fields:
     Bugs: https://github.com/rstudio/r-builds/issues
 depends:
-- ${gxx_package-g++}
-- ${gcc_package-gcc}
-- ${gfortran_package-gfortran}
+- g++
+- gcc
+- gfortran
 - libbz2-dev
 - libc6
 - libcairo2


### PR DESCRIPTION
The C17 issues from https://github.com/rstudio/r-builds/issues/153 have now been resolved in R-devel (https://github.com/wch/r-source/commit/49a85483a7318f1c519f514f7d66c9aa242a0a18), so revert the gcc-8 patches made for Ubuntu 18 and openSUSE in https://github.com/rstudio/r-builds/pull/156/, https://github.com/rstudio/r-builds/pull/157.

Closes https://github.com/rstudio/r-builds/issues/153