### PR TITLE
Add support for Ubuntu 24.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-2004 ubuntu-2204 debian-10 debian-11 debian-12 centos-7 centos-8 rhel-9 opensuse-154 opensuse-155 fedora-38 fedora-39
+PLATFORMS := ubuntu-2004 ubuntu-2204 ubuntu-2404 debian-10 debian-11 debian-12 centos-7 centos-8 rhel-9 opensuse-154 opensuse-155 fedora-38 fedora-39
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless.js
 
 deps:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bug, or ask questions on [Posit Community](https://community.rstudio.com).
 
 R binaries are built for the following Linux operating systems:
 
-- Ubuntu 20.04, 22.04
+- Ubuntu 20.04, 22.04, 24.04
 - Debian 10, 11, 12
 - CentOS 7
 - Red Hat Enterprise Linux 7, 8, 9
@@ -51,7 +51,7 @@ bash -c "$(curl -L https://rstd.io/r-install)"
 Define the version of R that you want to install. Available versions
 of R can be found here: https://cdn.posit.co/r/versions.json
 ```bash
-R_VERSION=4.1.3
+R_VERSION=4.3.3
 ```
 
 ### Download and install R
@@ -64,6 +64,9 @@ curl -O https://cdn.posit.co/r/ubuntu-2004/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Ubuntu 22.04
 curl -O https://cdn.posit.co/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_amd64.deb
+
+# Ubuntu 24.04
+curl -O https://cdn.posit.co/r/ubuntu-2404/pkgs/r-${R_VERSION}_1_amd64.deb
 
 # Debian 10
 curl -O https://cdn.posit.co/r/debian-10/pkgs/r-${R_VERSION}_1_amd64.deb

--- a/builder/Dockerfile.ubuntu-2404
+++ b/builder/Dockerfile.ubuntu-2404
@@ -1,0 +1,33 @@
+FROM ubuntu:noble
+
+ENV OS_IDENTIFIER ubuntu-2404
+
+RUN set -x \
+  && sed -i "s|Types: deb|Types: deb deb-src|g" /etc/apt/sources.list.d/ubuntu.sources \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt update \
+  && apt install -y curl libcurl4-openssl-dev libicu-dev libopenblas0-pthread libpcre2-dev libpcre3-dev unzip wget \
+  && apt build-dep -y r-base
+
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_$(dpkg --print-architecture).deb" && \
+    apt install -y "./nfpm_$(dpkg --print-architecture).deb" && \
+    rm "nfpm_$(dpkg --print-architecture).deb"
+
+RUN chmod 0777 /opt
+
+# Override the default pager used by R
+ENV PAGER /usr/bin/pager
+
+# R 3.x requires PCRE2 for Pango support on Ubuntu 24
+ENV INCLUDE_PCRE2_IN_R_3 yes
+
+COPY package.ubuntu-2404 /package.sh
+COPY build.sh .
+COPY patches /patches
+ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -23,6 +23,18 @@ services:
     image: r-builds:ubuntu-2204
     volumes:
       - ./integration/tmp:/tmp/output
+  ubuntu-2404:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.ubuntu-2404
+    image: r-builds:ubuntu-2404
+    volumes:
+      - ./integration/tmp:/tmp/output
   debian-10:
     command: ./build.sh
     environment:

--- a/builder/package.ubuntu-2404
+++ b/builder/package.ubuntu-2404
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
+fi
+
+# R 3.x requires PCRE1. On Ubuntu 24, R 3.x also requires PCRE2 for Pango support.
+pcre_libs='- libpcre2-dev'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_libs='- libpcre2-dev
+- libpcre3-dev'
+fi
+
+deflate_libs='# - libdeflate-dev'
+if grep -q '^LIBS *=.*[-]ldeflate' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    deflate_libs='- libdeflate-dev'
+fi
+
+cat <<EOF > /tmp/nfpm.yml
+name: r-${R_VERSION}
+version: 1
+version_schema: none
+section: universe/math
+priority: optional
+arch: $(dpkg --print-architecture)
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: Posit Software, PBC
+homepage: https://www.r-project.org
+license: GPL-2
+deb:
+  fields:
+    Bugs: https://github.com/rstudio/r-builds/issues
+depends:
+- g++
+- gcc
+- gfortran
+- libbz2-dev
+- libc6
+- libcairo2
+- libcurl4t64
+${deflate_libs}
+- libglib2.0-0t64
+- libgomp1
+- libicu-dev
+- libjpeg8
+- liblzma-dev
+- libopenblas-dev
+- libpango-1.0-0
+- libpangocairo-1.0-0
+- libpaper-utils
+${pcre_libs}
+- libpng16-16t64
+- libreadline8t64
+- libtcl8.6
+- libtiff6
+- libtirpc-dev
+- libtk8.6
+- libx11-6
+- libxt6t64
+- make
+- ucf
+- unzip
+- zip
+- zlib1g-dev
+contents:
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
+EOF
+
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p deb \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/r-${R_VERSION}*.deb | head -1)

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -157,6 +157,20 @@ rBuildsBatchJobDefinitionUbuntu2204:
       Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:ubuntu-2204"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionUbuntu2404:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:ubuntu-2404"
+    Timeout:
+      AttemptDurationSeconds: 7200
 rBuildsBatchJobDefinitionDebian10:
   Type: AWS::Batch::JobDefinition
   Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -59,6 +59,8 @@ provider:
       Ref: rBuildsBatchJobDefinitionUbuntu2004
     JOB_DEFINITION_ARN_ubuntu_2204:
       Ref: rBuildsBatchJobDefinitionUbuntu2204
+    JOB_DEFINITION_ARN_ubuntu_2404:
+      Ref: rBuildsBatchJobDefinitionUbuntu2404
     JOB_DEFINITION_ARN_debian_10:
       Ref: rBuildsBatchJobDefinitionDebian10
     JOB_DEFINITION_ARN_debian_11:
@@ -79,7 +81,7 @@ provider:
       Ref: rBuildsBatchJobDefinitionFedora38
     JOB_DEFINITION_ARN_fedora_39:
       Ref: rBuildsBatchJobDefinitionFedora39
-    SUPPORTED_PLATFORMS: ubuntu-2004,ubuntu-2204,debian-10,debian-11,debian-12,centos-7,centos-8,rhel-9,opensuse-154,opensuse-155,fedora-38,fedora-39
+    SUPPORTED_PLATFORMS: ubuntu-2004,ubuntu-2204,ubuntu-2404,debian-10,debian-11,debian-12,centos-7,centos-8,rhel-9,opensuse-154,opensuse-155,fedora-38,fedora-39
 
 functions:
   queueBuilds:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,6 +15,14 @@ services:
       - R_VERSION=${R_VERSION}
     volumes:
       - ../:/r-builds
+  ubuntu-2404:
+    image: ubuntu:noble
+    command: /r-builds/test/test-apt.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-2404
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ../:/r-builds
   debian-12:
     image: debian:bookworm
     command: /r-builds/test/test-apt.sh


### PR DESCRIPTION
Adds Ubuntu 24.04. It's currently in beta so this is just adding early support to unblock other things. When Ubuntu 24 is officially released, we can rerun the builds and update the documentation website.