### PR TITLE
Fix CentOS 7 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ deps:
 	npm install
 
 docker-build:
-	@cd builder && docker-compose build --parallel
+	@cd builder && docker compose build --parallel
 
 AWS_ACCOUNT_ID:=$(shell aws sts get-caller-identity --output text --query 'Account')
 AWS_REGION := us-east-1
@@ -16,13 +16,13 @@ docker-push: ecr-login docker-build
 	done
 
 docker-down:
-	@cd builder && docker-compose down
+	@cd builder && docker compose down
 
 docker-build-r: docker-build
-	@cd builder && docker-compose up
+	@cd builder && docker compose up
 
 docker-shell-r-env:
-	@cd builder && docker-compose run --entrypoint /bin/bash ubuntu-2004
+	@cd builder && docker compose run --entrypoint /bin/bash ubuntu-2004
 
 ecr-login:
 	(aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com)
@@ -41,13 +41,13 @@ serverless-deploy.%: deps fetch-serverless-custom-file
 
 define GEN_TARGETS
 docker-build-$(platform):
-	@cd builder && docker-compose build $(platform)
+	@cd builder && docker compose build $(platform)
 
 build-r-$(platform):
-	@cd builder && R_VERSION=$(R_VERSION) docker-compose run --rm $(platform)
+	@cd builder && R_VERSION=$(R_VERSION) docker compose run --rm $(platform)
 
 test-r-$(platform):
-	@cd test && R_VERSION=$(R_VERSION) docker-compose run --rm $(platform)
+	@cd test && R_VERSION=$(R_VERSION) docker compose run --rm $(platform)
 
 bash-$(platform):
 	docker run -it --rm --entrypoint /bin/bash -v $(CURDIR):/r-builds r-builds:$(platform)

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -2,6 +2,9 @@ FROM centos:centos7
 
 ENV OS_IDENTIFIER centos-7
 
+# Use vault.centos.org since CentOS 7 is EOL and the official mirrors are no longer available
+RUN sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*
+
 RUN yum -y update \
     && yum -y install \
     autoconf \

--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ install_epel () {
       ${SUDO} yum install ${yes} https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
       ;;
     "7")
-      ${SUDO} yum install ${yes} https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+      ${SUDO} yum install ${yes} https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
       ;;
     "8")
       ;;

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -49,7 +49,9 @@ services:
       - ../:/r-builds
   centos-7:
     image: centos:centos7
-    command: /r-builds/test/test-yum.sh
+    command: |
+      /bin/bash -c 'sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/* &&
+      /r-builds/test/test-yum.sh'
     environment:
       - OS_IDENTIFIER=centos-7
       - R_VERSION=${R_VERSION}


### PR DESCRIPTION
Fix CentOS 7 builds - use vault.centos.org now that the mirrors are removed.

CentOS 7 is EOL but we still need it around for a little longer before fully deprecating it.

Also switch deprecated docker-compose commands to `docker compose`. This was also causing failures in GHA.