### PR TITLE
Use FlexiBLAS on RHEL 9 for R 4.3.0 and above

### DIFF
--- a/builder/Dockerfile.rhel-9
+++ b/builder/Dockerfile.rhel-9
@@ -11,6 +11,7 @@ RUN dnf -y upgrade \
     automake \
     bzip2-devel \
     cairo-devel \
+    flexiblas-devel \
     gcc-c++ \
     gcc-gfortran \
     java-11-openjdk-devel \

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -131,6 +131,16 @@ compile_r() {
 
   CONFIGURE_OPTIONS=${CONFIGURE_OPTIONS:-$default_configure_options}
 
+  # For RHEL 9, link to external FlexiBLAS starting from R 4.3.0 to align with EPEL 9
+  if _version_is_greater_than "${R_VERSION}" 4.2.10; then
+    if [[ "${OS_IDENTIFIER}" = "rhel-9" ]]; then
+      CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS \
+        --with-blas=flexiblas --with-lapack=flexiblas"
+    fi
+  fi
+
+  echo "Using CONFIGURE_OPTIONS: ${CONFIGURE_OPTIONS}"
+
   # set some common environment variables for the configure step
   AWK=/usr/bin/awk \
   LIBnn=lib \

--- a/builder/package.centos-8
+++ b/builder/package.centos-8
@@ -10,7 +10,20 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_lib='pcre-devel'
 fi
 
-# create post-install script required for openblas
+# Create post-install script required for OpenBLAS.
+#
+# On RHEL and SUSE, we link R against the internal shared BLAS to make the
+# R binaries more portable and allow users to switch BLAS implementations without
+# having to recompile R. We default to OpenBLAS, but users may prefer other implementations.
+# 
+# Binary packages built against the shared BLAS are also more portable and may be used
+# with the default R distributed by RHEL/SUSE, or other R installations using
+# shared BLAS and configured with a different BLAS (such as Microsoft R Open with MKL).
+# This is especially important for Posit Package Manager's binary packages.
+#
+# However, as of R 4.2.3, EPEL 8's R no longer uses shared BLAS and now links to an
+# external OpenBLAS (OpenMP). This means EPEL R no longer has a swappable BLAS and
+# is no longer compatible with these R builds.
 cat <<EOF >> /post-install.sh
 mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
 ln -s /usr/lib64/libopenblasp.so.0 ${R_INSTALL_PATH}/lib/R/lib/libRblas.so

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -11,8 +11,6 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 - pcre-devel'
 fi
 
-# Create post-install script required for OpenBLAS.
-#
 # On RHEL and SUSE, we link R against the internal shared BLAS to make the
 # R binaries more portable and allow users to switch BLAS implementations without
 # having to recompile R. We default to OpenBLAS, but users may prefer other implementations.
@@ -20,7 +18,12 @@ fi
 # Binary packages built against the shared BLAS are also more portable and may be used
 # with the default R distributed by RHEL/SUSE, or other R installations using
 # shared BLAS and configured with a different BLAS (such as Microsoft R Open with MKL).
-# This is especially important for RSPM's binary packages.
+# This is especially important for Posit Package Manager's binary packages.
+#
+# However, EPEL 9's R now links externally against FlexiBLAS, which provides a
+# native BLAS switching mechanism for Fedora/RHEL. Starting with R 4.3.0, we also
+# link to external FlexiBLAS for compatibility.
+# https://fedoraproject.org/wiki/Changes/FlexiBLAS_as_BLAS/LAPACK_manager
 #
 # On Ubuntu/Debian, we link R against the external BLAS instead (--with-blas/--with-lapack),
 # as those distributions use the alternatives system to swap BLAS libraries at runtime.
@@ -28,17 +31,40 @@ fi
 # for portability.
 #
 # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Shared-BLAS
-cat <<EOF >> /post-install.sh
-mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
-ln -s /usr/lib64/libopenblasp.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
+if [[ "$("${R_INSTALL_PATH}/bin/R" CMD config BLAS_LIBS)" == "-lflexiblas" ]]; then
+  blas_lib='flexiblas-devel'
+
+  # Create postremove script to remove empty directories, as nFPM doesn't include them in the RPM files.
+  cat <<EOF >> /after-remove.sh
+  if [ -d ${R_INSTALL_PATH} ]; then
+    rm -r ${R_INSTALL_PATH}
+  fi
 EOF
 
-# Create after-remove script to remove internal BLAS, which won't be cleaned up automatically.
-cat <<EOF >> /after-remove.sh
-if [ -d ${R_INSTALL_PATH} ]; then
-  rm -r ${R_INSTALL_PATH}
-fi
+  scripts="scripts:
+  postremove: /after-remove.sh
+"
+else
+  blas_lib='openblas-devel'
+
+  # Create post-install script required for OpenBLAS.
+  cat <<EOF >> /post-install.sh
+  mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
+  ln -s /usr/lib64/libopenblasp.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
 EOF
+
+  # Create after-remove script to remove internal BLAS, which won't be cleaned up automatically.
+  cat <<EOF >> /after-remove.sh
+  if [ -d ${R_INSTALL_PATH} ]; then
+    rm -r ${R_INSTALL_PATH}
+  fi
+EOF
+
+  scripts="scripts:
+  postinstall: /post-install.sh
+  postremove: /after-remove.sh
+"
+fi
 
 if [ "$(arch)" == "aarch64" ]; then echo arm64; else echo amd64; fi > /tmp/arch
 
@@ -66,7 +92,7 @@ depends:
 - libXmu
 - libXt
 - make
-- openblas-devel
+- ${blas_lib}
 - pango
 ${pcre_libs}
 - tcl
@@ -79,9 +105,7 @@ ${pcre_libs}
 contents:
 - src: ${R_INSTALL_PATH}
   dst: ${R_INSTALL_PATH}
-scripts:
-  postinstall: /post-install.sh
-  postremove: /after-remove.sh
+${scripts}
 EOF
 
 nfpm package \


### PR DESCRIPTION
Resolves https://github.com/rstudio/r-builds/issues/154

Switch to externally-linked FlexiBLAS on RHEL 9 for compatibility with EPEL R, starting from R 4.3.0. FlexiBLAS defaults to OpenBLAS-OpenMP (and can be used to swap to any other BLAS), so it's not a huge change from the currently used OpenBLAS-pthreads.

R 4.2.3 and below continue to use shared BLAS (OpenBLAS) for backward compatibility.

I didn't change anything for RHEL 8 because EPEL 8 R's new BLAS configuration is no longer swappable, and I figured it was better to keep the flexibility/consistency.

For testing, CI should pass, and I've done some manual testing to confirm that R devel/4.3.0 now links to FlexiBLAS, and R 4.2.3 still links to R's internal BLAS:
```sh
$ /opt/R/devel/bin/R -s -e 'sessionInfo()'
R Under development (unstable) (2023-04-18 r84280)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Rocky Linux 9.0 (Blue Onyx)

Matrix products: default
BLAS/LAPACK: FlexiBLAS OPENBLAS-OPENMP;  LAPACK version 3.9.0

$ ldd /opt/R/devel/lib/R/lib/libR.so | grep blas
	libflexiblas.so.3 => /lib64/libflexiblas.so.3 (0x00007fdc3815f000)

$ /opt/R/devel/bin/R CMD config BLAS_LIBS
-lflexiblas

$ /opt/R/devel/bin/R CMD config LAPACK_LIBS
-lflexiblas
```

```sh
$ /opt/R/4.2.3/bin/R CMD config BLAS_LIBS
-L/opt/R/4.2.3/lib/R/lib -lRblas

$ /opt/R/4.2.3/bin/R CMD config LAPACK_LIBS
-L/opt/R/4.2.3/lib/R/lib -lRlapack
```