### PR TITLE
Fix R 3.0.0 - R 3.0.3 on arm64

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -75,6 +75,10 @@ patch_r() {
   if [ -f "/patches/R-${1}-${OS_IDENTIFIER}.patch" ]; then
       patch -p1 < "/patches/R-${1}-${OS_IDENTIFIER}.patch"
   fi
+
+  if [ -f "/patches/R-${1}-`arch`.patch" ]; then
+      patch -p1 < "/patches/R-${1}-`arch`.patch"
+  fi
 }
 
 # compile_r() - $1 as r version

--- a/builder/patches/R-3.0.0-aarch64.patch
+++ b/builder/patches/R-3.0.0-aarch64.patch
@@ -1,0 +1,709 @@
+diff --git a/configure b/configure
+index b3c299e..01f205d 100755
+--- a/configure
++++ b/configure
+@@ -5193,6 +5193,7 @@ elif test ${makeinfo_version_maj} -lt 4 \
+ else
+   r_cv_prog_makeinfo_v4=yes
+ fi
++r_cv_prog_makeinfo_v4=yes
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $r_cv_prog_makeinfo_v4" >&5
+ $as_echo "$r_cv_prog_makeinfo_v4" >&6; }
+diff --git a/src/extra/tre/regcomp.c b/src/extra/tre/regcomp.c
+index 93ddb92..31d4e52 100644
+--- a/src/extra/tre/regcomp.c
++++ b/src/extra/tre/regcomp.c
+@@ -99,7 +99,6 @@ tre_regncomp(regex_t *preg, const char *regex, size_t n, int cflags)
+   return ret;
+ }
+ 
+-
+ /* this version takes bytes literally, to be used with raw vectors */
+ int
+ tre_regncompb(regex_t *preg, const char *regex, size_t n, int cflags)
+@@ -131,7 +130,6 @@ tre_regcomp(regex_t *preg, const char *regex, int cflags)
+   return tre_regncomp(preg, regex, regex ? strlen(regex) : 0, cflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags)
+ {
+diff --git a/src/extra/tre/regexec.c b/src/extra/tre/regexec.c
+index 6edaf81..d8f91a3 100644
+--- a/src/extra/tre/regexec.c
++++ b/src/extra/tre/regexec.c
+@@ -217,7 +217,6 @@ tre_regexec(const regex_t *preg, const char *str,
+   return tre_regnexec(preg, str, (unsigned)-1, nmatch, pmatch, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regexecb(const regex_t *preg, const char *str,
+ 	     size_t nmatch, regmatch_t pmatch[], int eflags)
+@@ -329,7 +328,6 @@ tre_regaexec(const regex_t *preg, const char *str,
+   return tre_reganexec(preg, str, (unsigned)-1, match, params, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regaexecb(const regex_t *preg, const char *str,
+ 	  regamatch_t *match, regaparams_t params, int eflags)
+diff --git a/src/extra/tre/tre-ast.h b/src/extra/tre/tre-ast.h
+index 844aee3..d9af376 100644
+--- a/src/extra/tre/tre-ast.h
++++ b/src/extra/tre/tre-ast.h
+@@ -55,16 +55,11 @@ typedef struct {
+    tags, matching parameter settings, and all expressions that match one
+    character. */
+ typedef struct {
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+-  int /* long */ code_min;
+-  int /* long */ code_max;
+-#endif
++  long code_min;
++  long code_max;
+   int position;
+   union {
+-    tre_ctype_t classt; /* [i_a] wrong syntax colouring prevention */
++    tre_ctype_t class;
+     int *params;
+   } u;
+   tre_ctype_t *neg_classes;
+diff --git a/src/extra/tre/tre-compile.c b/src/extra/tre/tre-compile.c
+index 7886455..92c14ab 100644
+--- a/src/extra/tre/tre-compile.c
++++ b/src/extra/tre/tre-compile.c
+@@ -6,6 +6,13 @@
+ 
+ */
+ 
++/*
++  TODO:
++   - Fix tre_ast_to_tnfa() to recurse using a stack instead of recursive
++     function calls.
++*/
++
++
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+@@ -684,8 +691,8 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 	      {
+ 		tre_literal_t *lit = node->obj;
+ 		int pos = lit->position;
+-		int min = lit->code_min;
+-		int max = lit->code_max;
++		int min = (int)lit->code_min;
++		int max = (int)lit->code_max;
+ 		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
+ 		  {
+ 		    /* XXX - e.g. [ab] has only one position but two
+@@ -945,7 +952,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 			  seq2 = copy;
+ 			if (seq2 == NULL)
+ 			  return REG_ESPACE;
+-			tmp = tre_ast_new_literal(mem, EMPTY, EMPTY, -1);
++			tmp = tre_ast_new_literal(mem, EMPTY, -1, -1);
+ 			if (tmp == NULL)
+ 			  return REG_ESPACE;
+ 			seq2 = tre_ast_new_union(mem, tmp, seq2);
+@@ -1052,15 +1059,15 @@ tre_set_empty(tre_mem_t mem)
+     return NULL;
+ 
+   new_set[0].position = -1;
+-  new_set[0].code_min = EMPTY;
+-  new_set[0].code_max = EMPTY;
++  new_set[0].code_min = -1;
++  new_set[0].code_max = -1;
+ 
+   return new_set;
+ }
+ 
+ static tre_pos_and_tags_t *
+ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+-	    tre_ctype_t classt, tre_ctype_t *neg_classes, int backref)
++	    tre_ctype_t class, tre_ctype_t *neg_classes, int backref)
+ {
+   tre_pos_and_tags_t *new_set;
+ 
+@@ -1071,12 +1078,12 @@ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+   new_set[0].position = position;
+   new_set[0].code_min = code_min;
+   new_set[0].code_max = code_max;
+-  new_set[0].classt = classt;
++  new_set[0].class = class;
+   new_set[0].neg_classes = neg_classes;
+   new_set[0].backref = backref;
+   new_set[1].position = -1;
+-  new_set[1].code_min = EMPTY;
+-  new_set[1].code_max = EMPTY;
++  new_set[1].code_min = -1;
++  new_set[1].code_max = -1;
+ 
+   return new_set;
+ }
+@@ -1103,7 +1110,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1].code_min = set1[s1].code_min;
+       new_set[s1].code_max = set1[s1].code_max;
+       new_set[s1].assertions = set1[s1].assertions | assertions;
+-      new_set[s1].classt = set1[s1].classt;
++      new_set[s1].class = set1[s1].class;
+       new_set[s1].neg_classes = set1[s1].neg_classes;
+       new_set[s1].backref = set1[s1].backref;
+       if (set1[s1].tags == NULL && tags == NULL)
+@@ -1148,7 +1155,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1 + s2].code_max = set2[s2].code_max;
+       /* XXX - why not | assertions here as well? */
+       new_set[s1 + s2].assertions = set2[s2].assertions;
+-      new_set[s1 + s2].classt = set2[s2].classt;
++      new_set[s1 + s2].class = set2[s2].class;
+       new_set[s1 + s2].neg_classes = set2[s2].neg_classes;
+       new_set[s1 + s2].backref = set2[s2].backref;
+       if (set2[s2].tags == NULL)
+@@ -1231,7 +1238,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
+ 			  break;
+ 		      if (tags[i] < 0)
+ 			{
+-			  tags[i] = lit->code_max;
++			  tags[i] = (int)lit->code_max;
+ 			  tags[i + 1] = -1;
+ 			}
+ 		    }
+@@ -1373,7 +1380,7 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
+ 		    node->lastpos = tre_set_one(mem, lit->position,
+ 						(int)lit->code_min,
+ 						(int)lit->code_max,
+-						lit->u.classt, lit->neg_classes,
++						lit->u.class, lit->neg_classes,
+ 						-1);
+ 		    if (!node->lastpos)
+ 		      return REG_ESPACE;
+@@ -1614,12 +1621,12 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 	      (trans + 1)->state = NULL;
+ 	    /* Use the character ranges, assertions, etc. from `p1' for
+ 	       the transition from `p1' to `p2'. */
+-	    trans->code_min = p1->code_min;
+-	    trans->code_max = p1->code_max;
++	    trans->code_min = (tre_cint_t) p1->code_min;
++	    trans->code_max = (tre_cint_t) p1->code_max;
+ 	    trans->state = transitions + offs[p2->position];
+ 	    trans->state_id = p2->position;
+ 	    trans->assertions = p1->assertions | p2->assertions
+-	      | (p1->classt ? ASSERT_CHAR_CLASS : 0)
++	      | (p1->class ? ASSERT_CHAR_CLASS : 0)
+ 	      | (p1->neg_classes != NULL ? ASSERT_CHAR_CLASS_NEG : 0);
+ 	    if (p1->backref >= 0)
+ 	      {
+@@ -1629,7 +1636,7 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		trans->assertions |= ASSERT_BACKREF;
+ 	      }
+ 	    else
+-	      trans->u.classt = p1->classt;
++	      trans->u.class = p1->class;
+ 	    if (p1->neg_classes != NULL)
+ 	      {
+ 		for (i = 0; p1->neg_classes[i] != (tre_ctype_t)0; i++);
+@@ -1743,8 +1750,8 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		DPRINT((", assert %d", trans->assertions));
+ 	      if (trans->assertions & ASSERT_BACKREF)
+ 		DPRINT((", backref %d", trans->u.backref));
+-	      else if (trans->u.classt)
+-		DPRINT((", class %ld", (long)trans->u.classt));
++	      else if (trans->u.class)
++		DPRINT((", class %ld", (long)trans->u.class));
+ 	      if (trans->neg_classes)
+ 		DPRINT((", neg_classes %p", trans->neg_classes));
+ 	      if (trans->params)
+@@ -1861,10 +1868,10 @@ tre_ast_to_tnfa(tre_ast_node_t *node, tre_tnfa_transition_t *transitions,
+   do				  \
+     {				  \
+       errcode = err;		  \
+-      if (/*CONSTCOND*/1)	  \
++      if (/*CONSTCOND*/(void)1,1)	  \
+       	goto error_exit;	  \
+     }				  \
+- while (/*CONSTCOND*/0)
++ while (/*CONSTCOND*/(void)0,0)
+ 
+ 
+ int
+@@ -2050,7 +2057,7 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
+   if (TRE_MB_CUR_MAX == 1 && !tmp_ast_l->nullable)
+     {
+       int count = 0;
+-      int k; /* [i_a] */
++      tre_cint_t k;
+       DPRINT(("Characters that can start a match:"));
+       tnfa->firstpos_chars = xcalloc(256, sizeof(char));
+       if (tnfa->firstpos_chars == NULL)
+@@ -2310,15 +2317,7 @@ tre_config(int query, void *result)
+     case TRE_CONFIG_VERSION:
+       *string_result = TRE_VERSION;
+       return REG_OK;
+-
+-	case TRE_MB_CUR_MAX_VALUE:  /* [i_a] */
+-#if defined(TRE_MB_CUR_MAX)
+-		*int_result = TRE_MB_CUR_MAX;
+-#else
+-		*int_result = 1;
+-#endif
+-		break;
+-  }
++    }
+ 
+   return REG_NOMATCH;
+ }
+diff --git a/src/extra/tre/tre-compile.h b/src/extra/tre/tre-compile.h
+index 0d81cf2..51d5ac9 100644
+--- a/src/extra/tre/tre-compile.h
++++ b/src/extra/tre/tre-compile.h
+@@ -12,16 +12,11 @@
+ 
+ typedef struct {
+   int position;
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+   int code_min;
+   int code_max;
+-#endif
+   int *tags;
+   int assertions;
+-  tre_ctype_t classt;
++  tre_ctype_t class;
+   tre_ctype_t *neg_classes;
+   int backref;
+   int *params;
+diff --git a/src/extra/tre/tre-internal.h b/src/extra/tre/tre-internal.h
+index c1300ac..822998e 100644
+--- a/src/extra/tre/tre-internal.h
++++ b/src/extra/tre/tre-internal.h
+@@ -22,9 +22,9 @@
+ 
+ #ifdef TRE_DEBUG
+ #include <stdio.h>
+-#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/0)
++#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/(void)0,0)
+ #else /* !TRE_DEBUG */
+-#define DPRINT(msg) do { } while(/*CONSTCOND*/0)
++#define DPRINT(msg) do { } while(/*CONSTCOND*/(void)0,0)
+ #endif /* !TRE_DEBUG */
+ 
+ #define elementsof(x)	( sizeof(x) / sizeof(x[0]) )
+@@ -151,13 +151,8 @@ typedef struct tnfa_transition tre_tnfa_transition_t;
+ 
+ struct tnfa_transition {
+   /* Range of accepted characters. */
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+   tre_cint_t code_min;
+   tre_cint_t code_max;
+-#else
+-  int code_min;
+-  int code_max;
+-#endif
+   /* Pointer to the destination state. */
+   tre_tnfa_transition_t *state;
+   /* ID number of the destination state. */
+@@ -171,7 +166,7 @@ struct tnfa_transition {
+   /* Assertion parameters. */
+   union {
+     /* Character class assertion. */
+-    tre_ctype_t classt;
++    tre_ctype_t class;
+     /* Back reference assertion. */
+     int backref;
+   } u;
+diff --git a/src/extra/tre/tre-match-approx.c b/src/extra/tre/tre-match-approx.c
+index 6011114..f08cd0f 100644
+--- a/src/extra/tre/tre-match-approx.c
++++ b/src/extra/tre/tre-match-approx.c
+@@ -328,7 +328,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
+   GET_NEXT_WCHAR();
+   pos = 0;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       DPRINT(("%03d:%2lc/%05d\n", pos, (tre_cint_t)next_c, (int)next_c));
+ 
+diff --git a/src/extra/tre/tre-match-backtrack.c b/src/extra/tre/tre-match-backtrack.c
+index 9630e81..9dd7e94 100644
+--- a/src/extra/tre/tre-match-backtrack.c
++++ b/src/extra/tre/tre-match-backtrack.c
+@@ -116,7 +116,7 @@ typedef struct tre_backtrack_struct {
+ #ifdef TRE_USE_ALLOCA
+ #define tre_bt_mem_new		  tre_mem_newa
+ #define tre_bt_mem_alloc	  tre_mem_alloca
+-#define tre_bt_mem_destroy(obj)	  do { } while (0)
++#define tre_bt_mem_destroy(obj)	  do { } while (0,0)
+ #else /* !TRE_USE_ALLOCA */
+ #define tre_bt_mem_new		  tre_mem_new
+ #define tre_bt_mem_alloc	  tre_mem_alloc
+@@ -173,7 +173,7 @@ typedef struct tre_backtrack_struct {
+ 	stack->item.tags[i] = (_tags)[i];				      \
+       BT_STACK_MBSTATE_IN;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define BT_STACK_POP()							      \
+   do									      \
+@@ -186,13 +186,13 @@ typedef struct tre_backtrack_struct {
+       str_byte = stack->item.str_byte;					      \
+       BT_STACK_WIDE_OUT;						      \
+       state = stack->item.state;					      \
+-      next_c = (tre_char_t)stack->item.next_c;					      \
++      next_c = (tre_char_t) stack->item.next_c;					      \
+       for (i = 0; i < tnfa->num_tags; i++)				      \
+ 	tags[i] = stack->item.tags[i];					      \
+       BT_STACK_MBSTATE_OUT;						      \
+       stack = stack->prev;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #undef MIN
+ #define MIN(a, b) ((a) <= (b) ? (a) : (b))
+@@ -372,7 +372,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+   if (state == NULL)
+     goto backtrack;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       tre_tnfa_transition_t *next_state;
+       int empty_br_match;
+@@ -632,7 +632,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+ 		    }
+ 		}
+ 	      DPRINT(("restarting from next start position\n"));
+-	      next_c = (tre_char_t)next_c_start;
++	      next_c = (tre_char_t) next_c_start;
+ #ifdef TRE_MBSTATE
+ 	      mbstate = mbstate_start;
+ #endif /* TRE_MBSTATE */
+diff --git a/src/extra/tre/tre-match-parallel.c b/src/extra/tre/tre-match-parallel.c
+index ddb9fda..6696d11 100644
+--- a/src/extra/tre/tre-match-parallel.c
++++ b/src/extra/tre/tre-match-parallel.c
+@@ -269,7 +269,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
+   DPRINT(("-------------+------------------------------------------------\n"));
+ 
+   reach_next_i = reach_next;
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       /* If no match found yet, add the initial states to `reach_next'. */
+       if (match_eo < 0)
+diff --git a/src/extra/tre/tre-match-utils.h b/src/extra/tre/tre-match-utils.h
+index 7d19c21..d0a4214 100644
+--- a/src/extra/tre/tre-match-utils.h
++++ b/src/extra/tre/tre-match-utils.h
+@@ -76,7 +76,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #else /* !TRE_MULTIBYTE */
+ 
+@@ -107,7 +107,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_MULTIBYTE */
+ 
+@@ -132,7 +132,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+ 						 str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_WCHAR */
+ 
+@@ -161,11 +161,11 @@
+ #define CHECK_CHAR_CLASSES(trans_i, tnfa, eflags)                             \
+   (((trans_i->assertions & ASSERT_CHAR_CLASS)                                 \
+        && !(tnfa->cflags & REG_ICASE)                                         \
+-       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.classt))                \
++       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.class))                 \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS)                             \
+         && (tnfa->cflags & REG_ICASE)                                         \
+-        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.classt)    \
+-	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.classt))       \
++        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.class)     \
++	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.class))    \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS_NEG)                         \
+         && tre_neg_char_classes_match(trans_i->neg_classes,(tre_cint_t)prev_c,\
+                                       tnfa->cflags & REG_ICASE)))
+diff --git a/src/extra/tre/tre-mem.c b/src/extra/tre/tre-mem.c
+index 51b630c..67ba676 100644
+--- a/src/extra/tre/tre-mem.c
++++ b/src/extra/tre/tre-mem.c
+@@ -111,8 +111,8 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
+ 	    block_size = size * 8;
+ 	  else
+ 	    block_size = TRE_MEM_BLOCK_SIZE;
+-	  DPRINT(("tre_mem_alloc: allocating new %u byte block\n",
+-		  (unsigned int)block_size));
++	  DPRINT(("tre_mem_alloc: allocating new %lu byte block\n",
++		  (unsigned long)block_size));
+ 	  l = xmalloc(sizeof(*l));
+ 	  if (l == NULL)
+ 	    {
+diff --git a/src/extra/tre/tre-parse.c b/src/extra/tre/tre-parse.c
+index 50d0438..86ccad6 100644
+--- a/src/extra/tre/tre-parse.c
++++ b/src/extra/tre/tre-parse.c
+@@ -123,23 +123,22 @@ tre_new_item(tre_mem_t mem, int min, int max, int *i, int *max_i,
+ 
+ /* Expands a character class to character ranges. */
+ static reg_errcode_t
+-tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
++tre_expand_ctype(tre_mem_t mem, tre_ctype_t class, tre_ast_node_t ***items,
+ 		 int *i, int *max_i, int cflags)
+ {
+   reg_errcode_t status = REG_OK;
+   tre_cint_t c;
+-  tre_cint_t j;
+-  int min = EMPTY, max = 0;
++  int j, min = -1, max = 0;
+   //assert(TRE_MB_CUR_MAX == 1); It is the ctx->cur_max that matters
+ 
+   DPRINT(("  expanding class to character ranges\n"));
+   for (j = 0; (j < 256) && (status == REG_OK); j++)
+     {
+-      c = j;
+-      if (tre_isctype(c, classt)
++      c = (tre_cint_t) j;
++      if (tre_isctype(c, class)
+ 	  || ((cflags & REG_ICASE)
+-	      && (tre_isctype(tre_tolower(c), classt)
+-		  || tre_isctype(tre_toupper(c), classt))))
++	      && (tre_isctype(tre_tolower(c), class)
++		  || tre_isctype(tre_toupper(c), class))))
+ {
+ 	  if (min < 0)
+ 	    min = c;
+@@ -149,7 +148,7 @@ tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
+ 	{
+ 	  DPRINT(("  range %c (%d) to %c (%d)\n", min, min, max, max));
+ 	  status = tre_new_item(mem, min, max, i, max_i, items);
+-	  min = EMPTY;
++	  min = -1;
+ 	}
+     }
+   if (min >= 0 && status == REG_OK)
+@@ -164,7 +163,7 @@ tre_compare_items(const void *a, const void *b)
+   const tre_ast_node_t *node_a = *(tre_ast_node_t * const *)a;
+   const tre_ast_node_t *node_b = *(tre_ast_node_t * const *)b;
+   tre_literal_t *l_a = node_a->obj, *l_b = node_b->obj;
+-  int a_min = l_a->code_min, b_min = l_b->code_min;
++  long a_min = l_a->code_min, b_min = l_b->code_min;
+ 
+   if (a_min < b_min)
+     return -1;
+@@ -255,7 +254,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ {
+   const tre_char_t *re = ctx->re;
+   reg_errcode_t status = REG_OK;
+-  tre_ctype_t classt = (tre_ctype_t)0;
++  tre_ctype_t class = (tre_ctype_t)0;
+   int i = *num_items;
+   int max_i = *items_size;
+   int skip;
+@@ -278,7 +277,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	{
+ 	  tre_cint_t min = 0, max = 0;
+ 
+-	  classt = (tre_ctype_t)0;
++	  class = (tre_ctype_t)0;
+ 	  if (re + 2 < ctx->re_end
+ 	      && *(re + 1) == CHAR_MINUS && *(re + 2) != CHAR_RBRACKET)
+ 	    {
+@@ -330,15 +329,15 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ #endif /* !TRE_WCHAR */
+ 		  tmp_str[len] = '\0';
+ 		  DPRINT(("  class name: %s\n", tmp_str));
+-		  classt = tre_ctype(tmp_str);
+-		  if (!classt)
++		  class = tre_ctype(tmp_str);
++		  if (!class)
+ 		    status = REG_ECTYPE;
+ 		  /* Optimize character classes for 8 bit character sets. */
+ 		  if (status == REG_OK && ctx->cur_max == 1)
+ 		    {
+-		      status = tre_expand_ctype(ctx->mem, classt, items,
++		      status = tre_expand_ctype(ctx->mem, class, items,
+ 						&i, &max_i, ctx->cflags);
+-		      classt = (tre_ctype_t)0;
++		      class = (tre_ctype_t)0;
+ 		      skip = 1;
+ 		    }
+ 		  re = endptr + 2;
+@@ -361,22 +360,22 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	  if (status != REG_OK)
+ 	    break;
+ 
+-	  if (classt && negate)
++	  if (class && negate)
+ 	    if (*num_neg_classes >= MAX_NEG_CLASSES)
+ 	      status = REG_ESPACE;
+ 	    else
+-	      neg_classes[(*num_neg_classes)++] = classt;
++	      neg_classes[(*num_neg_classes)++] = class;
+ 	  else if (!skip)
+ 	    {
+ 	      status = tre_new_item(ctx->mem, min, max, &i, &max_i, items);
+ 	      if (status != REG_OK)
+ 		break;
+-	      ((tre_literal_t*)((*items)[i-1])->obj)->u.classt = classt;
++	      ((tre_literal_t*)((*items)[i-1])->obj)->u.class = class;
+ 	    }
+ 
+ 	  /* Add opposite-case counterpoints if REG_ICASE is present.
+ 	     This is broken if there are more than two "same" characters. */
+-	  if (ctx->cflags & REG_ICASE && !classt && status == REG_OK && !skip)
++	  if (ctx->cflags & REG_ICASE && !class && status == REG_OK && !skip)
+ 	    {
+ 	      tre_cint_t cmin, ccurr;
+ 
+@@ -455,11 +454,11 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+     {
+       int min, max;
+       tre_literal_t *l = items[j]->obj;
+-      min = l->code_min;
+-      max = l->code_max;
++      min = (int) l->code_min;
++      max = (int) l->code_max;
+ 
+       DPRINT(("item: %d - %d, class %p, curr_max = %d\n",
+-	      (int)l->code_min, (int)l->code_max, (void *)l->u.classt, curr_max));
++	      (int)l->code_min, (int)l->code_max, (void *)l->u.class, curr_max));
+ 
+       if (negate)
+ 	{
+@@ -831,7 +830,7 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+   /* Create the AST node(s). */
+   if (min == 0 && max == 0)
+     {
+-      *result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++      *result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+       if (*result == NULL)
+ 	return REG_ESPACE;
+     }
+@@ -1212,7 +1211,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		  DPRINT(("tre_parse:	extension: '%.*" STRF "\n",
+ 			  REST(ctx->re)));
+ 		  ctx->re += 2;
+-		  while (/*CONSTCOND*/1)
++		  while (/*CONSTCOND*/(void)1,1)
+ 		    {
+ 		      if (*ctx->re == L'i')
+ 			{
+@@ -1352,7 +1351,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		     subexpression was closed.	POSIX leaves the meaning of
+ 		     this to be implementation-defined.	 We interpret this as
+ 		     an empty expression (which matches an empty string).  */
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (result == NULL)
+ 		    return REG_ESPACE;
+ 		  if (!(ctx->cflags & REG_EXTENDED))
+@@ -1645,7 +1644,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		{
+ 		  DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
+ 			  REST(ctx->re)));
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (!result)
+ 		    return REG_ESPACE;
+ 		  break;
+@@ -1715,7 +1714,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 	    if (result->submatch_id >= 0)
+ 	      {
+ 		tre_ast_node_t *n, *tmp_node;
+-		n = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		n = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		if (n == NULL)
+ 		  return REG_ESPACE;
+ 		tmp_node = tre_ast_new_catenation(ctx->mem, n, result);
+diff --git a/src/extra/tre/tre-stack.h b/src/extra/tre/tre-stack.h
+index 7d11c5e..a1acbe7 100644
+--- a/src/extra/tre/tre-stack.h
++++ b/src/extra/tre/tre-stack.h
+@@ -54,7 +54,7 @@ declare_popf(int, int);
+     {									      \
+       status = tre_stack_push_ ## typetag(s, value);			      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define STACK_PUSHX(s, typetag, value)					      \
+   {									      \
+diff --git a/src/extra/tre/tre.h b/src/extra/tre/tre.h
+index 9d7d3a7..128475d 100644
+--- a/src/extra/tre/tre.h
++++ b/src/extra/tre/tre.h
+@@ -137,14 +137,6 @@ extern int
+ tre_regexec(const regex_t *preg, const char *string, size_t nmatch,
+ 	    regmatch_t pmatch[], int eflags);
+ 
+-extern size_t
+-tre_regerror(int errcode, const regex_t *preg, char *errbuf,
+-	     size_t errbuf_size);
+-
+-extern void
+-tre_regfree(regex_t *preg);
+-
+-/* R additions */
+ extern int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags);
+ 
+@@ -152,6 +144,13 @@ extern int
+ tre_regexecb(const regex_t *preg, const char *string, size_t nmatch,
+ 	     regmatch_t pmatch[], int eflags);
+ 
++extern size_t
++tre_regerror(int errcode, const regex_t *preg, char *errbuf,
++	     size_t errbuf_size);
++
++extern void
++tre_regfree(regex_t *preg);
++
+ #ifdef TRE_WCHAR
+ #ifdef HAVE_WCHAR_H
+ #include <wchar.h>
+@@ -223,7 +222,10 @@ extern int
+ tre_regaexec(const regex_t *preg, const char *string,
+ 	     regamatch_t *match, regaparams_t params, int eflags);
+ 
+-/* R addition */
++extern int
++tre_reganexec(const regex_t *preg, const char *string, size_t len,
++	      regamatch_t *match, regaparams_t params, int eflags);
++
+ extern int
+ tre_regaexecb(const regex_t *preg, const char *string,
+ 	      regamatch_t *match, regaparams_t params, int eflags);
+@@ -279,8 +281,7 @@ enum {
+   TRE_CONFIG_WCHAR,
+   TRE_CONFIG_MULTIBYTE,
+   TRE_CONFIG_SYSTEM_ABI,
+-  TRE_CONFIG_VERSION,
+-  TRE_MB_CUR_MAX_VALUE  /* [i_a] - derived from MULTIBYTE and WCHAR, but still handy to have: no need to copy logic in TRE header files, etc. in order to know this */
++  TRE_CONFIG_VERSION
+ };
+ 
+ /* Returns 1 if the compiled pattern has back references, 0 if not. */

--- a/builder/patches/R-3.0.1-aarch64.patch
+++ b/builder/patches/R-3.0.1-aarch64.patch
@@ -1,0 +1,709 @@
+diff --git a/configure b/configure
+index b3c299e..01f205d 100755
+--- a/configure
++++ b/configure
+@@ -5193,6 +5193,7 @@ elif test ${makeinfo_version_maj} -lt 4 \
+ else
+   r_cv_prog_makeinfo_v4=yes
+ fi
++r_cv_prog_makeinfo_v4=yes
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $r_cv_prog_makeinfo_v4" >&5
+ $as_echo "$r_cv_prog_makeinfo_v4" >&6; }
+diff --git a/src/extra/tre/regcomp.c b/src/extra/tre/regcomp.c
+index 93ddb92..31d4e52 100644
+--- a/src/extra/tre/regcomp.c
++++ b/src/extra/tre/regcomp.c
+@@ -99,7 +99,6 @@ tre_regncomp(regex_t *preg, const char *regex, size_t n, int cflags)
+   return ret;
+ }
+ 
+-
+ /* this version takes bytes literally, to be used with raw vectors */
+ int
+ tre_regncompb(regex_t *preg, const char *regex, size_t n, int cflags)
+@@ -131,7 +130,6 @@ tre_regcomp(regex_t *preg, const char *regex, int cflags)
+   return tre_regncomp(preg, regex, regex ? strlen(regex) : 0, cflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags)
+ {
+diff --git a/src/extra/tre/regexec.c b/src/extra/tre/regexec.c
+index 6edaf81..d8f91a3 100644
+--- a/src/extra/tre/regexec.c
++++ b/src/extra/tre/regexec.c
+@@ -217,7 +217,6 @@ tre_regexec(const regex_t *preg, const char *str,
+   return tre_regnexec(preg, str, (unsigned)-1, nmatch, pmatch, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regexecb(const regex_t *preg, const char *str,
+ 	     size_t nmatch, regmatch_t pmatch[], int eflags)
+@@ -329,7 +328,6 @@ tre_regaexec(const regex_t *preg, const char *str,
+   return tre_reganexec(preg, str, (unsigned)-1, match, params, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regaexecb(const regex_t *preg, const char *str,
+ 	  regamatch_t *match, regaparams_t params, int eflags)
+diff --git a/src/extra/tre/tre-ast.h b/src/extra/tre/tre-ast.h
+index 844aee3..d9af376 100644
+--- a/src/extra/tre/tre-ast.h
++++ b/src/extra/tre/tre-ast.h
+@@ -55,16 +55,11 @@ typedef struct {
+    tags, matching parameter settings, and all expressions that match one
+    character. */
+ typedef struct {
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+-  int /* long */ code_min;
+-  int /* long */ code_max;
+-#endif
++  long code_min;
++  long code_max;
+   int position;
+   union {
+-    tre_ctype_t classt; /* [i_a] wrong syntax colouring prevention */
++    tre_ctype_t class;
+     int *params;
+   } u;
+   tre_ctype_t *neg_classes;
+diff --git a/src/extra/tre/tre-compile.c b/src/extra/tre/tre-compile.c
+index 7886455..92c14ab 100644
+--- a/src/extra/tre/tre-compile.c
++++ b/src/extra/tre/tre-compile.c
+@@ -6,6 +6,13 @@
+ 
+ */
+ 
++/*
++  TODO:
++   - Fix tre_ast_to_tnfa() to recurse using a stack instead of recursive
++     function calls.
++*/
++
++
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+@@ -684,8 +691,8 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 	      {
+ 		tre_literal_t *lit = node->obj;
+ 		int pos = lit->position;
+-		int min = lit->code_min;
+-		int max = lit->code_max;
++		int min = (int)lit->code_min;
++		int max = (int)lit->code_max;
+ 		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
+ 		  {
+ 		    /* XXX - e.g. [ab] has only one position but two
+@@ -945,7 +952,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 			  seq2 = copy;
+ 			if (seq2 == NULL)
+ 			  return REG_ESPACE;
+-			tmp = tre_ast_new_literal(mem, EMPTY, EMPTY, -1);
++			tmp = tre_ast_new_literal(mem, EMPTY, -1, -1);
+ 			if (tmp == NULL)
+ 			  return REG_ESPACE;
+ 			seq2 = tre_ast_new_union(mem, tmp, seq2);
+@@ -1052,15 +1059,15 @@ tre_set_empty(tre_mem_t mem)
+     return NULL;
+ 
+   new_set[0].position = -1;
+-  new_set[0].code_min = EMPTY;
+-  new_set[0].code_max = EMPTY;
++  new_set[0].code_min = -1;
++  new_set[0].code_max = -1;
+ 
+   return new_set;
+ }
+ 
+ static tre_pos_and_tags_t *
+ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+-	    tre_ctype_t classt, tre_ctype_t *neg_classes, int backref)
++	    tre_ctype_t class, tre_ctype_t *neg_classes, int backref)
+ {
+   tre_pos_and_tags_t *new_set;
+ 
+@@ -1071,12 +1078,12 @@ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+   new_set[0].position = position;
+   new_set[0].code_min = code_min;
+   new_set[0].code_max = code_max;
+-  new_set[0].classt = classt;
++  new_set[0].class = class;
+   new_set[0].neg_classes = neg_classes;
+   new_set[0].backref = backref;
+   new_set[1].position = -1;
+-  new_set[1].code_min = EMPTY;
+-  new_set[1].code_max = EMPTY;
++  new_set[1].code_min = -1;
++  new_set[1].code_max = -1;
+ 
+   return new_set;
+ }
+@@ -1103,7 +1110,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1].code_min = set1[s1].code_min;
+       new_set[s1].code_max = set1[s1].code_max;
+       new_set[s1].assertions = set1[s1].assertions | assertions;
+-      new_set[s1].classt = set1[s1].classt;
++      new_set[s1].class = set1[s1].class;
+       new_set[s1].neg_classes = set1[s1].neg_classes;
+       new_set[s1].backref = set1[s1].backref;
+       if (set1[s1].tags == NULL && tags == NULL)
+@@ -1148,7 +1155,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1 + s2].code_max = set2[s2].code_max;
+       /* XXX - why not | assertions here as well? */
+       new_set[s1 + s2].assertions = set2[s2].assertions;
+-      new_set[s1 + s2].classt = set2[s2].classt;
++      new_set[s1 + s2].class = set2[s2].class;
+       new_set[s1 + s2].neg_classes = set2[s2].neg_classes;
+       new_set[s1 + s2].backref = set2[s2].backref;
+       if (set2[s2].tags == NULL)
+@@ -1231,7 +1238,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
+ 			  break;
+ 		      if (tags[i] < 0)
+ 			{
+-			  tags[i] = lit->code_max;
++			  tags[i] = (int)lit->code_max;
+ 			  tags[i + 1] = -1;
+ 			}
+ 		    }
+@@ -1373,7 +1380,7 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
+ 		    node->lastpos = tre_set_one(mem, lit->position,
+ 						(int)lit->code_min,
+ 						(int)lit->code_max,
+-						lit->u.classt, lit->neg_classes,
++						lit->u.class, lit->neg_classes,
+ 						-1);
+ 		    if (!node->lastpos)
+ 		      return REG_ESPACE;
+@@ -1614,12 +1621,12 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 	      (trans + 1)->state = NULL;
+ 	    /* Use the character ranges, assertions, etc. from `p1' for
+ 	       the transition from `p1' to `p2'. */
+-	    trans->code_min = p1->code_min;
+-	    trans->code_max = p1->code_max;
++	    trans->code_min = (tre_cint_t) p1->code_min;
++	    trans->code_max = (tre_cint_t) p1->code_max;
+ 	    trans->state = transitions + offs[p2->position];
+ 	    trans->state_id = p2->position;
+ 	    trans->assertions = p1->assertions | p2->assertions
+-	      | (p1->classt ? ASSERT_CHAR_CLASS : 0)
++	      | (p1->class ? ASSERT_CHAR_CLASS : 0)
+ 	      | (p1->neg_classes != NULL ? ASSERT_CHAR_CLASS_NEG : 0);
+ 	    if (p1->backref >= 0)
+ 	      {
+@@ -1629,7 +1636,7 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		trans->assertions |= ASSERT_BACKREF;
+ 	      }
+ 	    else
+-	      trans->u.classt = p1->classt;
++	      trans->u.class = p1->class;
+ 	    if (p1->neg_classes != NULL)
+ 	      {
+ 		for (i = 0; p1->neg_classes[i] != (tre_ctype_t)0; i++);
+@@ -1743,8 +1750,8 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		DPRINT((", assert %d", trans->assertions));
+ 	      if (trans->assertions & ASSERT_BACKREF)
+ 		DPRINT((", backref %d", trans->u.backref));
+-	      else if (trans->u.classt)
+-		DPRINT((", class %ld", (long)trans->u.classt));
++	      else if (trans->u.class)
++		DPRINT((", class %ld", (long)trans->u.class));
+ 	      if (trans->neg_classes)
+ 		DPRINT((", neg_classes %p", trans->neg_classes));
+ 	      if (trans->params)
+@@ -1861,10 +1868,10 @@ tre_ast_to_tnfa(tre_ast_node_t *node, tre_tnfa_transition_t *transitions,
+   do				  \
+     {				  \
+       errcode = err;		  \
+-      if (/*CONSTCOND*/1)	  \
++      if (/*CONSTCOND*/(void)1,1)	  \
+       	goto error_exit;	  \
+     }				  \
+- while (/*CONSTCOND*/0)
++ while (/*CONSTCOND*/(void)0,0)
+ 
+ 
+ int
+@@ -2050,7 +2057,7 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
+   if (TRE_MB_CUR_MAX == 1 && !tmp_ast_l->nullable)
+     {
+       int count = 0;
+-      int k; /* [i_a] */
++      tre_cint_t k;
+       DPRINT(("Characters that can start a match:"));
+       tnfa->firstpos_chars = xcalloc(256, sizeof(char));
+       if (tnfa->firstpos_chars == NULL)
+@@ -2310,15 +2317,7 @@ tre_config(int query, void *result)
+     case TRE_CONFIG_VERSION:
+       *string_result = TRE_VERSION;
+       return REG_OK;
+-
+-	case TRE_MB_CUR_MAX_VALUE:  /* [i_a] */
+-#if defined(TRE_MB_CUR_MAX)
+-		*int_result = TRE_MB_CUR_MAX;
+-#else
+-		*int_result = 1;
+-#endif
+-		break;
+-  }
++    }
+ 
+   return REG_NOMATCH;
+ }
+diff --git a/src/extra/tre/tre-compile.h b/src/extra/tre/tre-compile.h
+index 0d81cf2..51d5ac9 100644
+--- a/src/extra/tre/tre-compile.h
++++ b/src/extra/tre/tre-compile.h
+@@ -12,16 +12,11 @@
+ 
+ typedef struct {
+   int position;
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+   int code_min;
+   int code_max;
+-#endif
+   int *tags;
+   int assertions;
+-  tre_ctype_t classt;
++  tre_ctype_t class;
+   tre_ctype_t *neg_classes;
+   int backref;
+   int *params;
+diff --git a/src/extra/tre/tre-internal.h b/src/extra/tre/tre-internal.h
+index c1300ac..822998e 100644
+--- a/src/extra/tre/tre-internal.h
++++ b/src/extra/tre/tre-internal.h
+@@ -22,9 +22,9 @@
+ 
+ #ifdef TRE_DEBUG
+ #include <stdio.h>
+-#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/0)
++#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/(void)0,0)
+ #else /* !TRE_DEBUG */
+-#define DPRINT(msg) do { } while(/*CONSTCOND*/0)
++#define DPRINT(msg) do { } while(/*CONSTCOND*/(void)0,0)
+ #endif /* !TRE_DEBUG */
+ 
+ #define elementsof(x)	( sizeof(x) / sizeof(x[0]) )
+@@ -151,13 +151,8 @@ typedef struct tnfa_transition tre_tnfa_transition_t;
+ 
+ struct tnfa_transition {
+   /* Range of accepted characters. */
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+   tre_cint_t code_min;
+   tre_cint_t code_max;
+-#else
+-  int code_min;
+-  int code_max;
+-#endif
+   /* Pointer to the destination state. */
+   tre_tnfa_transition_t *state;
+   /* ID number of the destination state. */
+@@ -171,7 +166,7 @@ struct tnfa_transition {
+   /* Assertion parameters. */
+   union {
+     /* Character class assertion. */
+-    tre_ctype_t classt;
++    tre_ctype_t class;
+     /* Back reference assertion. */
+     int backref;
+   } u;
+diff --git a/src/extra/tre/tre-match-approx.c b/src/extra/tre/tre-match-approx.c
+index 6011114..f08cd0f 100644
+--- a/src/extra/tre/tre-match-approx.c
++++ b/src/extra/tre/tre-match-approx.c
+@@ -328,7 +328,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
+   GET_NEXT_WCHAR();
+   pos = 0;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       DPRINT(("%03d:%2lc/%05d\n", pos, (tre_cint_t)next_c, (int)next_c));
+ 
+diff --git a/src/extra/tre/tre-match-backtrack.c b/src/extra/tre/tre-match-backtrack.c
+index 9630e81..9dd7e94 100644
+--- a/src/extra/tre/tre-match-backtrack.c
++++ b/src/extra/tre/tre-match-backtrack.c
+@@ -116,7 +116,7 @@ typedef struct tre_backtrack_struct {
+ #ifdef TRE_USE_ALLOCA
+ #define tre_bt_mem_new		  tre_mem_newa
+ #define tre_bt_mem_alloc	  tre_mem_alloca
+-#define tre_bt_mem_destroy(obj)	  do { } while (0)
++#define tre_bt_mem_destroy(obj)	  do { } while (0,0)
+ #else /* !TRE_USE_ALLOCA */
+ #define tre_bt_mem_new		  tre_mem_new
+ #define tre_bt_mem_alloc	  tre_mem_alloc
+@@ -173,7 +173,7 @@ typedef struct tre_backtrack_struct {
+ 	stack->item.tags[i] = (_tags)[i];				      \
+       BT_STACK_MBSTATE_IN;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define BT_STACK_POP()							      \
+   do									      \
+@@ -186,13 +186,13 @@ typedef struct tre_backtrack_struct {
+       str_byte = stack->item.str_byte;					      \
+       BT_STACK_WIDE_OUT;						      \
+       state = stack->item.state;					      \
+-      next_c = (tre_char_t)stack->item.next_c;					      \
++      next_c = (tre_char_t) stack->item.next_c;					      \
+       for (i = 0; i < tnfa->num_tags; i++)				      \
+ 	tags[i] = stack->item.tags[i];					      \
+       BT_STACK_MBSTATE_OUT;						      \
+       stack = stack->prev;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #undef MIN
+ #define MIN(a, b) ((a) <= (b) ? (a) : (b))
+@@ -372,7 +372,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+   if (state == NULL)
+     goto backtrack;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       tre_tnfa_transition_t *next_state;
+       int empty_br_match;
+@@ -632,7 +632,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+ 		    }
+ 		}
+ 	      DPRINT(("restarting from next start position\n"));
+-	      next_c = (tre_char_t)next_c_start;
++	      next_c = (tre_char_t) next_c_start;
+ #ifdef TRE_MBSTATE
+ 	      mbstate = mbstate_start;
+ #endif /* TRE_MBSTATE */
+diff --git a/src/extra/tre/tre-match-parallel.c b/src/extra/tre/tre-match-parallel.c
+index ddb9fda..6696d11 100644
+--- a/src/extra/tre/tre-match-parallel.c
++++ b/src/extra/tre/tre-match-parallel.c
+@@ -269,7 +269,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
+   DPRINT(("-------------+------------------------------------------------\n"));
+ 
+   reach_next_i = reach_next;
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       /* If no match found yet, add the initial states to `reach_next'. */
+       if (match_eo < 0)
+diff --git a/src/extra/tre/tre-match-utils.h b/src/extra/tre/tre-match-utils.h
+index 7d19c21..d0a4214 100644
+--- a/src/extra/tre/tre-match-utils.h
++++ b/src/extra/tre/tre-match-utils.h
+@@ -76,7 +76,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #else /* !TRE_MULTIBYTE */
+ 
+@@ -107,7 +107,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_MULTIBYTE */
+ 
+@@ -132,7 +132,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+ 						 str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_WCHAR */
+ 
+@@ -161,11 +161,11 @@
+ #define CHECK_CHAR_CLASSES(trans_i, tnfa, eflags)                             \
+   (((trans_i->assertions & ASSERT_CHAR_CLASS)                                 \
+        && !(tnfa->cflags & REG_ICASE)                                         \
+-       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.classt))                \
++       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.class))                 \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS)                             \
+         && (tnfa->cflags & REG_ICASE)                                         \
+-        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.classt)    \
+-	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.classt))       \
++        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.class)     \
++	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.class))    \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS_NEG)                         \
+         && tre_neg_char_classes_match(trans_i->neg_classes,(tre_cint_t)prev_c,\
+                                       tnfa->cflags & REG_ICASE)))
+diff --git a/src/extra/tre/tre-mem.c b/src/extra/tre/tre-mem.c
+index 51b630c..67ba676 100644
+--- a/src/extra/tre/tre-mem.c
++++ b/src/extra/tre/tre-mem.c
+@@ -111,8 +111,8 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
+ 	    block_size = size * 8;
+ 	  else
+ 	    block_size = TRE_MEM_BLOCK_SIZE;
+-	  DPRINT(("tre_mem_alloc: allocating new %u byte block\n",
+-		  (unsigned int)block_size));
++	  DPRINT(("tre_mem_alloc: allocating new %lu byte block\n",
++		  (unsigned long)block_size));
+ 	  l = xmalloc(sizeof(*l));
+ 	  if (l == NULL)
+ 	    {
+diff --git a/src/extra/tre/tre-parse.c b/src/extra/tre/tre-parse.c
+index 50d0438..86ccad6 100644
+--- a/src/extra/tre/tre-parse.c
++++ b/src/extra/tre/tre-parse.c
+@@ -123,23 +123,22 @@ tre_new_item(tre_mem_t mem, int min, int max, int *i, int *max_i,
+ 
+ /* Expands a character class to character ranges. */
+ static reg_errcode_t
+-tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
++tre_expand_ctype(tre_mem_t mem, tre_ctype_t class, tre_ast_node_t ***items,
+ 		 int *i, int *max_i, int cflags)
+ {
+   reg_errcode_t status = REG_OK;
+   tre_cint_t c;
+-  tre_cint_t j;
+-  int min = EMPTY, max = 0;
++  int j, min = -1, max = 0;
+   //assert(TRE_MB_CUR_MAX == 1); It is the ctx->cur_max that matters
+ 
+   DPRINT(("  expanding class to character ranges\n"));
+   for (j = 0; (j < 256) && (status == REG_OK); j++)
+     {
+-      c = j;
+-      if (tre_isctype(c, classt)
++      c = (tre_cint_t) j;
++      if (tre_isctype(c, class)
+ 	  || ((cflags & REG_ICASE)
+-	      && (tre_isctype(tre_tolower(c), classt)
+-		  || tre_isctype(tre_toupper(c), classt))))
++	      && (tre_isctype(tre_tolower(c), class)
++		  || tre_isctype(tre_toupper(c), class))))
+ {
+ 	  if (min < 0)
+ 	    min = c;
+@@ -149,7 +148,7 @@ tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
+ 	{
+ 	  DPRINT(("  range %c (%d) to %c (%d)\n", min, min, max, max));
+ 	  status = tre_new_item(mem, min, max, i, max_i, items);
+-	  min = EMPTY;
++	  min = -1;
+ 	}
+     }
+   if (min >= 0 && status == REG_OK)
+@@ -164,7 +163,7 @@ tre_compare_items(const void *a, const void *b)
+   const tre_ast_node_t *node_a = *(tre_ast_node_t * const *)a;
+   const tre_ast_node_t *node_b = *(tre_ast_node_t * const *)b;
+   tre_literal_t *l_a = node_a->obj, *l_b = node_b->obj;
+-  int a_min = l_a->code_min, b_min = l_b->code_min;
++  long a_min = l_a->code_min, b_min = l_b->code_min;
+ 
+   if (a_min < b_min)
+     return -1;
+@@ -255,7 +254,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ {
+   const tre_char_t *re = ctx->re;
+   reg_errcode_t status = REG_OK;
+-  tre_ctype_t classt = (tre_ctype_t)0;
++  tre_ctype_t class = (tre_ctype_t)0;
+   int i = *num_items;
+   int max_i = *items_size;
+   int skip;
+@@ -278,7 +277,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	{
+ 	  tre_cint_t min = 0, max = 0;
+ 
+-	  classt = (tre_ctype_t)0;
++	  class = (tre_ctype_t)0;
+ 	  if (re + 2 < ctx->re_end
+ 	      && *(re + 1) == CHAR_MINUS && *(re + 2) != CHAR_RBRACKET)
+ 	    {
+@@ -330,15 +329,15 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ #endif /* !TRE_WCHAR */
+ 		  tmp_str[len] = '\0';
+ 		  DPRINT(("  class name: %s\n", tmp_str));
+-		  classt = tre_ctype(tmp_str);
+-		  if (!classt)
++		  class = tre_ctype(tmp_str);
++		  if (!class)
+ 		    status = REG_ECTYPE;
+ 		  /* Optimize character classes for 8 bit character sets. */
+ 		  if (status == REG_OK && ctx->cur_max == 1)
+ 		    {
+-		      status = tre_expand_ctype(ctx->mem, classt, items,
++		      status = tre_expand_ctype(ctx->mem, class, items,
+ 						&i, &max_i, ctx->cflags);
+-		      classt = (tre_ctype_t)0;
++		      class = (tre_ctype_t)0;
+ 		      skip = 1;
+ 		    }
+ 		  re = endptr + 2;
+@@ -361,22 +360,22 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	  if (status != REG_OK)
+ 	    break;
+ 
+-	  if (classt && negate)
++	  if (class && negate)
+ 	    if (*num_neg_classes >= MAX_NEG_CLASSES)
+ 	      status = REG_ESPACE;
+ 	    else
+-	      neg_classes[(*num_neg_classes)++] = classt;
++	      neg_classes[(*num_neg_classes)++] = class;
+ 	  else if (!skip)
+ 	    {
+ 	      status = tre_new_item(ctx->mem, min, max, &i, &max_i, items);
+ 	      if (status != REG_OK)
+ 		break;
+-	      ((tre_literal_t*)((*items)[i-1])->obj)->u.classt = classt;
++	      ((tre_literal_t*)((*items)[i-1])->obj)->u.class = class;
+ 	    }
+ 
+ 	  /* Add opposite-case counterpoints if REG_ICASE is present.
+ 	     This is broken if there are more than two "same" characters. */
+-	  if (ctx->cflags & REG_ICASE && !classt && status == REG_OK && !skip)
++	  if (ctx->cflags & REG_ICASE && !class && status == REG_OK && !skip)
+ 	    {
+ 	      tre_cint_t cmin, ccurr;
+ 
+@@ -455,11 +454,11 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+     {
+       int min, max;
+       tre_literal_t *l = items[j]->obj;
+-      min = l->code_min;
+-      max = l->code_max;
++      min = (int) l->code_min;
++      max = (int) l->code_max;
+ 
+       DPRINT(("item: %d - %d, class %p, curr_max = %d\n",
+-	      (int)l->code_min, (int)l->code_max, (void *)l->u.classt, curr_max));
++	      (int)l->code_min, (int)l->code_max, (void *)l->u.class, curr_max));
+ 
+       if (negate)
+ 	{
+@@ -831,7 +830,7 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+   /* Create the AST node(s). */
+   if (min == 0 && max == 0)
+     {
+-      *result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++      *result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+       if (*result == NULL)
+ 	return REG_ESPACE;
+     }
+@@ -1212,7 +1211,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		  DPRINT(("tre_parse:	extension: '%.*" STRF "\n",
+ 			  REST(ctx->re)));
+ 		  ctx->re += 2;
+-		  while (/*CONSTCOND*/1)
++		  while (/*CONSTCOND*/(void)1,1)
+ 		    {
+ 		      if (*ctx->re == L'i')
+ 			{
+@@ -1352,7 +1351,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		     subexpression was closed.	POSIX leaves the meaning of
+ 		     this to be implementation-defined.	 We interpret this as
+ 		     an empty expression (which matches an empty string).  */
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (result == NULL)
+ 		    return REG_ESPACE;
+ 		  if (!(ctx->cflags & REG_EXTENDED))
+@@ -1645,7 +1644,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		{
+ 		  DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
+ 			  REST(ctx->re)));
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (!result)
+ 		    return REG_ESPACE;
+ 		  break;
+@@ -1715,7 +1714,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 	    if (result->submatch_id >= 0)
+ 	      {
+ 		tre_ast_node_t *n, *tmp_node;
+-		n = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		n = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		if (n == NULL)
+ 		  return REG_ESPACE;
+ 		tmp_node = tre_ast_new_catenation(ctx->mem, n, result);
+diff --git a/src/extra/tre/tre-stack.h b/src/extra/tre/tre-stack.h
+index 7d11c5e..a1acbe7 100644
+--- a/src/extra/tre/tre-stack.h
++++ b/src/extra/tre/tre-stack.h
+@@ -54,7 +54,7 @@ declare_popf(int, int);
+     {									      \
+       status = tre_stack_push_ ## typetag(s, value);			      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define STACK_PUSHX(s, typetag, value)					      \
+   {									      \
+diff --git a/src/extra/tre/tre.h b/src/extra/tre/tre.h
+index 9d7d3a7..128475d 100644
+--- a/src/extra/tre/tre.h
++++ b/src/extra/tre/tre.h
+@@ -137,14 +137,6 @@ extern int
+ tre_regexec(const regex_t *preg, const char *string, size_t nmatch,
+ 	    regmatch_t pmatch[], int eflags);
+ 
+-extern size_t
+-tre_regerror(int errcode, const regex_t *preg, char *errbuf,
+-	     size_t errbuf_size);
+-
+-extern void
+-tre_regfree(regex_t *preg);
+-
+-/* R additions */
+ extern int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags);
+ 
+@@ -152,6 +144,13 @@ extern int
+ tre_regexecb(const regex_t *preg, const char *string, size_t nmatch,
+ 	     regmatch_t pmatch[], int eflags);
+ 
++extern size_t
++tre_regerror(int errcode, const regex_t *preg, char *errbuf,
++	     size_t errbuf_size);
++
++extern void
++tre_regfree(regex_t *preg);
++
+ #ifdef TRE_WCHAR
+ #ifdef HAVE_WCHAR_H
+ #include <wchar.h>
+@@ -223,7 +222,10 @@ extern int
+ tre_regaexec(const regex_t *preg, const char *string,
+ 	     regamatch_t *match, regaparams_t params, int eflags);
+ 
+-/* R addition */
++extern int
++tre_reganexec(const regex_t *preg, const char *string, size_t len,
++	      regamatch_t *match, regaparams_t params, int eflags);
++
+ extern int
+ tre_regaexecb(const regex_t *preg, const char *string,
+ 	      regamatch_t *match, regaparams_t params, int eflags);
+@@ -279,8 +281,7 @@ enum {
+   TRE_CONFIG_WCHAR,
+   TRE_CONFIG_MULTIBYTE,
+   TRE_CONFIG_SYSTEM_ABI,
+-  TRE_CONFIG_VERSION,
+-  TRE_MB_CUR_MAX_VALUE  /* [i_a] - derived from MULTIBYTE and WCHAR, but still handy to have: no need to copy logic in TRE header files, etc. in order to know this */
++  TRE_CONFIG_VERSION
+ };
+ 
+ /* Returns 1 if the compiled pattern has back references, 0 if not. */

--- a/builder/patches/R-3.0.2-aarch64.patch
+++ b/builder/patches/R-3.0.2-aarch64.patch
@@ -1,0 +1,709 @@
+diff --git a/configure b/configure
+index b3c299e..01f205d 100755
+--- a/configure
++++ b/configure
+@@ -5193,6 +5193,7 @@ elif test ${makeinfo_version_maj} -lt 4 \
+ else
+   r_cv_prog_makeinfo_v4=yes
+ fi
++r_cv_prog_makeinfo_v4=yes
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $r_cv_prog_makeinfo_v4" >&5
+ $as_echo "$r_cv_prog_makeinfo_v4" >&6; }
+diff --git a/src/extra/tre/regcomp.c b/src/extra/tre/regcomp.c
+index 93ddb92..31d4e52 100644
+--- a/src/extra/tre/regcomp.c
++++ b/src/extra/tre/regcomp.c
+@@ -99,7 +99,6 @@ tre_regncomp(regex_t *preg, const char *regex, size_t n, int cflags)
+   return ret;
+ }
+ 
+-
+ /* this version takes bytes literally, to be used with raw vectors */
+ int
+ tre_regncompb(regex_t *preg, const char *regex, size_t n, int cflags)
+@@ -131,7 +130,6 @@ tre_regcomp(regex_t *preg, const char *regex, int cflags)
+   return tre_regncomp(preg, regex, regex ? strlen(regex) : 0, cflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags)
+ {
+diff --git a/src/extra/tre/regexec.c b/src/extra/tre/regexec.c
+index 6edaf81..d8f91a3 100644
+--- a/src/extra/tre/regexec.c
++++ b/src/extra/tre/regexec.c
+@@ -217,7 +217,6 @@ tre_regexec(const regex_t *preg, const char *str,
+   return tre_regnexec(preg, str, (unsigned)-1, nmatch, pmatch, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regexecb(const regex_t *preg, const char *str,
+ 	     size_t nmatch, regmatch_t pmatch[], int eflags)
+@@ -329,7 +328,6 @@ tre_regaexec(const regex_t *preg, const char *str,
+   return tre_reganexec(preg, str, (unsigned)-1, match, params, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regaexecb(const regex_t *preg, const char *str,
+ 	  regamatch_t *match, regaparams_t params, int eflags)
+diff --git a/src/extra/tre/tre-ast.h b/src/extra/tre/tre-ast.h
+index 844aee3..d9af376 100644
+--- a/src/extra/tre/tre-ast.h
++++ b/src/extra/tre/tre-ast.h
+@@ -55,16 +55,11 @@ typedef struct {
+    tags, matching parameter settings, and all expressions that match one
+    character. */
+ typedef struct {
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+-  int /* long */ code_min;
+-  int /* long */ code_max;
+-#endif
++  long code_min;
++  long code_max;
+   int position;
+   union {
+-    tre_ctype_t classt; /* [i_a] wrong syntax colouring prevention */
++    tre_ctype_t class;
+     int *params;
+   } u;
+   tre_ctype_t *neg_classes;
+diff --git a/src/extra/tre/tre-compile.c b/src/extra/tre/tre-compile.c
+index 7886455..92c14ab 100644
+--- a/src/extra/tre/tre-compile.c
++++ b/src/extra/tre/tre-compile.c
+@@ -6,6 +6,13 @@
+ 
+ */
+ 
++/*
++  TODO:
++   - Fix tre_ast_to_tnfa() to recurse using a stack instead of recursive
++     function calls.
++*/
++
++
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+@@ -684,8 +691,8 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 	      {
+ 		tre_literal_t *lit = node->obj;
+ 		int pos = lit->position;
+-		int min = lit->code_min;
+-		int max = lit->code_max;
++		int min = (int)lit->code_min;
++		int max = (int)lit->code_max;
+ 		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
+ 		  {
+ 		    /* XXX - e.g. [ab] has only one position but two
+@@ -945,7 +952,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 			  seq2 = copy;
+ 			if (seq2 == NULL)
+ 			  return REG_ESPACE;
+-			tmp = tre_ast_new_literal(mem, EMPTY, EMPTY, -1);
++			tmp = tre_ast_new_literal(mem, EMPTY, -1, -1);
+ 			if (tmp == NULL)
+ 			  return REG_ESPACE;
+ 			seq2 = tre_ast_new_union(mem, tmp, seq2);
+@@ -1052,15 +1059,15 @@ tre_set_empty(tre_mem_t mem)
+     return NULL;
+ 
+   new_set[0].position = -1;
+-  new_set[0].code_min = EMPTY;
+-  new_set[0].code_max = EMPTY;
++  new_set[0].code_min = -1;
++  new_set[0].code_max = -1;
+ 
+   return new_set;
+ }
+ 
+ static tre_pos_and_tags_t *
+ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+-	    tre_ctype_t classt, tre_ctype_t *neg_classes, int backref)
++	    tre_ctype_t class, tre_ctype_t *neg_classes, int backref)
+ {
+   tre_pos_and_tags_t *new_set;
+ 
+@@ -1071,12 +1078,12 @@ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+   new_set[0].position = position;
+   new_set[0].code_min = code_min;
+   new_set[0].code_max = code_max;
+-  new_set[0].classt = classt;
++  new_set[0].class = class;
+   new_set[0].neg_classes = neg_classes;
+   new_set[0].backref = backref;
+   new_set[1].position = -1;
+-  new_set[1].code_min = EMPTY;
+-  new_set[1].code_max = EMPTY;
++  new_set[1].code_min = -1;
++  new_set[1].code_max = -1;
+ 
+   return new_set;
+ }
+@@ -1103,7 +1110,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1].code_min = set1[s1].code_min;
+       new_set[s1].code_max = set1[s1].code_max;
+       new_set[s1].assertions = set1[s1].assertions | assertions;
+-      new_set[s1].classt = set1[s1].classt;
++      new_set[s1].class = set1[s1].class;
+       new_set[s1].neg_classes = set1[s1].neg_classes;
+       new_set[s1].backref = set1[s1].backref;
+       if (set1[s1].tags == NULL && tags == NULL)
+@@ -1148,7 +1155,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1 + s2].code_max = set2[s2].code_max;
+       /* XXX - why not | assertions here as well? */
+       new_set[s1 + s2].assertions = set2[s2].assertions;
+-      new_set[s1 + s2].classt = set2[s2].classt;
++      new_set[s1 + s2].class = set2[s2].class;
+       new_set[s1 + s2].neg_classes = set2[s2].neg_classes;
+       new_set[s1 + s2].backref = set2[s2].backref;
+       if (set2[s2].tags == NULL)
+@@ -1231,7 +1238,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
+ 			  break;
+ 		      if (tags[i] < 0)
+ 			{
+-			  tags[i] = lit->code_max;
++			  tags[i] = (int)lit->code_max;
+ 			  tags[i + 1] = -1;
+ 			}
+ 		    }
+@@ -1373,7 +1380,7 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
+ 		    node->lastpos = tre_set_one(mem, lit->position,
+ 						(int)lit->code_min,
+ 						(int)lit->code_max,
+-						lit->u.classt, lit->neg_classes,
++						lit->u.class, lit->neg_classes,
+ 						-1);
+ 		    if (!node->lastpos)
+ 		      return REG_ESPACE;
+@@ -1614,12 +1621,12 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 	      (trans + 1)->state = NULL;
+ 	    /* Use the character ranges, assertions, etc. from `p1' for
+ 	       the transition from `p1' to `p2'. */
+-	    trans->code_min = p1->code_min;
+-	    trans->code_max = p1->code_max;
++	    trans->code_min = (tre_cint_t) p1->code_min;
++	    trans->code_max = (tre_cint_t) p1->code_max;
+ 	    trans->state = transitions + offs[p2->position];
+ 	    trans->state_id = p2->position;
+ 	    trans->assertions = p1->assertions | p2->assertions
+-	      | (p1->classt ? ASSERT_CHAR_CLASS : 0)
++	      | (p1->class ? ASSERT_CHAR_CLASS : 0)
+ 	      | (p1->neg_classes != NULL ? ASSERT_CHAR_CLASS_NEG : 0);
+ 	    if (p1->backref >= 0)
+ 	      {
+@@ -1629,7 +1636,7 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		trans->assertions |= ASSERT_BACKREF;
+ 	      }
+ 	    else
+-	      trans->u.classt = p1->classt;
++	      trans->u.class = p1->class;
+ 	    if (p1->neg_classes != NULL)
+ 	      {
+ 		for (i = 0; p1->neg_classes[i] != (tre_ctype_t)0; i++);
+@@ -1743,8 +1750,8 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		DPRINT((", assert %d", trans->assertions));
+ 	      if (trans->assertions & ASSERT_BACKREF)
+ 		DPRINT((", backref %d", trans->u.backref));
+-	      else if (trans->u.classt)
+-		DPRINT((", class %ld", (long)trans->u.classt));
++	      else if (trans->u.class)
++		DPRINT((", class %ld", (long)trans->u.class));
+ 	      if (trans->neg_classes)
+ 		DPRINT((", neg_classes %p", trans->neg_classes));
+ 	      if (trans->params)
+@@ -1861,10 +1868,10 @@ tre_ast_to_tnfa(tre_ast_node_t *node, tre_tnfa_transition_t *transitions,
+   do				  \
+     {				  \
+       errcode = err;		  \
+-      if (/*CONSTCOND*/1)	  \
++      if (/*CONSTCOND*/(void)1,1)	  \
+       	goto error_exit;	  \
+     }				  \
+- while (/*CONSTCOND*/0)
++ while (/*CONSTCOND*/(void)0,0)
+ 
+ 
+ int
+@@ -2050,7 +2057,7 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
+   if (TRE_MB_CUR_MAX == 1 && !tmp_ast_l->nullable)
+     {
+       int count = 0;
+-      int k; /* [i_a] */
++      tre_cint_t k;
+       DPRINT(("Characters that can start a match:"));
+       tnfa->firstpos_chars = xcalloc(256, sizeof(char));
+       if (tnfa->firstpos_chars == NULL)
+@@ -2310,15 +2317,7 @@ tre_config(int query, void *result)
+     case TRE_CONFIG_VERSION:
+       *string_result = TRE_VERSION;
+       return REG_OK;
+-
+-	case TRE_MB_CUR_MAX_VALUE:  /* [i_a] */
+-#if defined(TRE_MB_CUR_MAX)
+-		*int_result = TRE_MB_CUR_MAX;
+-#else
+-		*int_result = 1;
+-#endif
+-		break;
+-  }
++    }
+ 
+   return REG_NOMATCH;
+ }
+diff --git a/src/extra/tre/tre-compile.h b/src/extra/tre/tre-compile.h
+index 0d81cf2..51d5ac9 100644
+--- a/src/extra/tre/tre-compile.h
++++ b/src/extra/tre/tre-compile.h
+@@ -12,16 +12,11 @@
+ 
+ typedef struct {
+   int position;
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+   int code_min;
+   int code_max;
+-#endif
+   int *tags;
+   int assertions;
+-  tre_ctype_t classt;
++  tre_ctype_t class;
+   tre_ctype_t *neg_classes;
+   int backref;
+   int *params;
+diff --git a/src/extra/tre/tre-internal.h b/src/extra/tre/tre-internal.h
+index c1300ac..822998e 100644
+--- a/src/extra/tre/tre-internal.h
++++ b/src/extra/tre/tre-internal.h
+@@ -22,9 +22,9 @@
+ 
+ #ifdef TRE_DEBUG
+ #include <stdio.h>
+-#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/0)
++#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/(void)0,0)
+ #else /* !TRE_DEBUG */
+-#define DPRINT(msg) do { } while(/*CONSTCOND*/0)
++#define DPRINT(msg) do { } while(/*CONSTCOND*/(void)0,0)
+ #endif /* !TRE_DEBUG */
+ 
+ #define elementsof(x)	( sizeof(x) / sizeof(x[0]) )
+@@ -151,13 +151,8 @@ typedef struct tnfa_transition tre_tnfa_transition_t;
+ 
+ struct tnfa_transition {
+   /* Range of accepted characters. */
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+   tre_cint_t code_min;
+   tre_cint_t code_max;
+-#else
+-  int code_min;
+-  int code_max;
+-#endif
+   /* Pointer to the destination state. */
+   tre_tnfa_transition_t *state;
+   /* ID number of the destination state. */
+@@ -171,7 +166,7 @@ struct tnfa_transition {
+   /* Assertion parameters. */
+   union {
+     /* Character class assertion. */
+-    tre_ctype_t classt;
++    tre_ctype_t class;
+     /* Back reference assertion. */
+     int backref;
+   } u;
+diff --git a/src/extra/tre/tre-match-approx.c b/src/extra/tre/tre-match-approx.c
+index 6011114..f08cd0f 100644
+--- a/src/extra/tre/tre-match-approx.c
++++ b/src/extra/tre/tre-match-approx.c
+@@ -328,7 +328,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
+   GET_NEXT_WCHAR();
+   pos = 0;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       DPRINT(("%03d:%2lc/%05d\n", pos, (tre_cint_t)next_c, (int)next_c));
+ 
+diff --git a/src/extra/tre/tre-match-backtrack.c b/src/extra/tre/tre-match-backtrack.c
+index 9630e81..9dd7e94 100644
+--- a/src/extra/tre/tre-match-backtrack.c
++++ b/src/extra/tre/tre-match-backtrack.c
+@@ -116,7 +116,7 @@ typedef struct tre_backtrack_struct {
+ #ifdef TRE_USE_ALLOCA
+ #define tre_bt_mem_new		  tre_mem_newa
+ #define tre_bt_mem_alloc	  tre_mem_alloca
+-#define tre_bt_mem_destroy(obj)	  do { } while (0)
++#define tre_bt_mem_destroy(obj)	  do { } while (0,0)
+ #else /* !TRE_USE_ALLOCA */
+ #define tre_bt_mem_new		  tre_mem_new
+ #define tre_bt_mem_alloc	  tre_mem_alloc
+@@ -173,7 +173,7 @@ typedef struct tre_backtrack_struct {
+ 	stack->item.tags[i] = (_tags)[i];				      \
+       BT_STACK_MBSTATE_IN;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define BT_STACK_POP()							      \
+   do									      \
+@@ -186,13 +186,13 @@ typedef struct tre_backtrack_struct {
+       str_byte = stack->item.str_byte;					      \
+       BT_STACK_WIDE_OUT;						      \
+       state = stack->item.state;					      \
+-      next_c = (tre_char_t)stack->item.next_c;					      \
++      next_c = (tre_char_t) stack->item.next_c;					      \
+       for (i = 0; i < tnfa->num_tags; i++)				      \
+ 	tags[i] = stack->item.tags[i];					      \
+       BT_STACK_MBSTATE_OUT;						      \
+       stack = stack->prev;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #undef MIN
+ #define MIN(a, b) ((a) <= (b) ? (a) : (b))
+@@ -372,7 +372,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+   if (state == NULL)
+     goto backtrack;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       tre_tnfa_transition_t *next_state;
+       int empty_br_match;
+@@ -632,7 +632,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+ 		    }
+ 		}
+ 	      DPRINT(("restarting from next start position\n"));
+-	      next_c = (tre_char_t)next_c_start;
++	      next_c = (tre_char_t) next_c_start;
+ #ifdef TRE_MBSTATE
+ 	      mbstate = mbstate_start;
+ #endif /* TRE_MBSTATE */
+diff --git a/src/extra/tre/tre-match-parallel.c b/src/extra/tre/tre-match-parallel.c
+index ddb9fda..6696d11 100644
+--- a/src/extra/tre/tre-match-parallel.c
++++ b/src/extra/tre/tre-match-parallel.c
+@@ -269,7 +269,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
+   DPRINT(("-------------+------------------------------------------------\n"));
+ 
+   reach_next_i = reach_next;
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       /* If no match found yet, add the initial states to `reach_next'. */
+       if (match_eo < 0)
+diff --git a/src/extra/tre/tre-match-utils.h b/src/extra/tre/tre-match-utils.h
+index 7d19c21..d0a4214 100644
+--- a/src/extra/tre/tre-match-utils.h
++++ b/src/extra/tre/tre-match-utils.h
+@@ -76,7 +76,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #else /* !TRE_MULTIBYTE */
+ 
+@@ -107,7 +107,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_MULTIBYTE */
+ 
+@@ -132,7 +132,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+ 						 str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_WCHAR */
+ 
+@@ -161,11 +161,11 @@
+ #define CHECK_CHAR_CLASSES(trans_i, tnfa, eflags)                             \
+   (((trans_i->assertions & ASSERT_CHAR_CLASS)                                 \
+        && !(tnfa->cflags & REG_ICASE)                                         \
+-       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.classt))                \
++       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.class))                 \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS)                             \
+         && (tnfa->cflags & REG_ICASE)                                         \
+-        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.classt)    \
+-	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.classt))       \
++        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.class)     \
++	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.class))    \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS_NEG)                         \
+         && tre_neg_char_classes_match(trans_i->neg_classes,(tre_cint_t)prev_c,\
+                                       tnfa->cflags & REG_ICASE)))
+diff --git a/src/extra/tre/tre-mem.c b/src/extra/tre/tre-mem.c
+index 51b630c..67ba676 100644
+--- a/src/extra/tre/tre-mem.c
++++ b/src/extra/tre/tre-mem.c
+@@ -111,8 +111,8 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
+ 	    block_size = size * 8;
+ 	  else
+ 	    block_size = TRE_MEM_BLOCK_SIZE;
+-	  DPRINT(("tre_mem_alloc: allocating new %u byte block\n",
+-		  (unsigned int)block_size));
++	  DPRINT(("tre_mem_alloc: allocating new %lu byte block\n",
++		  (unsigned long)block_size));
+ 	  l = xmalloc(sizeof(*l));
+ 	  if (l == NULL)
+ 	    {
+diff --git a/src/extra/tre/tre-parse.c b/src/extra/tre/tre-parse.c
+index 50d0438..86ccad6 100644
+--- a/src/extra/tre/tre-parse.c
++++ b/src/extra/tre/tre-parse.c
+@@ -123,23 +123,22 @@ tre_new_item(tre_mem_t mem, int min, int max, int *i, int *max_i,
+ 
+ /* Expands a character class to character ranges. */
+ static reg_errcode_t
+-tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
++tre_expand_ctype(tre_mem_t mem, tre_ctype_t class, tre_ast_node_t ***items,
+ 		 int *i, int *max_i, int cflags)
+ {
+   reg_errcode_t status = REG_OK;
+   tre_cint_t c;
+-  tre_cint_t j;
+-  int min = EMPTY, max = 0;
++  int j, min = -1, max = 0;
+   //assert(TRE_MB_CUR_MAX == 1); It is the ctx->cur_max that matters
+ 
+   DPRINT(("  expanding class to character ranges\n"));
+   for (j = 0; (j < 256) && (status == REG_OK); j++)
+     {
+-      c = j;
+-      if (tre_isctype(c, classt)
++      c = (tre_cint_t) j;
++      if (tre_isctype(c, class)
+ 	  || ((cflags & REG_ICASE)
+-	      && (tre_isctype(tre_tolower(c), classt)
+-		  || tre_isctype(tre_toupper(c), classt))))
++	      && (tre_isctype(tre_tolower(c), class)
++		  || tre_isctype(tre_toupper(c), class))))
+ {
+ 	  if (min < 0)
+ 	    min = c;
+@@ -149,7 +148,7 @@ tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
+ 	{
+ 	  DPRINT(("  range %c (%d) to %c (%d)\n", min, min, max, max));
+ 	  status = tre_new_item(mem, min, max, i, max_i, items);
+-	  min = EMPTY;
++	  min = -1;
+ 	}
+     }
+   if (min >= 0 && status == REG_OK)
+@@ -164,7 +163,7 @@ tre_compare_items(const void *a, const void *b)
+   const tre_ast_node_t *node_a = *(tre_ast_node_t * const *)a;
+   const tre_ast_node_t *node_b = *(tre_ast_node_t * const *)b;
+   tre_literal_t *l_a = node_a->obj, *l_b = node_b->obj;
+-  int a_min = l_a->code_min, b_min = l_b->code_min;
++  long a_min = l_a->code_min, b_min = l_b->code_min;
+ 
+   if (a_min < b_min)
+     return -1;
+@@ -255,7 +254,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ {
+   const tre_char_t *re = ctx->re;
+   reg_errcode_t status = REG_OK;
+-  tre_ctype_t classt = (tre_ctype_t)0;
++  tre_ctype_t class = (tre_ctype_t)0;
+   int i = *num_items;
+   int max_i = *items_size;
+   int skip;
+@@ -278,7 +277,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	{
+ 	  tre_cint_t min = 0, max = 0;
+ 
+-	  classt = (tre_ctype_t)0;
++	  class = (tre_ctype_t)0;
+ 	  if (re + 2 < ctx->re_end
+ 	      && *(re + 1) == CHAR_MINUS && *(re + 2) != CHAR_RBRACKET)
+ 	    {
+@@ -330,15 +329,15 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ #endif /* !TRE_WCHAR */
+ 		  tmp_str[len] = '\0';
+ 		  DPRINT(("  class name: %s\n", tmp_str));
+-		  classt = tre_ctype(tmp_str);
+-		  if (!classt)
++		  class = tre_ctype(tmp_str);
++		  if (!class)
+ 		    status = REG_ECTYPE;
+ 		  /* Optimize character classes for 8 bit character sets. */
+ 		  if (status == REG_OK && ctx->cur_max == 1)
+ 		    {
+-		      status = tre_expand_ctype(ctx->mem, classt, items,
++		      status = tre_expand_ctype(ctx->mem, class, items,
+ 						&i, &max_i, ctx->cflags);
+-		      classt = (tre_ctype_t)0;
++		      class = (tre_ctype_t)0;
+ 		      skip = 1;
+ 		    }
+ 		  re = endptr + 2;
+@@ -361,22 +360,22 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	  if (status != REG_OK)
+ 	    break;
+ 
+-	  if (classt && negate)
++	  if (class && negate)
+ 	    if (*num_neg_classes >= MAX_NEG_CLASSES)
+ 	      status = REG_ESPACE;
+ 	    else
+-	      neg_classes[(*num_neg_classes)++] = classt;
++	      neg_classes[(*num_neg_classes)++] = class;
+ 	  else if (!skip)
+ 	    {
+ 	      status = tre_new_item(ctx->mem, min, max, &i, &max_i, items);
+ 	      if (status != REG_OK)
+ 		break;
+-	      ((tre_literal_t*)((*items)[i-1])->obj)->u.classt = classt;
++	      ((tre_literal_t*)((*items)[i-1])->obj)->u.class = class;
+ 	    }
+ 
+ 	  /* Add opposite-case counterpoints if REG_ICASE is present.
+ 	     This is broken if there are more than two "same" characters. */
+-	  if (ctx->cflags & REG_ICASE && !classt && status == REG_OK && !skip)
++	  if (ctx->cflags & REG_ICASE && !class && status == REG_OK && !skip)
+ 	    {
+ 	      tre_cint_t cmin, ccurr;
+ 
+@@ -455,11 +454,11 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+     {
+       int min, max;
+       tre_literal_t *l = items[j]->obj;
+-      min = l->code_min;
+-      max = l->code_max;
++      min = (int) l->code_min;
++      max = (int) l->code_max;
+ 
+       DPRINT(("item: %d - %d, class %p, curr_max = %d\n",
+-	      (int)l->code_min, (int)l->code_max, (void *)l->u.classt, curr_max));
++	      (int)l->code_min, (int)l->code_max, (void *)l->u.class, curr_max));
+ 
+       if (negate)
+ 	{
+@@ -831,7 +830,7 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+   /* Create the AST node(s). */
+   if (min == 0 && max == 0)
+     {
+-      *result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++      *result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+       if (*result == NULL)
+ 	return REG_ESPACE;
+     }
+@@ -1212,7 +1211,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		  DPRINT(("tre_parse:	extension: '%.*" STRF "\n",
+ 			  REST(ctx->re)));
+ 		  ctx->re += 2;
+-		  while (/*CONSTCOND*/1)
++		  while (/*CONSTCOND*/(void)1,1)
+ 		    {
+ 		      if (*ctx->re == L'i')
+ 			{
+@@ -1352,7 +1351,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		     subexpression was closed.	POSIX leaves the meaning of
+ 		     this to be implementation-defined.	 We interpret this as
+ 		     an empty expression (which matches an empty string).  */
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (result == NULL)
+ 		    return REG_ESPACE;
+ 		  if (!(ctx->cflags & REG_EXTENDED))
+@@ -1645,7 +1644,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		{
+ 		  DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
+ 			  REST(ctx->re)));
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (!result)
+ 		    return REG_ESPACE;
+ 		  break;
+@@ -1715,7 +1714,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 	    if (result->submatch_id >= 0)
+ 	      {
+ 		tre_ast_node_t *n, *tmp_node;
+-		n = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		n = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		if (n == NULL)
+ 		  return REG_ESPACE;
+ 		tmp_node = tre_ast_new_catenation(ctx->mem, n, result);
+diff --git a/src/extra/tre/tre-stack.h b/src/extra/tre/tre-stack.h
+index 7d11c5e..a1acbe7 100644
+--- a/src/extra/tre/tre-stack.h
++++ b/src/extra/tre/tre-stack.h
+@@ -54,7 +54,7 @@ declare_popf(int, int);
+     {									      \
+       status = tre_stack_push_ ## typetag(s, value);			      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define STACK_PUSHX(s, typetag, value)					      \
+   {									      \
+diff --git a/src/extra/tre/tre.h b/src/extra/tre/tre.h
+index 9d7d3a7..128475d 100644
+--- a/src/extra/tre/tre.h
++++ b/src/extra/tre/tre.h
+@@ -137,14 +137,6 @@ extern int
+ tre_regexec(const regex_t *preg, const char *string, size_t nmatch,
+ 	    regmatch_t pmatch[], int eflags);
+ 
+-extern size_t
+-tre_regerror(int errcode, const regex_t *preg, char *errbuf,
+-	     size_t errbuf_size);
+-
+-extern void
+-tre_regfree(regex_t *preg);
+-
+-/* R additions */
+ extern int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags);
+ 
+@@ -152,6 +144,13 @@ extern int
+ tre_regexecb(const regex_t *preg, const char *string, size_t nmatch,
+ 	     regmatch_t pmatch[], int eflags);
+ 
++extern size_t
++tre_regerror(int errcode, const regex_t *preg, char *errbuf,
++	     size_t errbuf_size);
++
++extern void
++tre_regfree(regex_t *preg);
++
+ #ifdef TRE_WCHAR
+ #ifdef HAVE_WCHAR_H
+ #include <wchar.h>
+@@ -223,7 +222,10 @@ extern int
+ tre_regaexec(const regex_t *preg, const char *string,
+ 	     regamatch_t *match, regaparams_t params, int eflags);
+ 
+-/* R addition */
++extern int
++tre_reganexec(const regex_t *preg, const char *string, size_t len,
++	      regamatch_t *match, regaparams_t params, int eflags);
++
+ extern int
+ tre_regaexecb(const regex_t *preg, const char *string,
+ 	      regamatch_t *match, regaparams_t params, int eflags);
+@@ -279,8 +281,7 @@ enum {
+   TRE_CONFIG_WCHAR,
+   TRE_CONFIG_MULTIBYTE,
+   TRE_CONFIG_SYSTEM_ABI,
+-  TRE_CONFIG_VERSION,
+-  TRE_MB_CUR_MAX_VALUE  /* [i_a] - derived from MULTIBYTE and WCHAR, but still handy to have: no need to copy logic in TRE header files, etc. in order to know this */
++  TRE_CONFIG_VERSION
+ };
+ 
+ /* Returns 1 if the compiled pattern has back references, 0 if not. */

--- a/builder/patches/R-3.0.3-aarch64.patch
+++ b/builder/patches/R-3.0.3-aarch64.patch
@@ -1,0 +1,709 @@
+diff --git a/configure b/configure
+index b3c299e..01f205d 100755
+--- a/configure
++++ b/configure
+@@ -5193,6 +5193,7 @@ elif test ${makeinfo_version_maj} -lt 4 \
+ else
+   r_cv_prog_makeinfo_v4=yes
+ fi
++r_cv_prog_makeinfo_v4=yes
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $r_cv_prog_makeinfo_v4" >&5
+ $as_echo "$r_cv_prog_makeinfo_v4" >&6; }
+diff --git a/src/extra/tre/regcomp.c b/src/extra/tre/regcomp.c
+index 93ddb92..31d4e52 100644
+--- a/src/extra/tre/regcomp.c
++++ b/src/extra/tre/regcomp.c
+@@ -99,7 +99,6 @@ tre_regncomp(regex_t *preg, const char *regex, size_t n, int cflags)
+   return ret;
+ }
+ 
+-
+ /* this version takes bytes literally, to be used with raw vectors */
+ int
+ tre_regncompb(regex_t *preg, const char *regex, size_t n, int cflags)
+@@ -131,7 +130,6 @@ tre_regcomp(regex_t *preg, const char *regex, int cflags)
+   return tre_regncomp(preg, regex, regex ? strlen(regex) : 0, cflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags)
+ {
+diff --git a/src/extra/tre/regexec.c b/src/extra/tre/regexec.c
+index 6edaf81..d8f91a3 100644
+--- a/src/extra/tre/regexec.c
++++ b/src/extra/tre/regexec.c
+@@ -217,7 +217,6 @@ tre_regexec(const regex_t *preg, const char *str,
+   return tre_regnexec(preg, str, (unsigned)-1, nmatch, pmatch, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regexecb(const regex_t *preg, const char *str,
+ 	     size_t nmatch, regmatch_t pmatch[], int eflags)
+@@ -329,7 +328,6 @@ tre_regaexec(const regex_t *preg, const char *str,
+   return tre_reganexec(preg, str, (unsigned)-1, match, params, eflags);
+ }
+ 
+-/* R addition */
+ int
+ tre_regaexecb(const regex_t *preg, const char *str,
+ 	  regamatch_t *match, regaparams_t params, int eflags)
+diff --git a/src/extra/tre/tre-ast.h b/src/extra/tre/tre-ast.h
+index 844aee3..d9af376 100644
+--- a/src/extra/tre/tre-ast.h
++++ b/src/extra/tre/tre-ast.h
+@@ -55,16 +55,11 @@ typedef struct {
+    tags, matching parameter settings, and all expressions that match one
+    character. */
+ typedef struct {
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+-  int /* long */ code_min;
+-  int /* long */ code_max;
+-#endif
++  long code_min;
++  long code_max;
+   int position;
+   union {
+-    tre_ctype_t classt; /* [i_a] wrong syntax colouring prevention */
++    tre_ctype_t class;
+     int *params;
+   } u;
+   tre_ctype_t *neg_classes;
+diff --git a/src/extra/tre/tre-compile.c b/src/extra/tre/tre-compile.c
+index 7886455..92c14ab 100644
+--- a/src/extra/tre/tre-compile.c
++++ b/src/extra/tre/tre-compile.c
+@@ -6,6 +6,13 @@
+ 
+ */
+ 
++/*
++  TODO:
++   - Fix tre_ast_to_tnfa() to recurse using a stack instead of recursive
++     function calls.
++*/
++
++
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+@@ -684,8 +691,8 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 	      {
+ 		tre_literal_t *lit = node->obj;
+ 		int pos = lit->position;
+-		int min = lit->code_min;
+-		int max = lit->code_max;
++		int min = (int)lit->code_min;
++		int max = (int)lit->code_max;
+ 		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
+ 		  {
+ 		    /* XXX - e.g. [ab] has only one position but two
+@@ -945,7 +952,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
+ 			  seq2 = copy;
+ 			if (seq2 == NULL)
+ 			  return REG_ESPACE;
+-			tmp = tre_ast_new_literal(mem, EMPTY, EMPTY, -1);
++			tmp = tre_ast_new_literal(mem, EMPTY, -1, -1);
+ 			if (tmp == NULL)
+ 			  return REG_ESPACE;
+ 			seq2 = tre_ast_new_union(mem, tmp, seq2);
+@@ -1052,15 +1059,15 @@ tre_set_empty(tre_mem_t mem)
+     return NULL;
+ 
+   new_set[0].position = -1;
+-  new_set[0].code_min = EMPTY;
+-  new_set[0].code_max = EMPTY;
++  new_set[0].code_min = -1;
++  new_set[0].code_max = -1;
+ 
+   return new_set;
+ }
+ 
+ static tre_pos_and_tags_t *
+ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+-	    tre_ctype_t classt, tre_ctype_t *neg_classes, int backref)
++	    tre_ctype_t class, tre_ctype_t *neg_classes, int backref)
+ {
+   tre_pos_and_tags_t *new_set;
+ 
+@@ -1071,12 +1078,12 @@ tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+   new_set[0].position = position;
+   new_set[0].code_min = code_min;
+   new_set[0].code_max = code_max;
+-  new_set[0].classt = classt;
++  new_set[0].class = class;
+   new_set[0].neg_classes = neg_classes;
+   new_set[0].backref = backref;
+   new_set[1].position = -1;
+-  new_set[1].code_min = EMPTY;
+-  new_set[1].code_max = EMPTY;
++  new_set[1].code_min = -1;
++  new_set[1].code_max = -1;
+ 
+   return new_set;
+ }
+@@ -1103,7 +1110,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1].code_min = set1[s1].code_min;
+       new_set[s1].code_max = set1[s1].code_max;
+       new_set[s1].assertions = set1[s1].assertions | assertions;
+-      new_set[s1].classt = set1[s1].classt;
++      new_set[s1].class = set1[s1].class;
+       new_set[s1].neg_classes = set1[s1].neg_classes;
+       new_set[s1].backref = set1[s1].backref;
+       if (set1[s1].tags == NULL && tags == NULL)
+@@ -1148,7 +1155,7 @@ tre_set_union(tre_mem_t mem, tre_pos_and_tags_t *set1, tre_pos_and_tags_t *set2,
+       new_set[s1 + s2].code_max = set2[s2].code_max;
+       /* XXX - why not | assertions here as well? */
+       new_set[s1 + s2].assertions = set2[s2].assertions;
+-      new_set[s1 + s2].classt = set2[s2].classt;
++      new_set[s1 + s2].class = set2[s2].class;
+       new_set[s1 + s2].neg_classes = set2[s2].neg_classes;
+       new_set[s1 + s2].backref = set2[s2].backref;
+       if (set2[s2].tags == NULL)
+@@ -1231,7 +1238,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
+ 			  break;
+ 		      if (tags[i] < 0)
+ 			{
+-			  tags[i] = lit->code_max;
++			  tags[i] = (int)lit->code_max;
+ 			  tags[i + 1] = -1;
+ 			}
+ 		    }
+@@ -1373,7 +1380,7 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
+ 		    node->lastpos = tre_set_one(mem, lit->position,
+ 						(int)lit->code_min,
+ 						(int)lit->code_max,
+-						lit->u.classt, lit->neg_classes,
++						lit->u.class, lit->neg_classes,
+ 						-1);
+ 		    if (!node->lastpos)
+ 		      return REG_ESPACE;
+@@ -1614,12 +1621,12 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 	      (trans + 1)->state = NULL;
+ 	    /* Use the character ranges, assertions, etc. from `p1' for
+ 	       the transition from `p1' to `p2'. */
+-	    trans->code_min = p1->code_min;
+-	    trans->code_max = p1->code_max;
++	    trans->code_min = (tre_cint_t) p1->code_min;
++	    trans->code_max = (tre_cint_t) p1->code_max;
+ 	    trans->state = transitions + offs[p2->position];
+ 	    trans->state_id = p2->position;
+ 	    trans->assertions = p1->assertions | p2->assertions
+-	      | (p1->classt ? ASSERT_CHAR_CLASS : 0)
++	      | (p1->class ? ASSERT_CHAR_CLASS : 0)
+ 	      | (p1->neg_classes != NULL ? ASSERT_CHAR_CLASS_NEG : 0);
+ 	    if (p1->backref >= 0)
+ 	      {
+@@ -1629,7 +1636,7 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		trans->assertions |= ASSERT_BACKREF;
+ 	      }
+ 	    else
+-	      trans->u.classt = p1->classt;
++	      trans->u.class = p1->class;
+ 	    if (p1->neg_classes != NULL)
+ 	      {
+ 		for (i = 0; p1->neg_classes[i] != (tre_ctype_t)0; i++);
+@@ -1743,8 +1750,8 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
+ 		DPRINT((", assert %d", trans->assertions));
+ 	      if (trans->assertions & ASSERT_BACKREF)
+ 		DPRINT((", backref %d", trans->u.backref));
+-	      else if (trans->u.classt)
+-		DPRINT((", class %ld", (long)trans->u.classt));
++	      else if (trans->u.class)
++		DPRINT((", class %ld", (long)trans->u.class));
+ 	      if (trans->neg_classes)
+ 		DPRINT((", neg_classes %p", trans->neg_classes));
+ 	      if (trans->params)
+@@ -1861,10 +1868,10 @@ tre_ast_to_tnfa(tre_ast_node_t *node, tre_tnfa_transition_t *transitions,
+   do				  \
+     {				  \
+       errcode = err;		  \
+-      if (/*CONSTCOND*/1)	  \
++      if (/*CONSTCOND*/(void)1,1)	  \
+       	goto error_exit;	  \
+     }				  \
+- while (/*CONSTCOND*/0)
++ while (/*CONSTCOND*/(void)0,0)
+ 
+ 
+ int
+@@ -2050,7 +2057,7 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
+   if (TRE_MB_CUR_MAX == 1 && !tmp_ast_l->nullable)
+     {
+       int count = 0;
+-      int k; /* [i_a] */
++      tre_cint_t k;
+       DPRINT(("Characters that can start a match:"));
+       tnfa->firstpos_chars = xcalloc(256, sizeof(char));
+       if (tnfa->firstpos_chars == NULL)
+@@ -2310,15 +2317,7 @@ tre_config(int query, void *result)
+     case TRE_CONFIG_VERSION:
+       *string_result = TRE_VERSION;
+       return REG_OK;
+-
+-	case TRE_MB_CUR_MAX_VALUE:  /* [i_a] */
+-#if defined(TRE_MB_CUR_MAX)
+-		*int_result = TRE_MB_CUR_MAX;
+-#else
+-		*int_result = 1;
+-#endif
+-		break;
+-  }
++    }
+ 
+   return REG_NOMATCH;
+ }
+diff --git a/src/extra/tre/tre-compile.h b/src/extra/tre/tre-compile.h
+index 0d81cf2..51d5ac9 100644
+--- a/src/extra/tre/tre-compile.h
++++ b/src/extra/tre/tre-compile.h
+@@ -12,16 +12,11 @@
+ 
+ typedef struct {
+   int position;
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+-  tre_cint_t code_min;
+-  tre_cint_t code_max;
+-#else
+   int code_min;
+   int code_max;
+-#endif
+   int *tags;
+   int assertions;
+-  tre_ctype_t classt;
++  tre_ctype_t class;
+   tre_ctype_t *neg_classes;
+   int backref;
+   int *params;
+diff --git a/src/extra/tre/tre-internal.h b/src/extra/tre/tre-internal.h
+index c1300ac..822998e 100644
+--- a/src/extra/tre/tre-internal.h
++++ b/src/extra/tre/tre-internal.h
+@@ -22,9 +22,9 @@
+ 
+ #ifdef TRE_DEBUG
+ #include <stdio.h>
+-#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/0)
++#define DPRINT(msg) do {printf msg; fflush(stdout);} while(/*CONSTCOND*/(void)0,0)
+ #else /* !TRE_DEBUG */
+-#define DPRINT(msg) do { } while(/*CONSTCOND*/0)
++#define DPRINT(msg) do { } while(/*CONSTCOND*/(void)0,0)
+ #endif /* !TRE_DEBUG */
+ 
+ #define elementsof(x)	( sizeof(x) / sizeof(x[0]) )
+@@ -151,13 +151,8 @@ typedef struct tnfa_transition tre_tnfa_transition_t;
+ 
+ struct tnfa_transition {
+   /* Range of accepted characters. */
+-#if 0 /* [i_a] must be able to carry the full span of all [Unicode] character codes *PLUS* these 'specials': TAG, PARAMETER, BACKREF, ASSERTION and EMPTY */
+   tre_cint_t code_min;
+   tre_cint_t code_max;
+-#else
+-  int code_min;
+-  int code_max;
+-#endif
+   /* Pointer to the destination state. */
+   tre_tnfa_transition_t *state;
+   /* ID number of the destination state. */
+@@ -171,7 +166,7 @@ struct tnfa_transition {
+   /* Assertion parameters. */
+   union {
+     /* Character class assertion. */
+-    tre_ctype_t classt;
++    tre_ctype_t class;
+     /* Back reference assertion. */
+     int backref;
+   } u;
+diff --git a/src/extra/tre/tre-match-approx.c b/src/extra/tre/tre-match-approx.c
+index 6011114..f08cd0f 100644
+--- a/src/extra/tre/tre-match-approx.c
++++ b/src/extra/tre/tre-match-approx.c
+@@ -328,7 +328,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
+   GET_NEXT_WCHAR();
+   pos = 0;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       DPRINT(("%03d:%2lc/%05d\n", pos, (tre_cint_t)next_c, (int)next_c));
+ 
+diff --git a/src/extra/tre/tre-match-backtrack.c b/src/extra/tre/tre-match-backtrack.c
+index 9630e81..9dd7e94 100644
+--- a/src/extra/tre/tre-match-backtrack.c
++++ b/src/extra/tre/tre-match-backtrack.c
+@@ -116,7 +116,7 @@ typedef struct tre_backtrack_struct {
+ #ifdef TRE_USE_ALLOCA
+ #define tre_bt_mem_new		  tre_mem_newa
+ #define tre_bt_mem_alloc	  tre_mem_alloca
+-#define tre_bt_mem_destroy(obj)	  do { } while (0)
++#define tre_bt_mem_destroy(obj)	  do { } while (0,0)
+ #else /* !TRE_USE_ALLOCA */
+ #define tre_bt_mem_new		  tre_mem_new
+ #define tre_bt_mem_alloc	  tre_mem_alloc
+@@ -173,7 +173,7 @@ typedef struct tre_backtrack_struct {
+ 	stack->item.tags[i] = (_tags)[i];				      \
+       BT_STACK_MBSTATE_IN;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define BT_STACK_POP()							      \
+   do									      \
+@@ -186,13 +186,13 @@ typedef struct tre_backtrack_struct {
+       str_byte = stack->item.str_byte;					      \
+       BT_STACK_WIDE_OUT;						      \
+       state = stack->item.state;					      \
+-      next_c = (tre_char_t)stack->item.next_c;					      \
++      next_c = (tre_char_t) stack->item.next_c;					      \
+       for (i = 0; i < tnfa->num_tags; i++)				      \
+ 	tags[i] = stack->item.tags[i];					      \
+       BT_STACK_MBSTATE_OUT;						      \
+       stack = stack->prev;						      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #undef MIN
+ #define MIN(a, b) ((a) <= (b) ? (a) : (b))
+@@ -372,7 +372,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+   if (state == NULL)
+     goto backtrack;
+ 
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       tre_tnfa_transition_t *next_state;
+       int empty_br_match;
+@@ -632,7 +632,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
+ 		    }
+ 		}
+ 	      DPRINT(("restarting from next start position\n"));
+-	      next_c = (tre_char_t)next_c_start;
++	      next_c = (tre_char_t) next_c_start;
+ #ifdef TRE_MBSTATE
+ 	      mbstate = mbstate_start;
+ #endif /* TRE_MBSTATE */
+diff --git a/src/extra/tre/tre-match-parallel.c b/src/extra/tre/tre-match-parallel.c
+index ddb9fda..6696d11 100644
+--- a/src/extra/tre/tre-match-parallel.c
++++ b/src/extra/tre/tre-match-parallel.c
+@@ -269,7 +269,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
+   DPRINT(("-------------+------------------------------------------------\n"));
+ 
+   reach_next_i = reach_next;
+-  while (/*CONSTCOND*/1)
++  while (/*CONSTCOND*/(void)1,1)
+     {
+       /* If no match found yet, add the initial states to `reach_next'. */
+       if (match_eo < 0)
+diff --git a/src/extra/tre/tre-match-utils.h b/src/extra/tre/tre-match-utils.h
+index 7d19c21..d0a4214 100644
+--- a/src/extra/tre/tre-match-utils.h
++++ b/src/extra/tre/tre-match-utils.h
+@@ -76,7 +76,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #else /* !TRE_MULTIBYTE */
+ 
+@@ -107,7 +107,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+                                                  str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_MULTIBYTE */
+ 
+@@ -132,7 +132,7 @@
+ 	str_user_end = str_source->get_next_char(&next_c, &pos_add_next,      \
+ 						 str_source->context);	      \
+       }									      \
+-  } while(/*CONSTCOND*/0)
++  } while(/*CONSTCOND*/(void)0,0)
+ 
+ #endif /* !TRE_WCHAR */
+ 
+@@ -161,11 +161,11 @@
+ #define CHECK_CHAR_CLASSES(trans_i, tnfa, eflags)                             \
+   (((trans_i->assertions & ASSERT_CHAR_CLASS)                                 \
+        && !(tnfa->cflags & REG_ICASE)                                         \
+-       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.classt))                \
++       && !tre_isctype((tre_cint_t)prev_c, trans_i->u.class))                 \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS)                             \
+         && (tnfa->cflags & REG_ICASE)                                         \
+-        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.classt)    \
+-	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.classt))       \
++        && !tre_isctype(tre_tolower((tre_cint_t)prev_c),trans_i->u.class)     \
++	&& !tre_isctype(tre_toupper((tre_cint_t)prev_c),trans_i->u.class))    \
+     || ((trans_i->assertions & ASSERT_CHAR_CLASS_NEG)                         \
+         && tre_neg_char_classes_match(trans_i->neg_classes,(tre_cint_t)prev_c,\
+                                       tnfa->cflags & REG_ICASE)))
+diff --git a/src/extra/tre/tre-mem.c b/src/extra/tre/tre-mem.c
+index 51b630c..67ba676 100644
+--- a/src/extra/tre/tre-mem.c
++++ b/src/extra/tre/tre-mem.c
+@@ -111,8 +111,8 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
+ 	    block_size = size * 8;
+ 	  else
+ 	    block_size = TRE_MEM_BLOCK_SIZE;
+-	  DPRINT(("tre_mem_alloc: allocating new %u byte block\n",
+-		  (unsigned int)block_size));
++	  DPRINT(("tre_mem_alloc: allocating new %lu byte block\n",
++		  (unsigned long)block_size));
+ 	  l = xmalloc(sizeof(*l));
+ 	  if (l == NULL)
+ 	    {
+diff --git a/src/extra/tre/tre-parse.c b/src/extra/tre/tre-parse.c
+index 50d0438..86ccad6 100644
+--- a/src/extra/tre/tre-parse.c
++++ b/src/extra/tre/tre-parse.c
+@@ -123,23 +123,22 @@ tre_new_item(tre_mem_t mem, int min, int max, int *i, int *max_i,
+ 
+ /* Expands a character class to character ranges. */
+ static reg_errcode_t
+-tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
++tre_expand_ctype(tre_mem_t mem, tre_ctype_t class, tre_ast_node_t ***items,
+ 		 int *i, int *max_i, int cflags)
+ {
+   reg_errcode_t status = REG_OK;
+   tre_cint_t c;
+-  tre_cint_t j;
+-  int min = EMPTY, max = 0;
++  int j, min = -1, max = 0;
+   //assert(TRE_MB_CUR_MAX == 1); It is the ctx->cur_max that matters
+ 
+   DPRINT(("  expanding class to character ranges\n"));
+   for (j = 0; (j < 256) && (status == REG_OK); j++)
+     {
+-      c = j;
+-      if (tre_isctype(c, classt)
++      c = (tre_cint_t) j;
++      if (tre_isctype(c, class)
+ 	  || ((cflags & REG_ICASE)
+-	      && (tre_isctype(tre_tolower(c), classt)
+-		  || tre_isctype(tre_toupper(c), classt))))
++	      && (tre_isctype(tre_tolower(c), class)
++		  || tre_isctype(tre_toupper(c), class))))
+ {
+ 	  if (min < 0)
+ 	    min = c;
+@@ -149,7 +148,7 @@ tre_expand_ctype(tre_mem_t mem, tre_ctype_t classt, tre_ast_node_t ***items,
+ 	{
+ 	  DPRINT(("  range %c (%d) to %c (%d)\n", min, min, max, max));
+ 	  status = tre_new_item(mem, min, max, i, max_i, items);
+-	  min = EMPTY;
++	  min = -1;
+ 	}
+     }
+   if (min >= 0 && status == REG_OK)
+@@ -164,7 +163,7 @@ tre_compare_items(const void *a, const void *b)
+   const tre_ast_node_t *node_a = *(tre_ast_node_t * const *)a;
+   const tre_ast_node_t *node_b = *(tre_ast_node_t * const *)b;
+   tre_literal_t *l_a = node_a->obj, *l_b = node_b->obj;
+-  int a_min = l_a->code_min, b_min = l_b->code_min;
++  long a_min = l_a->code_min, b_min = l_b->code_min;
+ 
+   if (a_min < b_min)
+     return -1;
+@@ -255,7 +254,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ {
+   const tre_char_t *re = ctx->re;
+   reg_errcode_t status = REG_OK;
+-  tre_ctype_t classt = (tre_ctype_t)0;
++  tre_ctype_t class = (tre_ctype_t)0;
+   int i = *num_items;
+   int max_i = *items_size;
+   int skip;
+@@ -278,7 +277,7 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	{
+ 	  tre_cint_t min = 0, max = 0;
+ 
+-	  classt = (tre_ctype_t)0;
++	  class = (tre_ctype_t)0;
+ 	  if (re + 2 < ctx->re_end
+ 	      && *(re + 1) == CHAR_MINUS && *(re + 2) != CHAR_RBRACKET)
+ 	    {
+@@ -330,15 +329,15 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ #endif /* !TRE_WCHAR */
+ 		  tmp_str[len] = '\0';
+ 		  DPRINT(("  class name: %s\n", tmp_str));
+-		  classt = tre_ctype(tmp_str);
+-		  if (!classt)
++		  class = tre_ctype(tmp_str);
++		  if (!class)
+ 		    status = REG_ECTYPE;
+ 		  /* Optimize character classes for 8 bit character sets. */
+ 		  if (status == REG_OK && ctx->cur_max == 1)
+ 		    {
+-		      status = tre_expand_ctype(ctx->mem, classt, items,
++		      status = tre_expand_ctype(ctx->mem, class, items,
+ 						&i, &max_i, ctx->cflags);
+-		      classt = (tre_ctype_t)0;
++		      class = (tre_ctype_t)0;
+ 		      skip = 1;
+ 		    }
+ 		  re = endptr + 2;
+@@ -361,22 +360,22 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
+ 	  if (status != REG_OK)
+ 	    break;
+ 
+-	  if (classt && negate)
++	  if (class && negate)
+ 	    if (*num_neg_classes >= MAX_NEG_CLASSES)
+ 	      status = REG_ESPACE;
+ 	    else
+-	      neg_classes[(*num_neg_classes)++] = classt;
++	      neg_classes[(*num_neg_classes)++] = class;
+ 	  else if (!skip)
+ 	    {
+ 	      status = tre_new_item(ctx->mem, min, max, &i, &max_i, items);
+ 	      if (status != REG_OK)
+ 		break;
+-	      ((tre_literal_t*)((*items)[i-1])->obj)->u.classt = classt;
++	      ((tre_literal_t*)((*items)[i-1])->obj)->u.class = class;
+ 	    }
+ 
+ 	  /* Add opposite-case counterpoints if REG_ICASE is present.
+ 	     This is broken if there are more than two "same" characters. */
+-	  if (ctx->cflags & REG_ICASE && !classt && status == REG_OK && !skip)
++	  if (ctx->cflags & REG_ICASE && !class && status == REG_OK && !skip)
+ 	    {
+ 	      tre_cint_t cmin, ccurr;
+ 
+@@ -455,11 +454,11 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+     {
+       int min, max;
+       tre_literal_t *l = items[j]->obj;
+-      min = l->code_min;
+-      max = l->code_max;
++      min = (int) l->code_min;
++      max = (int) l->code_max;
+ 
+       DPRINT(("item: %d - %d, class %p, curr_max = %d\n",
+-	      (int)l->code_min, (int)l->code_max, (void *)l->u.classt, curr_max));
++	      (int)l->code_min, (int)l->code_max, (void *)l->u.class, curr_max));
+ 
+       if (negate)
+ 	{
+@@ -831,7 +830,7 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
+   /* Create the AST node(s). */
+   if (min == 0 && max == 0)
+     {
+-      *result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++      *result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+       if (*result == NULL)
+ 	return REG_ESPACE;
+     }
+@@ -1212,7 +1211,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		  DPRINT(("tre_parse:	extension: '%.*" STRF "\n",
+ 			  REST(ctx->re)));
+ 		  ctx->re += 2;
+-		  while (/*CONSTCOND*/1)
++		  while (/*CONSTCOND*/(void)1,1)
+ 		    {
+ 		      if (*ctx->re == L'i')
+ 			{
+@@ -1352,7 +1351,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		     subexpression was closed.	POSIX leaves the meaning of
+ 		     this to be implementation-defined.	 We interpret this as
+ 		     an empty expression (which matches an empty string).  */
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (result == NULL)
+ 		    return REG_ESPACE;
+ 		  if (!(ctx->cflags & REG_EXTENDED))
+@@ -1645,7 +1644,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 		{
+ 		  DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
+ 			  REST(ctx->re)));
+-		  result = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		  if (!result)
+ 		    return REG_ESPACE;
+ 		  break;
+@@ -1715,7 +1714,7 @@ tre_parse(tre_parse_ctx_t *ctx)
+ 	    if (result->submatch_id >= 0)
+ 	      {
+ 		tre_ast_node_t *n, *tmp_node;
+-		n = tre_ast_new_literal(ctx->mem, EMPTY, EMPTY, -1);
++		n = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+ 		if (n == NULL)
+ 		  return REG_ESPACE;
+ 		tmp_node = tre_ast_new_catenation(ctx->mem, n, result);
+diff --git a/src/extra/tre/tre-stack.h b/src/extra/tre/tre-stack.h
+index 7d11c5e..a1acbe7 100644
+--- a/src/extra/tre/tre-stack.h
++++ b/src/extra/tre/tre-stack.h
+@@ -54,7 +54,7 @@ declare_popf(int, int);
+     {									      \
+       status = tre_stack_push_ ## typetag(s, value);			      \
+     }									      \
+-  while (/*CONSTCOND*/0)
++  while (/*CONSTCOND*/(void)0,0)
+ 
+ #define STACK_PUSHX(s, typetag, value)					      \
+   {									      \
+diff --git a/src/extra/tre/tre.h b/src/extra/tre/tre.h
+index 9d7d3a7..128475d 100644
+--- a/src/extra/tre/tre.h
++++ b/src/extra/tre/tre.h
+@@ -137,14 +137,6 @@ extern int
+ tre_regexec(const regex_t *preg, const char *string, size_t nmatch,
+ 	    regmatch_t pmatch[], int eflags);
+ 
+-extern size_t
+-tre_regerror(int errcode, const regex_t *preg, char *errbuf,
+-	     size_t errbuf_size);
+-
+-extern void
+-tre_regfree(regex_t *preg);
+-
+-/* R additions */
+ extern int
+ tre_regcompb(regex_t *preg, const char *regex, int cflags);
+ 
+@@ -152,6 +144,13 @@ extern int
+ tre_regexecb(const regex_t *preg, const char *string, size_t nmatch,
+ 	     regmatch_t pmatch[], int eflags);
+ 
++extern size_t
++tre_regerror(int errcode, const regex_t *preg, char *errbuf,
++	     size_t errbuf_size);
++
++extern void
++tre_regfree(regex_t *preg);
++
+ #ifdef TRE_WCHAR
+ #ifdef HAVE_WCHAR_H
+ #include <wchar.h>
+@@ -223,7 +222,10 @@ extern int
+ tre_regaexec(const regex_t *preg, const char *string,
+ 	     regamatch_t *match, regaparams_t params, int eflags);
+ 
+-/* R addition */
++extern int
++tre_reganexec(const regex_t *preg, const char *string, size_t len,
++	      regamatch_t *match, regaparams_t params, int eflags);
++
+ extern int
+ tre_regaexecb(const regex_t *preg, const char *string,
+ 	      regamatch_t *match, regaparams_t params, int eflags);
+@@ -279,8 +281,7 @@ enum {
+   TRE_CONFIG_WCHAR,
+   TRE_CONFIG_MULTIBYTE,
+   TRE_CONFIG_SYSTEM_ABI,
+-  TRE_CONFIG_VERSION,
+-  TRE_MB_CUR_MAX_VALUE  /* [i_a] - derived from MULTIBYTE and WCHAR, but still handy to have: no need to copy logic in TRE header files, etc. in order to know this */
++  TRE_CONFIG_VERSION
+ };
+ 
+ /* Returns 1 if the compiled pattern has back references, 0 if not. */

--- a/builder/patches/README.md
+++ b/builder/patches/README.md
@@ -7,3 +7,7 @@ all platforms, create a patch file at `patches/R-${R_VERSION}.patch` (such as
 To add a patch for an R version on a specific platform create a patch file at
 `patches/R-${R_VERSION}-${OS_IDENTIFIER}.patch` (such as
 `patches/R-3.3.0-centos-8.patch`).
+
+To add a patch for an R version on a specific architecture, create a patch
+file at `patches/R-${R_VERSION}-<arch>.patch`, where `<arch>` can be
+`x86_64` or `aarch64` (e.g. `patches/R-3.3.0-aarch64.patch`).


### PR DESCRIPTION
Otherwise recommended packages do not compile and data sets are broken in every package, including base packages.

This came up e.g. here: https://bugs.r-project.org/show_bug.cgi?id=15491 but neither the fix, nor the commit by BDR fixes this. The issue is in the vendored TRE regex library, which got updated before R 3.1.0, so this patch is a combination of those updates:
https://github.com/wch/r-source/commit/a2635929ac962a866c67b6273440d09a3b26f0cf
https://github.com/wch/r-source/commit/3b5876791fa4c26321fc415b27f920ecc3cf1dc8

I tested this with R 3.0.0 - R 3.0.3 on Debian 12, and R 3.0.0 on Fedora 37.