### PR TITLE
Fix BLAS portability issues with Ubuntu 20.04 R builds

### DIFF
--- a/builder/Dockerfile.debian-12
+++ b/builder/Dockerfile.debian-12
@@ -7,7 +7,7 @@ RUN set -x \
   && echo 'deb-src http://deb.debian.org/debian bookworm main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y curl gcc libcurl4-openssl-dev libicu-dev \
-     libopenblas0 libpcre2-dev make unzip wget \
+     libopenblas0-pthread libpcre2-dev make unzip wget \
   && apt-get build-dep -y r-base
 
 # Install AWS CLI

--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -6,7 +6,7 @@ RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y curl libopenblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip \
+  && apt-get install -y curl libopenblas0-pthread libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev wget python3-pip \
   && apt-get build-dep -y r-base
 
 RUN pip3 install awscli

--- a/builder/Dockerfile.ubuntu-2404
+++ b/builder/Dockerfile.ubuntu-2404
@@ -6,6 +6,13 @@ RUN set -x \
   && sed -i "s|Types: deb|Types: deb deb-src|g" /etc/apt/sources.list.d/ubuntu.sources \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt update \
+  # For BLAS/LAPACK, select the library-only OpenBLAS package that gets included in the
+  # the libopenblas-dev package by default. Usually this is OpenBLAS with pthreads.
+  #
+  # Note that libopenblas-dev must NOT be installed to ensure that R links to BLAS in a
+  # portable way, via the generic libblas.so provided by the libblas-dev package.
+  # This gets installed through the r-base build dependencies. If both libblas-dev and
+  # libopenblas-dev are present, R will prefer linking to OpenBLAS.
   && apt install -y curl libcurl4-openssl-dev libicu-dev libopenblas0-pthread libpcre2-dev libpcre3-dev unzip wget \
   && apt build-dep -y r-base
 


### PR DESCRIPTION
Issue reported by @dpastoor about some Package Manager binary packages failing to load on Ubuntu 20, like RcppArmadillo. 

When we switched the Ubuntu 20 builds to use OpenBLAS once again (https://github.com/rstudio/r-builds/pull/215), this inadvertently changed R to link against OpenBLAS instead of the generic `libblas.so` that all Ubuntu builds should be linking against. The generic `libblas.so` is what allows BLAS libraries to be freely swapped on Ubuntu/Debian without breaking binaries that use it.

So Package Manager binaries that use BLAS are now broken for anyone that installed R on Ubuntu 20 before May 2024. The workaround would be to manually install OpenBLAS via `apt install libopenblas0-pthread`.

This was also the root cause of the Cloud issue from a few months back. Switching the BLAS dependency to OpenBLAS shouldn't have actually changed what R linked to and broken anything. I just didn't realize this back then.

So currently, Ubuntu 20 R links to `libopenblas.so`:
```sh
$ readelf -d $(R RHOME)/lib/libR.so | grep blas
 0x0000000000000001 (NEEDED)             Shared library: [libopenblas.so.0]
```

This is what R should be linking to instead, from the Ubuntu 22/24 builds:
```sh
# jammy
$ readelf -d /opt/R/4.4.0/lib/R/lib/libR.so | grep blas
 0x0000000000000001 (NEEDED)             Shared library: [libblas.so.3]
```

The fix was to remove the development package for OpenBLAS. Apparently if both OpenBLAS and default BLAS dev headers are present, R will choose OpenBLAS first. Alternatively we can explictly specify the linker flags via `--with-blas=-lblas` I think, but I didn't want to change too much.

I've added a comment in the latest Ubuntu dockerfile to document this for the future.