### PR TITLE
Add R builds for openSUSE 15.5 / SLES 15 SP5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-2004 ubuntu-2204 debian-10 debian-11 debian-12 centos-7 centos-8 rhel-9 opensuse-154
+PLATFORMS := ubuntu-2004 ubuntu-2204 debian-10 debian-11 debian-12 centos-7 centos-8 rhel-9 opensuse-154 opensuse-155
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless.js
 
 deps:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ R binaries are built for the following Linux operating systems:
 - Debian 10, 11, 12
 - CentOS 7
 - Red Hat Enterprise Linux 7, 8, 9
-- openSUSE 15.4
-- SUSE Linux Enterprise 15 SP4
+- openSUSE 15.4, 15.5
+- SUSE Linux Enterprise 15 SP4, 15 SP5
 
 Operating systems are supported until their vendor end-of-support dates, which
 can be found on the [Posit Platform Support](https://posit.co/about/platform-support/)
@@ -48,7 +48,7 @@ bash -c "$(curl -L https://rstd.io/r-install)"
 Define the version of R that you want to install. Available versions
 of R can be found here: https://cdn.posit.co/r/versions.json
 ```bash
-R_VERSION=4.1.3
+R_VERSION=4.2.3
 ```
 
 ### Download and install R
@@ -139,6 +139,9 @@ Download the rpm package:
 ```bash
 # openSUSE 15.4 / SLES 15 SP4
 curl -O https://cdn.posit.co/r/opensuse-154/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
+
+# openSUSE 15.5 / SLES 15 SP5
+curl -O https://cdn.posit.co/r/opensuse-155/pkgs/R-${R_VERSION}-1-1.x86_64.rpm
 ```
 
 Then install the package:

--- a/builder/Dockerfile.opensuse-155
+++ b/builder/Dockerfile.opensuse-155
@@ -1,0 +1,103 @@
+FROM opensuse/leap:15.5
+
+ENV OS_IDENTIFIER opensuse-155
+
+# Most of these packages, and also the configure options that follow were determined
+# by reviewing "R-base.spec" from the following OpenSUSE RPM:
+# https://download.opensuse.org/repositories/devel:/languages:/R:/released/openSUSE_Leap_42.3/src/R-base-3.5.3-103.1.src.rpm
+
+RUN zypper --non-interactive update
+RUN zypper --non-interactive --gpg-auto-import-keys -n install \
+    bzip2 \
+    cairo-devel \
+    curl \
+    fdupes \
+    gcc \
+    gcc-c++ \
+    gcc-fortran \
+    glib2-devel \
+    glibc-locale \
+    help2man \
+    # Like openSUSE/SLES 15.3 and 15.4, SUSE 15.5 ships with both ICU 65 (libicu-devel) and
+    # ICU 69 (icu.691-devel). Prefer ICU 69 because the devel packages can't coexist, and
+    # zypper resolves libicu-devel to icu.691-devel when installing RPMs.
+    icu.691-devel \
+    java-11-openjdk-devel \
+    libX11-devel \
+    libXScrnSaver-devel \
+    libXmu-devel \
+    libXt-devel \
+    libbz2-devel \
+    libcurl-devel \
+    libjpeg-devel \
+    libpng-devel \
+    libtiff-devel \
+    make \
+    pango-devel \
+    pcre-devel \
+    pcre2-devel \
+    perl \
+    perl-macros \
+    readline-devel \
+    rpm-build \
+    shadow \
+    tcl-devel \
+    texinfo \
+    texlive-ae \
+    texlive-bibtex \
+    texlive-cm-super \
+    texlive-dvips \
+    texlive-fancyvrb \
+    texlive-helvetic \
+    texlive-inconsolata \
+    texlive-latex \
+    texlive-makeindex \
+    texlive-metafont \
+    texlive-psnfss \
+    texlive-tex \
+    texlive-times \
+    tk-devel \
+    unzip \
+    wget \
+    xdg-utils \
+    xorg-x11-devel \
+    xz-devel \
+    zip \
+    zlib-devel \
+    && zypper clean
+
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+RUN if [ "$(arch)" == "aarch64" ]; then echo arm64; else echo amd64; fi > /tmp/arch
+
+RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_$(cat /tmp/arch).rpm" && \
+    zypper --non-interactive --no-gpg-checks install "nfpm_$(cat /tmp/arch).rpm" && \
+    rm "nfpm_$(cat /tmp/arch).rpm"
+
+RUN chmod 0777 /opt
+
+# Configure flags for SUSE that don't use the defaults in build.sh
+ENV CONFIGURE_OPTIONS="\
+    --enable-R-shlib \
+    --with-tcltk \
+    --with-x \
+    --enable-memory-profiling \
+    --with-tcl-config=/usr/lib64/tclConfig.sh \
+    --with-tk-config=/usr/lib64/tkConfig.sh"
+
+# Make sure that patching Java does not break R.
+# On SUSE, the default JAVA_HOME path always uses the major Java version only,
+# but the JDK path is chosen by default. We change this to the JRE path to
+# support users who only want to install the JRE (non-devel) package.
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Java-support
+# https://solutions.posit.co/envs-pkgs/using-rjava/
+ENV JAVA_HOME=/usr/lib64/jvm/jre-11-openjdk
+
+COPY package.opensuse-155 /package.sh
+COPY build.sh .
+COPY patches /patches
+ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -107,3 +107,15 @@ services:
     image: r-builds:opensuse-154
     volumes:
       - ./integration/tmp:/tmp/output
+  opensuse-155:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.opensuse-155
+    image: r-builds:opensuse-155
+    volumes:
+      - ./integration/tmp:/tmp/output

--- a/builder/package.opensuse-155
+++ b/builder/package.opensuse-155
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
+fi
+
+# R 3.x requires PCRE1
+pcre_lib='pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_lib='pcre-devel'
+fi
+
+# Create post-install script required for OpenBLAS.
+#
+# On RHEL and SUSE, we link R against the internal shared BLAS to make the
+# R binaries more portable and allow users to switch BLAS implementations without
+# having to recompile R. We default to OpenBLAS, but users may prefer other implementations.
+# 
+# Binary packages built against the shared BLAS are also more portable and may be used
+# with the default R distributed by RHEL/SUSE, or other R installations using
+# shared BLAS and configured with a different BLAS (such as Microsoft R Open with MKL).
+# This is especially important for RSPM's binary packages.
+#
+# On Ubuntu/Debian, we link R against the external BLAS instead (--with-blas/--with-lapack),
+# as those distributions use the alternatives system to swap BLAS libraries at runtime.
+# The default R distributions on Ubuntu/Debian use the external BLAS, so we do as well
+# for portability.
+#
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Shared-BLAS
+cat <<EOF >> /post-install.sh
+mv ${R_INSTALL_PATH}/lib/R/lib/libRblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so.keep
+ln -s /usr/lib64/libopenblas.so ${R_INSTALL_PATH}/lib/R/lib/libRblas.so
+EOF
+
+# Create after-remove script to remove internal BLAS, which won't be cleaned up automatically.
+cat <<EOF >> /after-remove.sh
+if [ -d ${R_INSTALL_PATH} ]; then
+  rm -r ${R_INSTALL_PATH}
+fi
+EOF
+
+if [ "$(arch)" == "aarch64" ]; then echo arm64; else echo amd64; fi > /tmp/arch
+
+cat <<EOF > /tmp/nfpm.yml
+name: R-${R_VERSION}
+version: 1
+version_schema: none
+arch: $(cat /tmp/arch)
+release: 1
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: Posit Software, PBC
+homepage: https://www.r-project.org
+license: GPLv2+
+depends:
+- fontconfig
+- gcc
+- gcc-c++
+- gcc-fortran
+- glibc-locale
+- gzip
+- icu.691-devel
+- libbz2-devel
+- libcairo2
+- libcurl-devel
+- libfreetype6
+- libgomp1
+- libjpeg62
+- libopenblas_pthreads-devel
+- libpango-1_0-0
+- libreadline7
+- libtiff5
+- make
+- ${pcre_lib}
+- tar
+- tcl
+- tk
+- unzip
+- which
+- xorg-x11
+- xorg-x11-fonts-100dpi
+- xorg-x11-fonts-75dpi
+- xz-devel
+- zip
+- zlib-devel
+contents:
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
+scripts:
+  postinstall: /post-install.sh
+  postremove: /after-remove.sh
+EOF
+
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p rpm \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm | head -1)

--- a/install.sh
+++ b/install.sh
@@ -202,7 +202,9 @@ download_url () {
         echo "${CDN_URL}/opensuse-42/pkgs/${name}"
         ;;
       "LEAP15" | "SLES15")
-        if [ "${ver}" -ge 154 ]; then
+        if [ "${ver}" -ge 155 ]; then
+          echo "${CDN_URL}/opensuse-155/pkgs/${name}"
+        elif [ "${ver}" -ge 154 ]; then
           echo "${CDN_URL}/opensuse-154/pkgs/${name}"
         elif [ "${ver}" -ge 153 ]; then
           echo "${CDN_URL}/opensuse-153/pkgs/${name}"

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -257,6 +257,20 @@ rBuildsBatchJobDefinitionOpensuse154:
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:opensuse-154"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionOpensuse155:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:opensuse-155"
+    Timeout:
+      AttemptDurationSeconds: 7200
 
 # step function cloudwatch event trigger resources
 rBuildsEventRuleIamRole:

--- a/serverless.yml
+++ b/serverless.yml
@@ -63,7 +63,9 @@ provider:
       Ref: rBuildsBatchJobDefinitionRhel9
     JOB_DEFINITION_ARN_opensuse_154:
       Ref: rBuildsBatchJobDefinitionOpensuse154
-    SUPPORTED_PLATFORMS: ubuntu-2004,ubuntu-2204,debian-10,debian-11,debian-12,centos-7,centos-8,rhel-9,opensuse-154
+    JOB_DEFINITION_ARN_opensuse_155:
+      Ref: rBuildsBatchJobDefinitionOpensuse155
+    SUPPORTED_PLATFORMS: ubuntu-2004,ubuntu-2204,debian-10,debian-11,debian-12,centos-7,centos-8,rhel-9,opensuse-154,opensuse-155
 
 functions:
   queueBuilds:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -71,3 +71,11 @@ services:
       - R_VERSION=${R_VERSION}
     volumes:
       - ../:/r-builds
+  opensuse-155:
+    image: opensuse/leap:15.5
+    command: /r-builds/test/test-zypper.sh
+    environment:
+      - OS_IDENTIFIER=opensuse-155
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ../:/r-builds


### PR DESCRIPTION
This was a copy-paste of SUSE 15.4 with no change. The SUSE 15.4 binaries also seem to work just fine on 15.5, but better to have a separate build anyway in case SUSE makes another breaking change in the minor release.