### PR TITLE
Fix invalid image for fedora-40

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -310,7 +310,7 @@ rBuildsBatchJobDefinitionFedora40:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:fedora-40"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/r-builds:fedora-40"
     Timeout:
       AttemptDurationSeconds: 7200
 


### PR DESCRIPTION
Just a PR ordering thing, #217 was made before #224 so we need to pull the `Image` changes from that later PR. Right now, builds fail from an invalid image syntax:
```json
{
  "jobArn": "arn:aws:batch:us-east-1:263245908434:job/1181280c-634a-4349-a163-64ae114b0c27",
  "jobName": "R-4_3_3-fedora-40",
  "jobId": "1181280c-634a-4349-a163-64ae114b0c27",
  "jobQueue": "arn:aws:batch:us-east-1:263245908434:job-queue/rBuildsBatchJobQueue-f6f17933b1240a9",
  "status": "FAILED",
  "attempts": [],
  "statusReason": "Container.image contains invalid characters.",
  "createdAt": 1716587008400,
  "dependsOn": [],
  "jobDefinition": "arn:aws:batch:us-east-1:263245908434:job-definition/rBuildsBatchJobDefiniti-2ad646f907cbecc:1",
  "parameters": {},
  "container": {
    "image": "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/r-builds:fedora-40",
```