### PR TITLE
Fix deploy job; use absolute path for HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ rebuild-all: deps fetch-serverless-custom-file
 	$(SLS_BINARY) invoke stepf -n rBuilds -d '{"force": true}'
 
 serverless-deploy.%: deps fetch-serverless-custom-file
-	$(SLS_BINARY) deploy --stage $*
+	$(SLS_BINARY) deploy --stage $* --verbose
 
 define GEN_TARGETS
 docker-build-$(platform):

--- a/deploy.Jenkinsfile
+++ b/deploy.Jenkinsfile
@@ -3,12 +3,18 @@ pipeline {
     dockerfile {
       dir 'jenkins'
       label 'docker'
+      // Required for the serverless-python-requirements plugin to install
+      // Python requirements using the AWS build images, running Docker inside Docker.
       additionalBuildArgs '--build-arg DOCKER_GID=$(stat -c %g /var/run/docker.sock) --build-arg JENKINS_UID=$(id -u jenkins) --build-arg JENKINS_GID=$(id -g jenkins)'
       args '-v /var/run/docker.sock:/var/run/docker.sock --group-add docker'
     }
   }
   environment {
-    HOME = "."
+    // Set HOME to the workspace for the serverless-python-requirements plugin.
+    // The plugin uses HOME for its default cache location, which needs to be
+    // mounted in the separate Python build container. This needs to be an absolute
+    // path that also exists on the host since we're mounting the Docker socket.
+    HOME = "${env.WORKSPACE}"
   }
   options {
     ansiColor('xterm')

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,10 @@ package:
     - integration/**
     - builder/**
     - docs/**
+    # Generated files by other tools
     - node_modules/**
+    - .npm/**
+    - .cache/**
 
 provider:
   name: aws


### PR DESCRIPTION
Pulled out the smaller changes from https://github.com/rstudio/r-builds/pull/171 to fix the deploy job with the existing docker inside docker packager:
- Set HOME to an absolute path, `env.WORKSPACE`, rather than a relative `.`, which is needed for both the docker bind mounting to work correctly, and the serverless-python-requirements plugin correctly include Python packages in the zip file.
- Add docs for how the deploy job works
- Add verbose logging since the plugin hides the actual error on failures. Now you should be able to see the docker run command:
```sh
[2023-07-06T23:37:22.224Z] ./node_modules/serverless/bin/serverless.js deploy --stage staging --verbose
[2023-07-06T23:37:26.380Z] 
[2023-07-06T23:37:26.380Z] Deploying r-builds to stage staging (us-east-1)
[2023-07-06T23:37:26.380Z] 
[2023-07-06T23:37:26.380Z] Generated requirements from /var/lib/jenkins/workspace/r-builds/deploy-r-builds/requirements.txt in /var/lib/jenkins/workspace/r-builds/deploy-r-builds/.serverless/requirements.txt
[2023-07-06T23:37:26.380Z] Installing requirements from "/var/lib/jenkins/workspace/r-builds/deploy-r-builds/.cache/serverless-python-requirements/2b10c0467f75bfbcf12e9b77be65ec7563b90c5995f0eaa96faefbd42c337bdd_x86_64_slspyc/requirements.txt"
[2023-07-06T23:37:26.380Z] Docker Image: lambci/lambda:build-python3.8
[2023-07-06T23:37:26.380Z] Using download cache directory /var/lib/jenkins/workspace/r-builds/deploy-r-builds/.cache/serverless-python-requirements/downloadCacheslspyc
[2023-07-06T23:37:26.380Z] Running docker run --rm -v /var/lib/jenkins/workspace/r-builds/deploy-r-builds/.cache/serverless-python-requirements/2b10c0467f75bfbcf12e9b77be65ec7563b90c5995f0eaa96faefbd42c337bdd_x86_64_slspyc\:/var/task\:z -v /var/lib/jenkins/workspace/r-builds/deploy-r-builds/.cache/serverless-python-requirements/downloadCacheslspyc\:/var/useDownloadCache\:z lambci/lambda\:build-python3.8 /bin/sh -c 'chown -R 0\\:0 /var/useDownloadCache && python3.8 -m pip install -t /var/task/ -r /var/task/requirements.txt --cache-dir /var/useDownloadCache && chown -R 386\\:386 /var/task && chown -R 386\\:386 /var/useDownloadCache'...
```
- Exclude other `.cache`/`.npm` generated files that didn't need to be in the serverless package
```sh
$ unzip r-builds-staging-queueBuilds-fda4c5bf-5e39-4c62-9eef-e358b4135ceb.zip 
$ du -sh $(ls -A) | sort -h | tail -n5
3.8M	docutils
28M	.npm
38M	botocore
46M	r-builds-staging-queueBuilds-fda4c5bf-5e39-4c62-9eef-e358b4135ceb.zip
56M	.cache
```

I just tested this again to be sure at https://build.posit.it/blue/organizations/jenkins/r-builds%2Fdeploy-r-builds/detail/deploy-r-builds/202/pipeline/, and confirmed that staging builds still work.