### PR TITLE
Switch to using vpcId and creating the security group directly from within serverless

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -113,7 +113,7 @@ rBuildsBatchComputeEnvironment:
       SpotIamFleetRole:
         "Fn::GetAtt": [ rBuildsSpotFleetIamRole, Arn ]
       SecurityGroupIds:
-        "Fn::GetAtt": [ rBuildsSecurityGroup, GroupId ]
+        - "Fn::GetAtt": [ rBuildsSecurityGroup, GroupId ]
       Subnets: ${self:custom.subnets}
       Type: SPOT
       BidPercentage: 100

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -4,7 +4,7 @@ rBuildsSecurityGroup:
     GroupDescription: RBuilds jobs - ${self:provider.stage}
     GroupName: RBuildsJobs-${self:provider.stage}
     VpcId: ${self:custom.vpcId}
-    Tags: ${self:provider.stackTags}
+    Tags: ${self:provider.tagsList}
 
 
 rBuildsBatchIamRole:
@@ -131,7 +131,7 @@ rBuildsBatchComputeEnvironment:
         - c5a.xlarge
         - c5a.2xlarge
       Ec2KeyPair: ${self:custom.ec2KeyPair}
-      Tags: ${self:provider.stackTags}
+      Tags: ${self:provider.tagsMap}
       MinvCpus: 0
       DesiredvCpus: 0
       MaxvCpus: 256

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -1,3 +1,12 @@
+rBuildsSecurityGroup:
+  Type: AWS::EC2::SecurityGroup
+  Properties:
+    GroupDescription: Security Group for the RBuilds jobs
+    GroupName: RBuildsJobs
+    VpcId: ${self:custom.vpcId}
+    Tags: ${self:custom.tagsList}
+
+
 rBuildsBatchIamRole:
   Type: AWS::IAM::Role
   Properties:
@@ -103,7 +112,8 @@ rBuildsBatchComputeEnvironment:
         Version: '$Latest'
       SpotIamFleetRole:
         "Fn::GetAtt": [ rBuildsSpotFleetIamRole, Arn ]
-      SecurityGroupIds: ${self:custom.securityGroupIds}
+      SecurityGroupIds:
+        "Fn::GetAtt": [ rBuildsSecurityGroup, GroupId ]
       Subnets: ${self:custom.subnets}
       Type: SPOT
       BidPercentage: 100

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -4,7 +4,7 @@ rBuildsSecurityGroup:
     GroupDescription: Security Group for the RBuilds jobs
     GroupName: RBuildsJobs
     VpcId: ${self:custom.vpcId}
-    Tags: ${self:custom.tagsList}
+    Tags: ${self:provider.stackTags}
 
 
 rBuildsBatchIamRole:

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -106,6 +106,7 @@ rBuildsBatchComputeEnvironment:
     ServiceRole:
       "Fn::GetAtt": [ rBuildsBatchIamRole, Arn ]
     ComputeResources:
+      AllocationStrategy: BEST_FIT_PROGRESSIVE
       LaunchTemplate:
         LaunchTemplateId:
           Ref: rBuildsEcsLaunchTemplate

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -1,8 +1,8 @@
 rBuildsSecurityGroup:
   Type: AWS::EC2::SecurityGroup
   Properties:
-    GroupDescription: Security Group for the RBuilds jobs
-    GroupName: RBuildsJobs
+    GroupDescription: RBuilds jobs - ${self:provider.stage}
+    GroupName: RBuildsJobs-${self:provider.stage}
     VpcId: ${self:custom.vpcId}
     Tags: ${self:provider.stackTags}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,7 +22,17 @@ provider:
   stage: ${opt:stage, self:custom.defaultStage}
   deploymentBucket:
     name: ${self:custom.deploymentBucket}
-  stackTags: ${self:custom.${self:provider.stage}.stackTags}
+  tagsList:
+    - Key: rs:project
+      Value: ${self:custom.${self:provider.stage}.tags.project}
+    - Key: rs:owner
+      Value: ${self:custom.${self:provider.stage}.tags.owner}
+    - Key: rs:environment
+      Value: ${self:custom.${self:provider.stage}.tags.environment}
+  tagsMap:
+    "rs:owner": ${self:custom.${self:provider.stage}.tags.owner}
+    "rs:project": ${self:custom.${self:provider.stage}.tags.project}
+    "rs:environment": ${self:custom.${self:provider.stage}.tags.environment}
   iamRoleStatements:
     -  Effect: Allow
        Action:


### PR DESCRIPTION
Requires updates to the `serverless-custom.yml` file be uploaded to s3 first

closes #170 