### PR TITLE
Newer Ubuntu/Debian need libdeflate for R-devel

### DIFF
--- a/builder/Dockerfile.debian-11
+++ b/builder/Dockerfile.debian-11
@@ -7,7 +7,7 @@ RUN set -x \
   && echo 'deb-src http://deb.debian.org/debian bullseye main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y curl gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas-base libpcre2-dev make python3-pip wget \
+     libopenblas-base libpcre2-dev make python3-pip wget libdeflate-dev \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli

--- a/builder/Dockerfile.debian-12
+++ b/builder/Dockerfile.debian-12
@@ -7,7 +7,7 @@ RUN set -x \
   && echo 'deb-src http://deb.debian.org/debian bookworm main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y curl gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas0 libpcre2-dev make unzip wget \
+     libopenblas0 libpcre2-dev make unzip wget libdeflate-dev \
   && apt-get build-dep -y r-base
 
 # Install AWS CLI

--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y curl libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python3-pip \
+  && apt-get install -y curl libcurl4-openssl-dev libicu-dev libopenblas-base libpcre2-dev wget python3-pip libdeflate-dev \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli

--- a/builder/package.debian-11
+++ b/builder/package.debian-11
@@ -36,6 +36,7 @@ depends:
 - libc6
 - libcairo2
 - libcurl4-openssl-dev
+- libdeflate0
 - libglib2.0-0
 - libgomp1
 - libicu-dev

--- a/builder/package.debian-12
+++ b/builder/package.debian-12
@@ -36,6 +36,7 @@ depends:
 - libc6
 - libcairo2
 - libcurl4-openssl-dev
+- libdeflate0
 - libglib2.0-0
 - libgomp1
 - libicu-dev

--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -35,6 +35,7 @@ depends:
 - libc6
 - libcairo2
 - libcurl4
+- libdeflate0
 - libglib2.0-0
 - libgomp1
 - libicu-dev


### PR DESCRIPTION
R-devel now links to libdeflate, so we need to
install it, and also depend on it.