### PR TITLE
Theoretically we can remove the rBuildsBatchIamRole because the AWSSe…

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -6,21 +6,6 @@ rBuildsSecurityGroup:
     VpcId: ${self:custom.vpcId}
     Tags: ${self:provider.tagsList}
 
-
-rBuildsBatchIamRole:
-  Type: AWS::IAM::Role
-  Properties:
-    Path: /service-role/
-    AssumeRolePolicyDocument:
-      Version: '2012-10-17'
-      Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-              - batch.amazonaws.com
-          Action: sts:AssumeRole
-    ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 rBuildsSpotFleetIamRole:
   Type: AWS::IAM::Role
   Properties:
@@ -103,8 +88,6 @@ rBuildsBatchComputeEnvironment:
   DependsOn: rBuildsBatchIamRole
   Properties:
     Type: MANAGED
-    ServiceRole:
-      "Fn::GetAtt": [ rBuildsBatchIamRole, Arn ]
     ComputeResources:
       AllocationStrategy: BEST_FIT_PROGRESSIVE
       LaunchTemplate:
@@ -135,6 +118,7 @@ rBuildsBatchComputeEnvironment:
       MinvCpus: 0
       DesiredvCpus: 0
       MaxvCpus: 256
+      UpdateToLatestImageVersion: true
 
 rBuildsBatchJobQueue:
   Type: AWS::Batch::JobQueue


### PR DESCRIPTION
…rviceRoleForBatch will be automatically created if we don't specify a service role for the compute environment
<img width="1056" alt="image" src="https://github.com/rstudio/r-builds/assets/266698/d3149b77-5624-4a8f-99a3-4fb11260178a">

Start the process to get to a place where the images will update automatically: 
<img width="1055" alt="image" src="https://github.com/rstudio/r-builds/assets/266698/2f3a38f2-f567-4272-8d43-608149c1029b">

We'll need to set this to false to get that fully enabled, but, it needs to happen in a separate PR.
<img width="1035" alt="image" src="https://github.com/rstudio/r-builds/assets/266698/04be409f-c554-440a-959c-b77dfe552233">
