### PR TITLE
Patch R 4.0.0 - R 4.3.3 for CVE-2024-27322

### DIFF
--- a/builder/patches/R-4.0.0.patch
+++ b/builder/patches/R-4.0.0.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 1e5bc60..1ce0c7b 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 094396b..75fae89 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN 4.0.0:
+ \section{\Rlogo CHANGES IN 4.0.0}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
  
-   SIGNIFICANT USER-VISIBLE CHANGES:
+   \subsection{SIGNIFICANT USER-VISIBLE CHANGES}{
+     \itemize{

--- a/builder/patches/R-4.0.0.patch
+++ b/builder/patches/R-4.0.0.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 1e5bc60..1ce0c7b 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN 4.0.0:
+ 
+   SIGNIFICANT USER-VISIBLE CHANGES:

--- a/builder/patches/R-4.0.1.patch
+++ b/builder/patches/R-4.0.1.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 8cd0e5c..10e38db 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 9417774..5a7fa23 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.0.1:
+ \section{\Rlogo CHANGES IN R 4.0.1}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
  
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{

--- a/builder/patches/R-4.0.1.patch
+++ b/builder/patches/R-4.0.1.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 8cd0e5c..10e38db 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.0.1:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.0.2.patch
+++ b/builder/patches/R-4.0.2.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 502ee68..704deb0 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 4c45f26..69285cd 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.0.2:
+ \section{\Rlogo CHANGES IN R 4.0.2}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
  
-   UTILITIES:
+   \subsection{UTILITIES}{
+     \itemize{

--- a/builder/patches/R-4.0.2.patch
+++ b/builder/patches/R-4.0.2.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 502ee68..704deb0 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.0.2:
+ 
+   UTILITIES:

--- a/builder/patches/R-4.0.3.patch
+++ b/builder/patches/R-4.0.3.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 7983a71..16c6674 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 916961a..521a1fd 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.0.3:
+ \section{\Rlogo CHANGES IN R 4.0.3}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
  
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{

--- a/builder/patches/R-4.0.3.patch
+++ b/builder/patches/R-4.0.3.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 7983a71..16c6674 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.0.3:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.0.4.patch
+++ b/builder/patches/R-4.0.4.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index ceaf22c..0688cd2 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index ec44c62..510dadc 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.0.4:
+ \section{\Rlogo CHANGES IN R 4.0.4}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
  
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{

--- a/builder/patches/R-4.0.4.patch
+++ b/builder/patches/R-4.0.4.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index ceaf22c..0688cd2 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.0.4:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.0.5.patch
+++ b/builder/patches/R-4.0.5.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index b20a8ee..7ed2d27 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 5640a16..5bebf9e 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.0.5:
- 
-   BUG FIXES:
+ \section{\Rlogo CHANGES IN R 4.0.5}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
+   \subsection{BUG FIXES}{
+     \itemize{
+       \item The change to the internal table in \R 4.0.4 for

--- a/builder/patches/R-4.0.5.patch
+++ b/builder/patches/R-4.0.5.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index b20a8ee..7ed2d27 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.0.5:
+ 
+   BUG FIXES:

--- a/builder/patches/R-4.1.0.patch
+++ b/builder/patches/R-4.1.0.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 39cdf12..d162c18 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.1.0:
+ 
+   FUTURE DIRECTIONS:

--- a/builder/patches/R-4.1.0.patch
+++ b/builder/patches/R-4.1.0.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 39cdf12..d162c18 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 2fcc2e7..f0ed95b 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.1.0:
- 
-   FUTURE DIRECTIONS:
+ \section{\Rlogo CHANGES IN R 4.1.0}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
+   \subsection{FUTURE DIRECTIONS}{
+     \itemize{
+       \item It is planned that the 4.1.x series will be the last to

--- a/builder/patches/R-4.1.1.patch
+++ b/builder/patches/R-4.1.1.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index b58c1e2..96c03e7 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 8515986..760dccb 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.1.1}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.1.1:
- 
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{
+       \item \code{require(\var{pkg}, quietly = TRUE)} is quieter and in

--- a/builder/patches/R-4.1.1.patch
+++ b/builder/patches/R-4.1.1.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index b58c1e2..96c03e7 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.1.1:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.1.2.patch
+++ b/builder/patches/R-4.1.2.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index ec745b3..0a3929b 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.1.2:
+ 
+   C-LEVEL FACILITIES:

--- a/builder/patches/R-4.1.2.patch
+++ b/builder/patches/R-4.1.2.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index ec745b3..0a3929b 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 90c8408..d24571b 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.1.2:
- 
-   C-LEVEL FACILITIES:
+ \section{\Rlogo CHANGES IN R 4.1.2}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
+   \subsection{C-LEVEL FACILITIES}{
+     \itemize{
+       \item The workaround in headers \file{R.h} and \file{Rmath.h}

--- a/builder/patches/R-4.1.3.patch
+++ b/builder/patches/R-4.1.3.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index a93a043..59d0dc8 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.1.3:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.1.3.patch
+++ b/builder/patches/R-4.1.3.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index a93a043..59d0dc8 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 8b4e587..b4f145e 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.1.3}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.1.3:
- 
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{
+       \item The default version of Bioconductor has been changed to

--- a/builder/patches/R-4.2.0.patch
+++ b/builder/patches/R-4.2.0.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 690d0d4..91658c3 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.2.0:
+ 
+   SIGNIFICANT USER-VISIBLE CHANGES:

--- a/builder/patches/R-4.2.0.patch
+++ b/builder/patches/R-4.2.0.patch
@@ -45,18 +45,20 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 690d0d4..91658c3 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 62f25ae..82dfac6 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,12 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
-+
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.2.0:
- 
-   SIGNIFICANT USER-VISIBLE CHANGES:
+ \section{\Rlogo CHANGES IN R 4.2.0}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
+   \subsection{SIGNIFICANT USER-VISIBLE CHANGES}{
+     \itemize{
+       \item The \code{formula} method of \code{aggregate()} now matches

--- a/builder/patches/R-4.2.1.patch
+++ b/builder/patches/R-4.2.1.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 238859d..3c8f99f 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 630c88f..3504a87 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.2.1}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.2.1:
- 
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{
+       \item New function \code{utils::findCRANmirror()} to find out if a

--- a/builder/patches/R-4.2.1.patch
+++ b/builder/patches/R-4.2.1.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 238859d..3c8f99f 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.2.1:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.2.2.patch
+++ b/builder/patches/R-4.2.2.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 08256d2..9dbe631 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.2.2:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.2.2.patch
+++ b/builder/patches/R-4.2.2.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 08256d2..9dbe631 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index b52627e..aee4475 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.2.2}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.2.2:
- 
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{
+       \item \code{tools::Rdiff(useDiff = TRUE)} checks for the presence

--- a/builder/patches/R-4.2.3.patch
+++ b/builder/patches/R-4.2.3.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index a30f7d3..d914b72 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index fe2a646..986e83d 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.2.3}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.2.3:
- 
-   C-LEVEL FACILITIES:
+   \subsection{C-LEVEL FACILITIES}{
+     \itemize{
+       \item The definition of \code{DL_FUNC} in \file{R_ext/Rdynload.h}

--- a/builder/patches/R-4.2.3.patch
+++ b/builder/patches/R-4.2.3.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index a30f7d3..d914b72 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.2.3:
+ 
+   C-LEVEL FACILITIES:

--- a/builder/patches/R-4.3.0.patch
+++ b/builder/patches/R-4.3.0.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 2e83bc3..185f45f 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 2fd50d5..6b24e71 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.3.0}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.3.0:
- 
-   SIGNIFICANT USER-VISIBLE CHANGES:
+   \subsection{SIGNIFICANT USER-VISIBLE CHANGES}{
+     \itemize{
+       \item Calling \code{&&} or \code{||} with LHS or (if evaluated) RHS of

--- a/builder/patches/R-4.3.0.patch
+++ b/builder/patches/R-4.3.0.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 2e83bc3..185f45f 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.3.0:
+ 
+   SIGNIFICANT USER-VISIBLE CHANGES:

--- a/builder/patches/R-4.3.1.patch
+++ b/builder/patches/R-4.3.1.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 317399c..4235d4d 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.3.1:
+ 
+   C-LEVEL FACILITIES:

--- a/builder/patches/R-4.3.1.patch
+++ b/builder/patches/R-4.3.1.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 317399c..4235d4d 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 5ca6489..62db476 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.3.1}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.3.1:
- 
-   C-LEVEL FACILITIES:
+   \subsection{C-LEVEL FACILITIES}{
+     \itemize{
+       \item The C-level API version of \R's \code{integrate()},

--- a/builder/patches/R-4.3.2.patch
+++ b/builder/patches/R-4.3.2.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index ae99650..8c618d8 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.3.2:
+ 
+   NEW FEATURES:

--- a/builder/patches/R-4.3.2.patch
+++ b/builder/patches/R-4.3.2.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index ae99650..8c618d8 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index dd59f87..f3abe02 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -6,6 +6,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.3.2}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.3.2:
- 
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{
+       \item The default initialization of the \code{"repos"} option

--- a/builder/patches/R-4.3.3.patch
+++ b/builder/patches/R-4.3.3.patch
@@ -45,18 +45,21 @@ index a389f71311..a190fbf8f3 100644
      SEXP object, icon, type, ver, fun;
      object = CAR(args); args = CDR(args);
      icon = CAR(args); args = CDR(args);
-diff --git a/doc/NEWS b/doc/NEWS
-index 7effa64..88f396d 100644
---- a/doc/NEWS
-+++ b/doc/NEWS
-@@ -1,5 +1,10 @@
- R News
+diff --git a/doc/NEWS.Rd b/doc/NEWS.Rd
+index 25bdb12..7456662 100644
+--- a/doc/NEWS.Rd
++++ b/doc/NEWS.Rd
+@@ -7,6 +7,13 @@
+ \encoding{UTF-8}
  
-+CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
+ \section{\Rlogo CHANGES IN R 4.3.3}{
++  \subsection{CHANGES IN POSIT'S BUILD FROM \url{https://github.com/rstudio/r-builds}}{
++    \itemize{
++      \item readRDS() and unserialize() now signal an error instead of
++      returning a PROMSXP, to fix CVE-2024-27322.
++    }
++  }
 +
-+    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
-+      to fix CVE-2024-27322.
-+
- CHANGES IN R 4.3.3:
- 
-   NEW FEATURES:
+   \subsection{NEW FEATURES}{
+     \itemize{
+       \item \code{iconv()} now fixes up variant encoding names such as

--- a/builder/patches/R-4.3.3.patch
+++ b/builder/patches/R-4.3.3.patch
@@ -1,0 +1,62 @@
+commit c06f7f2518673a75f9b36f2af9caf7b69ab4952e
+Author: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date:   Sun Mar 31 19:35:58 2024 +0000
+
+    readRDS() and unserialize() now signal an errorr instead of returning a PROMSXP.
+    
+    
+    git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f71311..a190fbf8f3 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);
+diff --git a/doc/NEWS b/doc/NEWS
+index 7effa64..88f396d 100644
+--- a/doc/NEWS
++++ b/doc/NEWS
+@@ -1,5 +1,10 @@
+ R News
+ 
++CHANGES IN POSIT'S BUILD FROM https://github.com/rstudio/r-builds
++
++    * readRDS() and unserialize() now signal an error instead of returning a PROMSXP,
++      to fix CVE-2024-27322.
++
+ CHANGES IN R 4.3.3:
+ 
+   NEW FEATURES:


### PR DESCRIPTION
We also update the NEWS file, so by grepping for
'CVE-2024-27322' one can tell if the patched version is installed or not.