### PR TITLE
Fix unexpected `4.3.3.tar.xz` version in `versions.json`

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -52,7 +52,7 @@ def _cran_r_versions(url):
     r_versions = []
     for link in soup.find_all('a'):
         href = link.get('href')
-        if 'R-' in href:
+        if href.startswith('R-') and href.endswith('.tar.gz'):
             v = href.replace('.tar.gz', '').replace('R-', '')
             if '-revised' not in v:  # reject 3.2.4-revised
                 r_versions.append(v)


### PR DESCRIPTION
For #209

Update versions.json generation for addition of .tar.xz source files.

```python
>>> _cran_r_versions(CRAN_SRC_R3_URL)
['3.0.0', '3.0.1', '3.0.2', '3.0.3', '3.1.0', '3.1.1', '3.1.2', '3.1.3', '3.2.0', '3.2.1', '3.2.2', '3.2.3', '3.2.4', '3.2.5', '3.3.0', '3.3.1', '3.3.2', '3.3.3', '3.4.0', '3.4.1', '3.4.2', '3.4.3', '3.4.4', '3.5.0', '3.5.1', '3.5.2', '3.5.3', '3.6.0', '3.6.1', '3.6.2', '3.6.3']
>>> _cran_r_versions(CRAN_SRC_R4_URL)
['4.0.0', '4.0.1', '4.0.2', '4.0.3', '4.0.4', '4.0.5', '4.1.0', '4.1.1', '4.1.2', '4.1.3', '4.2.0', '4.2.1', '4.2.2', '4.2.3', '4.3.0', '4.3.1', '4.3.2', '4.3.3']
```