### PR TITLE
The xfig() device is deprecated in R 4.4.0

### DIFF
--- a/builder/package.ubuntu-2204
+++ b/builder/package.ubuntu-2204
@@ -11,6 +11,11 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 - libpcre3-dev'
 fi
 
+deflate_libs='# - libdeflate-dev'
+if grep -q '^LIBS *=.*[-]ldeflate' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    deflate_libs='- libdeflate-dev'
+fi
+
 cat <<EOF > /tmp/nfpm.yml
 name: r-${R_VERSION}
 version: 1
@@ -35,6 +40,7 @@ depends:
 - libc6
 - libcairo2
 - libcurl4
+${deflate_libs}
 - libglib2.0-0
 - libgomp1
 - libicu-dev

--- a/test/test.R
+++ b/test/test.R
@@ -34,8 +34,10 @@ tryCatch(capabilities(), warning = function(w) {
 
 # Check graphics devices
 # https://stat.ethz.ch/R-manual/R-devel/library/grDevices/html/Devices.html
-for (dev_name in c("png", "jpeg", "tiff", "svg", "bmp", "pdf", "postscript",
-                   "xfig", "pictex", "cairo_pdf", "cairo_ps")) {
+devices <- c("png", "jpeg", "tiff", "svg", "bmp", "pdf", "postscript",
+             if (getRversion() < "4.4.0") "xfig",
+             "pictex", "cairo_pdf", "cairo_ps")
+for (dev_name in devices) {
   # Skip unsupported graphics devices (e.g. tiff in R >= 3.3 on CentOS 6)
   if (dev_name %in% names(capabilities()) && capabilities(dev_name) == FALSE) {
     next

--- a/test/test.R
+++ b/test/test.R
@@ -35,8 +35,8 @@ tryCatch(capabilities(), warning = function(w) {
 # Check graphics devices
 # https://stat.ethz.ch/R-manual/R-devel/library/grDevices/html/Devices.html
 devices <- c("png", "jpeg", "tiff", "svg", "bmp", "pdf", "postscript",
-             if (getRversion() < "4.4.0") "xfig",
-             "pictex", "cairo_pdf", "cairo_ps")
+             if (getRversion() < "4.4.0") c("xfig", "pictex"),
+             "cairo_pdf", "cairo_ps")
 for (dev_name in devices) {
   # Skip unsupported graphics devices (e.g. tiff in R >= 3.3 on CentOS 6)
   if (dev_name %in% names(capabilities()) && capabilities(dev_name) == FALSE) {


### PR DESCRIPTION
So we do not test it any more.

Cf. wch/r-source@d04d9db

This is on top of #204.