### PR TITLE
Fix missing Pango support in R 3.x for openSUSE 15.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,9 @@ on:
         description: |
           Comma-separated list of R versions. Specify "last-N" to use the
           last N minor R versions, or "all" to use all minor R versions since R 3.1.
-          Defaults to "last-5,devel".
+          Defaults to "last-5,3.6.3,devel".
         required: false
-        default: 'last-5,devel'
+        default: 'last-5,3.6.3,devel'
         type: string
 
 permissions:

--- a/builder/Dockerfile.opensuse-156
+++ b/builder/Dockerfile.opensuse-156
@@ -99,6 +99,9 @@ ENV CONFIGURE_OPTIONS="\
 # https://solutions.posit.co/envs-pkgs/using-rjava/
 ENV JAVA_HOME=/usr/lib64/jvm/jre-11-openjdk
 
+# R 3.x requires PCRE2 for Pango support on SUSE 15.6
+ENV INCLUDE_PCRE2_IN_R_3 yes
+
 COPY package.opensuse-156 /package.sh
 COPY build.sh .
 COPY patches /patches

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -118,7 +118,7 @@ compile_r() {
   #
   # The INCLUDE_PCRE2_IN_R_3 environment variable can be set to include PCRE2
   # in R 3.x builds, for distributions where PCRE2 is always required.
-  # In Debian 11/Ubuntu 22/RHEL 9, Pango now depends on PCRE2, so R 3.x will not be compiled with
+  # In Debian 11/Ubuntu 22/RHEL 9/SUSE 15.6, Pango now depends on PCRE2, so R 3.x will not be compiled with
   # Pango support if the PCRE2 pkg-config file is missing.
   if [[ "${r_version}" =~ ^3 ]] && pkg-config --exists libpcre2-8 && [ -z "$INCLUDE_PCRE2_IN_R_3" ]; then
     mkdir -p /tmp/pcre2

--- a/builder/package.opensuse-156
+++ b/builder/package.opensuse-156
@@ -4,10 +4,11 @@ if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
   mkdir -p "/tmp/output/${OS_IDENTIFIER}"
 fi
 
-# R 3.x requires PCRE1
-pcre_lib='pcre2-devel'
+# R 3.x requires PCRE1. On openSUSE 15.6+, R 3.x also requires PCRE2 for Pango support.
+pcre_libs='- pcre2-devel'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
-  pcre_lib='pcre-devel'
+  pcre_libs='- pcre2-devel
+-d pcre-devel'
 fi
 
 # Create post-install script required for OpenBLAS.
@@ -72,7 +73,7 @@ depends:
 - libreadline7
 - libtiff6
 - make
-- ${pcre_lib}
+${pcre_libs}
 - tar
 - tcl
 - tk

--- a/builder/package.opensuse-156
+++ b/builder/package.opensuse-156
@@ -8,7 +8,7 @@ fi
 pcre_libs='- pcre2-devel'
 if [[ "${R_VERSION}" =~ ^3 ]]; then
   pcre_libs='- pcre2-devel
--d pcre-devel'
+- pcre-devel'
 fi
 
 # Create post-install script required for OpenBLAS.

--- a/test/get_r_versions.py
+++ b/test/get_r_versions.py
@@ -15,10 +15,11 @@ def main():
         'versions',
         type=str,
         nargs='?',
-        default='last-5,devel',
+        # R 3.6 is a special case, as we need longer term (but unstated) support for it.
+        default='last-5,3.6.3,devel',
         help="""Comma-separated list of R versions. Specify "last-N" to use the
             last N minor R versions, or "all" to use all minor R versions since R 3.1.
-            Defaults to "last-5,devel".
+            Defaults to "last-5,3.6.3,devel".
             """
     )
     args = parser.parse_args()


### PR DESCRIPTION

Fix missing Pango support in R 3.x for openSUSE 15.6. Same as https://github.com/rstudio/r-builds/pull/120 for Ubuntu 22 a while back. This was a new thing in SUSE 15.6, and wasn't caught by the tests because we don't test R 3.x anymore. I've added a test for R 3.6, since we have to support it longer term than usual.

The error was with running any graphics device, like `png()`:
```r
> png()
Error in .External2(C_X11, paste0("png::", filename), g$width, g$height,  : 
  unable to start device PNG
In addition: Warning message:
In png() : unable to open connection to X11 display ''

# This should be cairo
> getOption("bitmapType")
[1] "Xlib"
```

And Pango now depending on PCRE2 in SUSE 15.6:
```sh
$ zypper in pango-devel

The following 120 NEW packages are going to be installed:
  ... libpango-1_0-0 libpcre2-16-0 libpcre2-32-0 libpcre2-posix3
  ...
```

After the fix, the tests should pass and `png()` should work again