### PR TITLE
Fix Jenkins image build; update Node; pin to serverless v3

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,17 +1,19 @@
-FROM node:14
+FROM node:22
 
 ARG JENKINS_UID=386
 ARG JENKINS_GID=386
 ARG DOCKER_GID=999
 
-RUN apt-get update -qq && apt-get install -y python-pip
-RUN pip install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
 
 # install docker cli
 RUN wget -q -O /tmp/docker-cli.deb https://download.docker.com/linux/debian/dists/stretch/pool/stable/$(dpkg --print-architecture)/docker-ce-cli_18.09.2~3-0~debian-stretch_$(dpkg --print-architecture).deb \
   && dpkg -i /tmp/docker-cli.deb
 
-RUN npm install -g serverless
+RUN npm install -g serverless@3
 
 # Create the jenkins user with the same id:gid as the jenkins node
 RUN groupadd -g $JENKINS_GID jenkins \

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,133 @@
       "name": "r-builds",
       "version": "0.1.0",
       "devDependencies": {
-        "serverless": "^3.36.0",
+        "serverless": "^3.39.0",
         "serverless-better-credentials": "^2.0.0",
         "serverless-python-requirements": "^6.0.0",
         "serverless-step-functions": "^3.21.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -28,6 +151,78 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
@@ -100,6 +295,692 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/@aws-sdk/client-api-gateway": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.686.0.tgz",
+      "integrity": "sha512-L1KIfL6zA2G9HJ8aeiq4/xTP0bUfnzCjSpkmgcG5BQRqXEMASrMaLy/XUlF/2X5MKbyC6GVYZctP203noGu2cw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-sdk-api-gateway": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+      "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+      "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sts": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+      "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/core": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+      "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+      "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+      "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+      "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+      "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-ini": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+      "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+      "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/token-providers": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+      "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+      "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+      "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+      "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+      "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+      "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/token-providers": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+      "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/types": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+      "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-endpoints": "^2.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+      "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+      "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/client-cloudformation": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.577.0.tgz",
@@ -152,6 +1033,3467 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.686.0.tgz",
+      "integrity": "sha512-igTsylpqVJrBL+4JYyI8lBac0USNgd4LQe/Xuwb17w+w5+7sBiZ7j/WBT31mKb+v5GAunJEEWDvRhCjhPUmUew==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+      "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+      "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sts": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+      "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/core": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+      "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+      "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+      "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+      "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+      "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-ini": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+      "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+      "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/token-providers": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+      "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+      "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+      "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+      "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+      "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+      "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/token-providers": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+      "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/types": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+      "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-endpoints": "^2.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+      "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+      "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.686.0.tgz",
+      "integrity": "sha512-5WuXi6BtmIrDo9LDoJ6i1aPA2qkoGoNzMJ5ScPqYLLT7Cx4J+mdA4MOp6vfBvEZR9eaJdWBmUOqxHvP76SQpqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/signature-v4-multi-region": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/client-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+      "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+      "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/client-sts": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+      "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/core": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+      "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+      "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+      "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+      "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+      "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-ini": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+      "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+      "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/token-providers": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+      "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+      "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+      "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+      "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+      "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+      "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/token-providers": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+      "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/types": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+      "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-endpoints": "^2.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+      "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+      "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.686.0.tgz",
+      "integrity": "sha512-x3R3U0xM8fvNhS2IyEKHxmhk6pcQNNlT30Rk8gUi01TK340MKfrlgXQhFKdvez8cdS2HiNkLpfPe4mEupRVYlg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+      "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+      "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sts": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+      "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/core": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+      "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+      "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+      "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+      "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+      "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-ini": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+      "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+      "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/token-providers": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+      "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+      "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+      "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+      "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+      "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+      "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/token-providers": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+      "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/types": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+      "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-endpoints": "^2.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+      "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+      "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.682.0.tgz",
+      "integrity": "sha512-J37hXQ3Qrm+kQ+bd9+yy7n5ZxBfTiCdiI4vpejDld0B5hPF2VO+tIRq5n+xHIHar5aLHnVv3c9pdjqWrYZ8gOg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/client-sts": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/eventstream-serde-browser": "^3.0.10",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
+        "@smithy/eventstream-serde-node": "^3.0.9",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
+      "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
+      "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
+      "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+      "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.679.0.tgz",
+      "integrity": "sha512-EdlTYbzMm3G7VUNAMxr9S1nC1qUNqhKlAxFU8E7cKsAe8Bp29CD5HAs3POc56AVo9GC4yRIS+/mtlZSmrckzUA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.679.0.tgz",
+      "integrity": "sha512-ZoKLubW5DqqV1/2a3TSn+9sSKg0T8SsYMt1JeirnuLJF0mCoYFUaWMyvxxKuxPoqvUsaycxKru4GkpJ10ltNBw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-stream": "^3.1.9",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
+      "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
+      "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-ini": "3.682.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.679.0.tgz",
+      "integrity": "sha512-u/p4TV8kQ0zJWDdZD4+vdQFTMhkDEJFws040Gm113VHa/Xo1SYOjbpvqeuFoz6VmM0bLvoOWjxB9MxnSQbwKpQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
+      "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/token-providers": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.679.0.tgz",
+      "integrity": "sha512-a74tLccVznXCaBefWPSysUcLXYJiSkeUmQGtalNgJ1vGkE36W5l/8czFiiowdWdKWz7+x6xf0w+Kjkjlj42Ung==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.679.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.679.0.tgz",
+      "integrity": "sha512-y176HuQ8JRY3hGX8rQzHDSbCl9P5Ny9l16z4xmaiLo+Qfte7ee4Yr3yaAKd7GFoJ3/Mhud2XZ37fR015MfYl2w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.679.0.tgz",
+      "integrity": "sha512-0vet8InEj7nvIvGKk+ch7bEF5SyZ7Us9U7YTEgXPrBNStKeRUsgwRm0ijPWWd0a3oz2okaEwXsFl7G/vI0XiEA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.679.0.tgz",
+      "integrity": "sha512-sQoAZFsQiW/LL3DfKMYwBoGjYDEnMbA9WslWN8xneCmBAwKo6IcSksvYs23PP8XMIoBGe2I2J9BSr654XWygTQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
+      "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.679.0.tgz",
+      "integrity": "sha512-Ybx54P8Tg6KKq5ck7uwdjiKif7n/8g1x+V0V9uTjBjRWqaIgiqzXwKWoPj6NCNkE7tJNtqI4JrNxp/3S3HvmRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.679.0.tgz",
+      "integrity": "sha512-1/+Zso/x2jqgutKixYFQEGli0FELTgah6bm7aB+m2FAWH4Hz7+iMUsazg6nSWm714sG9G3h5u42Dmpvi9X6/hA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.679.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.679.0.tgz",
+      "integrity": "sha512-YL6s4Y/1zC45OvddvgE139fjeWSKKPgLlnfrvhVL7alNyY9n7beR4uhoDpNrt5mI6sn9qiBF17790o+xLAXjjg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-endpoints": "^2.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.679.0.tgz",
+      "integrity": "sha512-CusSm2bTBG1kFypcsqU8COhnYc6zltobsqs3nRrvYqYaOqtMnuE46K4XTWpnzKgwDejgZGOE+WYyprtAxrPvmQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
+      "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/querystring-builder": "^3.0.7",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.685.0.tgz",
+      "integrity": "sha512-ClvMeQHbLhWkpxnVymo4qWS5/yZcPXjorDbSday3joCWYWCSHTO409nWd+jx6eA4MKT/EY/uJ6ZBJRFfByKLuA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/client-sts": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.679.0",
+        "@aws-sdk/middleware-expect-continue": "3.679.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-location-constraint": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-sdk-s3": "3.685.0",
+        "@aws-sdk/middleware-ssec": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/signature-v4-multi-region": "3.685.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@aws-sdk/xml-builder": "3.679.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/eventstream-serde-browser": "^3.0.10",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
+        "@smithy/eventstream-serde-node": "^3.0.9",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-blob-browser": "^3.1.6",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/hash-stream-node": "^3.1.6",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/md5-js": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
+      "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
+      "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
+      "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+      "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.679.0.tgz",
+      "integrity": "sha512-EdlTYbzMm3G7VUNAMxr9S1nC1qUNqhKlAxFU8E7cKsAe8Bp29CD5HAs3POc56AVo9GC4yRIS+/mtlZSmrckzUA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.679.0.tgz",
+      "integrity": "sha512-ZoKLubW5DqqV1/2a3TSn+9sSKg0T8SsYMt1JeirnuLJF0mCoYFUaWMyvxxKuxPoqvUsaycxKru4GkpJ10ltNBw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-stream": "^3.1.9",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
+      "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
+      "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-ini": "3.682.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.679.0.tgz",
+      "integrity": "sha512-u/p4TV8kQ0zJWDdZD4+vdQFTMhkDEJFws040Gm113VHa/Xo1SYOjbpvqeuFoz6VmM0bLvoOWjxB9MxnSQbwKpQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
+      "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/token-providers": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.679.0.tgz",
+      "integrity": "sha512-a74tLccVznXCaBefWPSysUcLXYJiSkeUmQGtalNgJ1vGkE36W5l/8czFiiowdWdKWz7+x6xf0w+Kjkjlj42Ung==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.679.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.679.0.tgz",
+      "integrity": "sha512-y176HuQ8JRY3hGX8rQzHDSbCl9P5Ny9l16z4xmaiLo+Qfte7ee4Yr3yaAKd7GFoJ3/Mhud2XZ37fR015MfYl2w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.679.0.tgz",
+      "integrity": "sha512-0vet8InEj7nvIvGKk+ch7bEF5SyZ7Us9U7YTEgXPrBNStKeRUsgwRm0ijPWWd0a3oz2okaEwXsFl7G/vI0XiEA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.679.0.tgz",
+      "integrity": "sha512-sQoAZFsQiW/LL3DfKMYwBoGjYDEnMbA9WslWN8xneCmBAwKo6IcSksvYs23PP8XMIoBGe2I2J9BSr654XWygTQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
+      "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.679.0.tgz",
+      "integrity": "sha512-Ybx54P8Tg6KKq5ck7uwdjiKif7n/8g1x+V0V9uTjBjRWqaIgiqzXwKWoPj6NCNkE7tJNtqI4JrNxp/3S3HvmRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.685.0.tgz",
+      "integrity": "sha512-IHLwuAZGqfUWVrNqw0ugnBa7iL8uBP4x6A7bfBDXRXWCWjUCed/1/D//0lKDHwpFkV74fGW6KoBacnWSUlXmwA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.685.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.679.0.tgz",
+      "integrity": "sha512-1/+Zso/x2jqgutKixYFQEGli0FELTgah6bm7aB+m2FAWH4Hz7+iMUsazg6nSWm714sG9G3h5u42Dmpvi9X6/hA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.679.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.679.0.tgz",
+      "integrity": "sha512-YL6s4Y/1zC45OvddvgE139fjeWSKKPgLlnfrvhVL7alNyY9n7beR4uhoDpNrt5mI6sn9qiBF17790o+xLAXjjg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-endpoints": "^2.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.679.0.tgz",
+      "integrity": "sha512-CusSm2bTBG1kFypcsqU8COhnYc6zltobsqs3nRrvYqYaOqtMnuE46K4XTWpnzKgwDejgZGOE+WYyprtAxrPvmQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
+      "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/querystring-builder": "^3.0.7",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -457,6 +4799,163 @@
         "@aws-sdk/client-sts": "^3.577.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.679.0.tgz",
+      "integrity": "sha512-5EpiPhhGgnF+uJR4DzWUk6Lx3pOn9oM6JGXxeHsiynfoBfq7vHMleq+uABHHSQS+y7XzbyZ7x8tXNQlliMwOsg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-arn-parser": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.679.0.tgz",
+      "integrity": "sha512-nYsh9PdWrF4EahTRdXHGlNud82RPc508CNGdh1lAGfPU3tNveGfMBX3PcGBtPOse3p9ebNKRWVmUc9eXSjGvHA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.682.0.tgz",
+      "integrity": "sha512-5u1STth6iZUtAvPDO0NJVYKUX2EYKU7v84MYYaZ3O27HphRjFqDos0keL2KTnHn/KmMD68rM3yiUareWR8hnAQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+      "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
@@ -466,6 +4965,33 @@
         "@aws-sdk/types": "3.577.0",
         "@smithy/protocol-http": "^4.0.0",
         "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.679.0.tgz",
+      "integrity": "sha512-SA1C1D3XgoKTGxyNsOqd016ONpk46xJLWDgJUd00Zb21Ox5wYCoY6aDRKiaMRW+1VfCJdezs1Do3XLyIU9KxyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -495,6 +5021,162 @@
         "@aws-sdk/types": "3.577.0",
         "@smithy/protocol-http": "^4.0.0",
         "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-api-gateway": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.686.0.tgz",
+      "integrity": "sha512-OtD2bKk8BMo4/wIlebTn/vhvsCJpf7q8pIkKcjgrFdRh2+I6klEoQ08bXfI4yCGGqswtEiE221H6zXIIBgx4Uw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-api-gateway/node_modules/@aws-sdk/types": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.685.0.tgz",
+      "integrity": "sha512-C4w92b3A99NbghrA2Ssw6y1RbDF3I3Bgzi2Izh0pXgyIoDiX0xs9bUs/FGYLK4uepYr78DAZY8DwEpzjWIXkSA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-arn-parser": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+      "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.679.0.tgz",
+      "integrity": "sha512-4GNUxXbs1M71uFHRiCAZtN0/g23ogI9YjMe5isAuYMHXwDB3MhqF7usKf954mBP6tplvN44vYlbJ84faaLrTtg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -534,6 +5216,124 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.686.0.tgz",
+      "integrity": "sha512-/e6nLBVSBXd2QC9hXLK7ka4pw5V1TlVg0VhoRIRspWxVmWmyQykyymAq0Z1kvg+D3Y6K8UiB2nE0QAsNqowPOA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/core": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+      "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.686.0.tgz",
+      "integrity": "sha512-nQ38oBZD2UJLt+N2hPgeZju8Vz9WvfOYE0ao4cGCSWwcUI72Tx162GxC+VK04V7krYQkmwWtcdtzZD40rMWdgw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-arn-parser": "3.679.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
@@ -560,6 +5360,18 @@
       "dev": true,
       "dependencies": {
         "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.679.0.tgz",
+      "integrity": "sha512-CwzEbU8R8rq9bqUFryO50RFBlkfufV9UfMArHPWlo+lmsC+NlSluHQALoj6Jkq3zf5ppn1CN0c1DDLrEqdQUXg==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -637,6 +5449,19 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.679.0.tgz",
+      "integrity": "sha512-nPmhVZb39ty5bcQ7mAwtjezBcsBqTYZ9A2D9v/lE92KCLdu5RhSkPH7O71ZqbZx1mUSg9fAOxHPiG79U5VlpLQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -657,6 +5482,30 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -1024,28 +5873,47 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
+      "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
-      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
+      "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1053,18 +5921,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-DujtuDA7BGEKExJ05W5OdxCoyekcKT3Rhg1ZGeiUWaz2BJIWXjZmsG/DIP4W48GHno7AQwRsaCb8NcBgH3QZpg==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-retry": "^3.0.1",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1072,15 +5940,82 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
-      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.5.tgz",
+      "integrity": "sha512-4FTQGAsuwqTzVMmiRVTn0RR9GrbRfkP0wfu/tXWVHd2LgNpTY0uglQpIScXK4NaEyXbB3JmZt8gfVqO50lP8wg==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.7.tgz",
+      "integrity": "sha512-kVSXScIiRN7q+s1x7BrQtZ1Aa9hvvP9FeCqCdBxv37GimIHgBCOnZ5Ip80HLt0DhnAKpiobFdGqTFgbaJNrazA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.11.tgz",
+      "integrity": "sha512-Pd1Wnq3CQ/v2SxRifDUihvpXzirJYbbtXfEnnLV/z0OGCTx/btVX74P86IgrZkjOydOASBGXdPpupYQI+iO/6A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.8.tgz",
+      "integrity": "sha512-zkFIG2i1BLbfoGQnf1qEeMqX0h5qAznzaZmMVNnvPZz9J5AWBPkOMckZWPedGUPcVITacwIdQXoPcdIQq5FRcg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.10.tgz",
+      "integrity": "sha512-hjpU1tIsJ9qpcoZq9zGHBJPBOeBGYt+n8vfhDwnITPhEre6APrvqq/y3XMDEGUT2cWQ4ramNqBPRbx3qn55rhw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.10.tgz",
+      "integrity": "sha512-ewG1GHbbqsFZ4asaq40KmxCmXO+AFSM1b+DcO2C03dyJj/ZH71CiTg853FSE/3SHK9q3jiYQIFjlGSwfxQ9kww==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1100,13 +6035,25 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/hash-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
-      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.7.tgz",
+      "integrity": "sha512-4yNlxVNJifPM5ThaA5HKnHkn7JhctFUHvcaz6YXxHlYOSIrzI6VKQPTN8Gs1iN5nqq9iFcwIR9THqchUCouIfg==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
+      "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -1115,13 +6062,27 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.7.tgz",
+      "integrity": "sha512-xMAsvJ3hLG63lsBVi1Hl6BBSfhd8/Qnp8fC06kjOpJvyyCEXdwHITa5Kvdsk6gaAXLhbZMhQMIGvgUbfnJDP6Q==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.8.tgz",
+      "integrity": "sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -1137,14 +6098,25 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+    "node_modules/@smithy/md5-js": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.8.tgz",
+      "integrity": "sha512-LwApfTK0OJ/tCyNUXqnWCKoE2b4rDSr4BJlDAVCkiWYeHESr+y+d5zlAanuLW6fnitVJRD/7d9/kN/ZM9Su4mA==",
       "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
+      "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1152,17 +6124,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
-      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.1.tgz",
+      "integrity": "sha512-wWO3xYmFm6WRW8VsEJ5oU6h7aosFXfszlz3Dj176pTij6o21oZnzkCLzShfmRaaCHDkBXWBdO0c4sQAvLFP6zA==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1170,18 +6143,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
-      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
+      "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -1190,12 +6163,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
-      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
+      "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1203,12 +6176,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
-      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
+      "integrity": "sha512-d7ZuwvYgp1+3682Nx0MD3D/HtkmZd49N3JUndYWQXfRZrYEnCWYc8BHcNmVsPAp9gKvlurdg/mubE6b/rPS9MA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1216,14 +6189,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
-      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1231,15 +6204,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
-      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+      "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
       "dev": true,
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1247,12 +6220,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
-      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+      "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1260,12 +6233,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
-      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+      "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1273,12 +6246,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
-      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
+      "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -1287,12 +6260,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
-      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
+      "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1300,24 +6273,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
-      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
+      "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0"
+        "@smithy/types": "^3.6.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
-      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1343,16 +6316,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
-      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
+      "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-stream": "^3.0.1",
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1360,9 +6334,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1372,13 +6346,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
-      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.8.tgz",
+      "integrity": "sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==",
       "dev": true,
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/querystring-parser": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -1443,14 +6417,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
-      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
+      "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1459,17 +6433,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
-      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
+      "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
       "dev": true,
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.0",
-        "@smithy/credential-provider-imds": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/credential-provider-imds": "^3.2.5",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1477,13 +6451,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
-      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.4.tgz",
+      "integrity": "sha512-kPt8j4emm7rdMWQyL0F89o92q10gvCUa6sBkBtDJ7nV2+P7wpXczzOfoDJ49CKXe5CCqb8dc1W+ZdLlrKzSAnQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1503,12 +6477,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
-      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
+      "integrity": "sha512-p7iYAPaQjoeM+AKABpYWeDdtwQNxasr4aXQEA/OmbOaug9V0odRVDy3Wx4ci8soljE/JXQo+abV0qZpW8NX0yA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1516,13 +6490,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
-      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
+      "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
       "dev": true,
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1530,14 +6504,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
-      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.2.1.tgz",
+      "integrity": "sha512-R3ufuzJRxSJbE58K9AEnL/uSZyVdHzud9wLS8tIbXclxKzoe09CRohj2xV8wpx5tj7ZbiJaKYcutMm1eYgz/0A==",
       "dev": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -1546,6 +6520,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
@@ -1574,13 +6561,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
-      "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.7.tgz",
+      "integrity": "sha512-d5yGlQtmN/z5eoTtIYgkvOw27US2Ous4VycnXatyoImIF9tzlcpnKqQ/V7qhvJmb2p6xZne1NopCLakdTnkBBQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1938,24 +6925,24 @@
       "dev": true
     },
     "node_modules/asl-path-validator": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.12.0.tgz",
-      "integrity": "sha512-pzBX2mKp8NQ7p1xM6sfSd2vFQJDX0UdUCun/YcRKMNSv7j93erTomK7iIU79N5rjJD++kPr9qwWhA67pFVpdhA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.14.1.tgz",
+      "integrity": "sha512-Q5P3WLX1sLhTKdMXsgCW6KwKeapozQADq2nhfC6a6/dTVkfj+mL42YS0NGB4cmlvm/qoXjOnElHoBQFjm2ce0g==",
       "dev": true,
       "dependencies": {
-        "jsonpath-plus": "^7.0.0"
+        "jsonpath-plus": "^10.0.0"
       }
     },
     "node_modules/asl-validator": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.8.2.tgz",
-      "integrity": "sha512-wSGCbzbTz5hfuSQl33u/OZEGXT8IE9taRbAPtCNg4boK7oHLlXZqH7VlwKGeKY4QwvDwlyktERBXs3r32JwIeQ==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.8.4.tgz",
+      "integrity": "sha512-7nOk/l6VtYQbBgxHcJHYABtgU9dL04beH4o6v2/n1jAD3dkFspx2AVEpgF2+Nz2RterF+sKa9cgyiGR3kHOZmg==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.12.0",
-        "asl-path-validator": "^0.12.0",
+        "asl-path-validator": "^0.14.1",
         "commander": "^10.0.1",
-        "jsonpath-plus": "^7.2.0",
+        "jsonpath-plus": "^10.0.0",
         "yaml": "^2.3.1"
       },
       "bin": {
@@ -2039,9 +7026,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -2145,12 +7132,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2671,9 +7658,9 @@
       }
     },
     "node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -3290,15 +8277,31 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es5-ext/node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
       },
       "engines": {
         "node": ">=0.10"
@@ -3616,9 +8619,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4131,9 +9134,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http2-wrapper": {
@@ -4706,6 +9709,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -4856,12 +9868,21 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
       "dev": true,
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jszip": {
@@ -5159,12 +10180,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -6184,12 +11205,18 @@
       }
     },
     "node_modules/serverless": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.38.0.tgz",
-      "integrity": "sha512-NJE1vOn8XmQEqfU9UxmVhkUFaCRmx6FhYw/jITN863WlOt4Y3PQbj3hwQyIb5QS1ZrXFq5ojklwewUXH7xGpdA==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.39.0.tgz",
+      "integrity": "sha512-FHI3fhe4TRS8+ez/KA7HmO3lt3fAynO+N1pCCzYRThMWG0J8RWCI0BI+K0mw9+sEV+QpBCpZRZbuGyUaTsaQew==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
+        "@aws-sdk/client-api-gateway": "^3.588.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.588.0",
+        "@aws-sdk/client-eventbridge": "^3.588.0",
+        "@aws-sdk/client-iam": "^3.588.0",
+        "@aws-sdk/client-lambda": "^3.588.0",
+        "@aws-sdk/client-s3": "^3.588.0",
         "@serverless/dashboard-plugin": "^7.2.0",
         "@serverless/platform-client": "^4.5.1",
         "@serverless/utils": "^6.13.1",
@@ -7226,9 +12253,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -7412,6 +12439,112 @@
     }
   },
   "dependencies": {
+    "@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "dev": true,
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "dev": true,
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
     "@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -7426,6 +12559,71 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "dev": true,
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
         }
       }
     },
@@ -7508,6 +12706,586 @@
         }
       }
     },
+    "@aws-sdk/client-api-gateway": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.686.0.tgz",
+      "integrity": "sha512-L1KIfL6zA2G9HJ8aeiq4/xTP0bUfnzCjSpkmgcG5BQRqXEMASrMaLy/XUlF/2X5MKbyC6GVYZctP203noGu2cw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-sdk-api-gateway": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "^5.2.0",
+            "@aws-crypto/supports-web-crypto": "^5.2.0",
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+          "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+          "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+          "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+          "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+          "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+          "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-stream": "^3.2.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+          "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+          "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-ini": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+          "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+          "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/token-providers": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+          "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+          "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+          "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+          "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+          "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+          "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+          "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+          "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+          "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-endpoints": "^2.1.4",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+          "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+          "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+          "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+          "dev": true,
+          "requires": {
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/querystring-builder": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "dev": true,
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
     "@aws-sdk/client-cloudformation": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.577.0.tgz",
@@ -7557,6 +13335,2934 @@
         "@smithy/util-waiter": "^3.0.0",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
+      }
+    },
+    "@aws-sdk/client-cognito-identity-provider": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.686.0.tgz",
+      "integrity": "sha512-igTsylpqVJrBL+4JYyI8lBac0USNgd4LQe/Xuwb17w+w5+7sBiZ7j/WBT31mKb+v5GAunJEEWDvRhCjhPUmUew==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "^5.2.0",
+            "@aws-crypto/supports-web-crypto": "^5.2.0",
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+          "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+          "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+          "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+          "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+          "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+          "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-stream": "^3.2.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+          "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+          "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-ini": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+          "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+          "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/token-providers": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+          "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+          "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+          "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+          "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+          "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+          "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+          "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+          "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+          "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-endpoints": "^2.1.4",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+          "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+          "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+          "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+          "dev": true,
+          "requires": {
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/querystring-builder": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "dev": true,
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-eventbridge": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.686.0.tgz",
+      "integrity": "sha512-5WuXi6BtmIrDo9LDoJ6i1aPA2qkoGoNzMJ5ScPqYLLT7Cx4J+mdA4MOp6vfBvEZR9eaJdWBmUOqxHvP76SQpqw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/signature-v4-multi-region": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "^5.2.0",
+            "@aws-crypto/supports-web-crypto": "^5.2.0",
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+          "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+          "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+          "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+          "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+          "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+          "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-stream": "^3.2.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+          "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+          "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-ini": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+          "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+          "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/token-providers": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+          "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+          "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+          "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+          "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+          "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+          "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+          "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+          "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+          "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-endpoints": "^2.1.4",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+          "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+          "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+          "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+          "dev": true,
+          "requires": {
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/querystring-builder": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "dev": true,
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-iam": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.686.0.tgz",
+      "integrity": "sha512-x3R3U0xM8fvNhS2IyEKHxmhk6pcQNNlT30Rk8gUi01TK340MKfrlgXQhFKdvez8cdS2HiNkLpfPe4mEupRVYlg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.7",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "^5.2.0",
+            "@aws-crypto/supports-web-crypto": "^5.2.0",
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+          "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+          "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+          "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-node": "3.686.0",
+            "@aws-sdk/middleware-host-header": "3.686.0",
+            "@aws-sdk/middleware-logger": "3.686.0",
+            "@aws-sdk/middleware-recursion-detection": "3.686.0",
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/region-config-resolver": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@aws-sdk/util-user-agent-browser": "3.686.0",
+            "@aws-sdk/util-user-agent-node": "3.686.0",
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/core": "^2.5.1",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/hash-node": "^3.0.8",
+            "@smithy/invalid-dependency": "^3.0.8",
+            "@smithy/middleware-content-length": "^3.0.10",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-retry": "^3.0.25",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.25",
+            "@smithy/util-defaults-mode-node": "^3.0.25",
+            "@smithy/util-endpoints": "^2.1.4",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+          "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+          "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+          "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-stream": "^3.2.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+          "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+          "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.686.0",
+            "@aws-sdk/credential-provider-http": "3.686.0",
+            "@aws-sdk/credential-provider-ini": "3.686.0",
+            "@aws-sdk/credential-provider-process": "3.686.0",
+            "@aws-sdk/credential-provider-sso": "3.686.0",
+            "@aws-sdk/credential-provider-web-identity": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+          "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+          "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.686.0",
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/token-providers": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+          "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+          "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+          "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+          "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+          "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-endpoints": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+          "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+          "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+          "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+          "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-endpoints": "^2.1.4",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+          "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/types": "^3.6.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+          "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+          "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+          "dev": true,
+          "requires": {
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/querystring-builder": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "dev": true,
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-lambda": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.682.0.tgz",
+      "integrity": "sha512-J37hXQ3Qrm+kQ+bd9+yy7n5ZxBfTiCdiI4vpejDld0B5hPF2VO+tIRq5n+xHIHar5aLHnVv3c9pdjqWrYZ8gOg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/client-sts": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/eventstream-serde-browser": "^3.0.10",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
+        "@smithy/eventstream-serde-node": "^3.0.9",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "^5.2.0",
+            "@aws-crypto/supports-web-crypto": "^5.2.0",
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
+          "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
+          "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-node": "3.682.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
+          "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.682.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-node": "3.682.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+          "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.679.0.tgz",
+          "integrity": "sha512-EdlTYbzMm3G7VUNAMxr9S1nC1qUNqhKlAxFU8E7cKsAe8Bp29CD5HAs3POc56AVo9GC4yRIS+/mtlZSmrckzUA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.679.0.tgz",
+          "integrity": "sha512-ZoKLubW5DqqV1/2a3TSn+9sSKg0T8SsYMt1JeirnuLJF0mCoYFUaWMyvxxKuxPoqvUsaycxKru4GkpJ10ltNBw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-stream": "^3.1.9",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
+          "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-env": "3.679.0",
+            "@aws-sdk/credential-provider-http": "3.679.0",
+            "@aws-sdk/credential-provider-process": "3.679.0",
+            "@aws-sdk/credential-provider-sso": "3.682.0",
+            "@aws-sdk/credential-provider-web-identity": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
+          "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.679.0",
+            "@aws-sdk/credential-provider-http": "3.679.0",
+            "@aws-sdk/credential-provider-ini": "3.682.0",
+            "@aws-sdk/credential-provider-process": "3.679.0",
+            "@aws-sdk/credential-provider-sso": "3.682.0",
+            "@aws-sdk/credential-provider-web-identity": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.679.0.tgz",
+          "integrity": "sha512-u/p4TV8kQ0zJWDdZD4+vdQFTMhkDEJFws040Gm113VHa/Xo1SYOjbpvqeuFoz6VmM0bLvoOWjxB9MxnSQbwKpQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
+          "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.682.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/token-providers": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.679.0.tgz",
+          "integrity": "sha512-a74tLccVznXCaBefWPSysUcLXYJiSkeUmQGtalNgJ1vGkE36W5l/8czFiiowdWdKWz7+x6xf0w+Kjkjlj42Ung==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.679.0.tgz",
+          "integrity": "sha512-y176HuQ8JRY3hGX8rQzHDSbCl9P5Ny9l16z4xmaiLo+Qfte7ee4Yr3yaAKd7GFoJ3/Mhud2XZ37fR015MfYl2w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.679.0.tgz",
+          "integrity": "sha512-0vet8InEj7nvIvGKk+ch7bEF5SyZ7Us9U7YTEgXPrBNStKeRUsgwRm0ijPWWd0a3oz2okaEwXsFl7G/vI0XiEA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.679.0.tgz",
+          "integrity": "sha512-sQoAZFsQiW/LL3DfKMYwBoGjYDEnMbA9WslWN8xneCmBAwKo6IcSksvYs23PP8XMIoBGe2I2J9BSr654XWygTQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
+          "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.679.0.tgz",
+          "integrity": "sha512-Ybx54P8Tg6KKq5ck7uwdjiKif7n/8g1x+V0V9uTjBjRWqaIgiqzXwKWoPj6NCNkE7tJNtqI4JrNxp/3S3HvmRw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.679.0.tgz",
+          "integrity": "sha512-1/+Zso/x2jqgutKixYFQEGli0FELTgah6bm7aB+m2FAWH4Hz7+iMUsazg6nSWm714sG9G3h5u42Dmpvi9X6/hA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.679.0.tgz",
+          "integrity": "sha512-YL6s4Y/1zC45OvddvgE139fjeWSKKPgLlnfrvhVL7alNyY9n7beR4uhoDpNrt5mI6sn9qiBF17790o+xLAXjjg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-endpoints": "^2.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.679.0.tgz",
+          "integrity": "sha512-CusSm2bTBG1kFypcsqU8COhnYc6zltobsqs3nRrvYqYaOqtMnuE46K4XTWpnzKgwDejgZGOE+WYyprtAxrPvmQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
+          "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.9",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+          "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+          "dev": true,
+          "requires": {
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/querystring-builder": "^3.0.7",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "dev": true,
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.685.0.tgz",
+      "integrity": "sha512-ClvMeQHbLhWkpxnVymo4qWS5/yZcPXjorDbSday3joCWYWCSHTO409nWd+jx6eA4MKT/EY/uJ6ZBJRFfByKLuA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/client-sts": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.679.0",
+        "@aws-sdk/middleware-expect-continue": "3.679.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-location-constraint": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-sdk-s3": "3.685.0",
+        "@aws-sdk/middleware-ssec": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/signature-v4-multi-region": "3.685.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@aws-sdk/xml-builder": "3.679.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/eventstream-serde-browser": "^3.0.10",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
+        "@smithy/eventstream-serde-node": "^3.0.9",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-blob-browser": "^3.1.6",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/hash-stream-node": "^3.1.6",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/md5-js": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "^5.2.0",
+            "@aws-crypto/supports-web-crypto": "^5.2.0",
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "dev": true,
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
+          "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
+          "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-node": "3.682.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
+          "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.682.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-node": "3.682.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+          "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.679.0.tgz",
+          "integrity": "sha512-EdlTYbzMm3G7VUNAMxr9S1nC1qUNqhKlAxFU8E7cKsAe8Bp29CD5HAs3POc56AVo9GC4yRIS+/mtlZSmrckzUA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.679.0.tgz",
+          "integrity": "sha512-ZoKLubW5DqqV1/2a3TSn+9sSKg0T8SsYMt1JeirnuLJF0mCoYFUaWMyvxxKuxPoqvUsaycxKru4GkpJ10ltNBw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-stream": "^3.1.9",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
+          "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-env": "3.679.0",
+            "@aws-sdk/credential-provider-http": "3.679.0",
+            "@aws-sdk/credential-provider-process": "3.679.0",
+            "@aws-sdk/credential-provider-sso": "3.682.0",
+            "@aws-sdk/credential-provider-web-identity": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
+          "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.679.0",
+            "@aws-sdk/credential-provider-http": "3.679.0",
+            "@aws-sdk/credential-provider-ini": "3.682.0",
+            "@aws-sdk/credential-provider-process": "3.679.0",
+            "@aws-sdk/credential-provider-sso": "3.682.0",
+            "@aws-sdk/credential-provider-web-identity": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.679.0.tgz",
+          "integrity": "sha512-u/p4TV8kQ0zJWDdZD4+vdQFTMhkDEJFws040Gm113VHa/Xo1SYOjbpvqeuFoz6VmM0bLvoOWjxB9MxnSQbwKpQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
+          "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.682.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/token-providers": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.679.0.tgz",
+          "integrity": "sha512-a74tLccVznXCaBefWPSysUcLXYJiSkeUmQGtalNgJ1vGkE36W5l/8czFiiowdWdKWz7+x6xf0w+Kjkjlj42Ung==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.679.0.tgz",
+          "integrity": "sha512-y176HuQ8JRY3hGX8rQzHDSbCl9P5Ny9l16z4xmaiLo+Qfte7ee4Yr3yaAKd7GFoJ3/Mhud2XZ37fR015MfYl2w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.679.0.tgz",
+          "integrity": "sha512-0vet8InEj7nvIvGKk+ch7bEF5SyZ7Us9U7YTEgXPrBNStKeRUsgwRm0ijPWWd0a3oz2okaEwXsFl7G/vI0XiEA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.679.0.tgz",
+          "integrity": "sha512-sQoAZFsQiW/LL3DfKMYwBoGjYDEnMbA9WslWN8xneCmBAwKo6IcSksvYs23PP8XMIoBGe2I2J9BSr654XWygTQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
+          "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.679.0.tgz",
+          "integrity": "sha512-Ybx54P8Tg6KKq5ck7uwdjiKif7n/8g1x+V0V9uTjBjRWqaIgiqzXwKWoPj6NCNkE7tJNtqI4JrNxp/3S3HvmRw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/signature-v4-multi-region": {
+          "version": "3.685.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.685.0.tgz",
+          "integrity": "sha512-IHLwuAZGqfUWVrNqw0ugnBa7iL8uBP4x6A7bfBDXRXWCWjUCed/1/D//0lKDHwpFkV74fGW6KoBacnWSUlXmwA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-sdk-s3": "3.685.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.679.0.tgz",
+          "integrity": "sha512-1/+Zso/x2jqgutKixYFQEGli0FELTgah6bm7aB+m2FAWH4Hz7+iMUsazg6nSWm714sG9G3h5u42Dmpvi9X6/hA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.679.0.tgz",
+          "integrity": "sha512-YL6s4Y/1zC45OvddvgE139fjeWSKKPgLlnfrvhVL7alNyY9n7beR4uhoDpNrt5mI6sn9qiBF17790o+xLAXjjg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-endpoints": "^2.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.679.0.tgz",
+          "integrity": "sha512-CusSm2bTBG1kFypcsqU8COhnYc6zltobsqs3nRrvYqYaOqtMnuE46K4XTWpnzKgwDejgZGOE+WYyprtAxrPvmQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
+          "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.9",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+          "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+          "dev": true,
+          "requires": {
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/querystring-builder": "^3.0.7",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "dev": true,
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -7823,6 +16529,132 @@
         "tslib": "^2.6.2"
       }
     },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.679.0.tgz",
+      "integrity": "sha512-5EpiPhhGgnF+uJR4DzWUk6Lx3pOn9oM6JGXxeHsiynfoBfq7vHMleq+uABHHSQS+y7XzbyZ7x8tXNQlliMwOsg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-arn-parser": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.679.0.tgz",
+      "integrity": "sha512-nYsh9PdWrF4EahTRdXHGlNud82RPc508CNGdh1lAGfPU3tNveGfMBX3PcGBtPOse3p9ebNKRWVmUc9eXSjGvHA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.682.0.tgz",
+      "integrity": "sha512-5u1STth6iZUtAvPDO0NJVYKUX2EYKU7v84MYYaZ3O27HphRjFqDos0keL2KTnHn/KmMD68rM3yiUareWR8hnAQ==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/core": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+          "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
     "@aws-sdk/middleware-host-header": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
@@ -7833,6 +16665,29 @@
         "@smithy/protocol-http": "^4.0.0",
         "@smithy/types": "^3.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.679.0.tgz",
+      "integrity": "sha512-SA1C1D3XgoKTGxyNsOqd016ONpk46xJLWDgJUd00Zb21Ox5wYCoY6aDRKiaMRW+1VfCJdezs1Do3XLyIU9KxyA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-logger": {
@@ -7856,6 +16711,131 @@
         "@smithy/protocol-http": "^4.0.0",
         "@smithy/types": "^3.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-api-gateway": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.686.0.tgz",
+      "integrity": "sha512-OtD2bKk8BMo4/wIlebTn/vhvsCJpf7q8pIkKcjgrFdRh2+I6klEoQ08bXfI4yCGGqswtEiE221H6zXIIBgx4Uw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+          "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.685.0.tgz",
+      "integrity": "sha512-C4w92b3A99NbghrA2Ssw6y1RbDF3I3Bgzi2Izh0pXgyIoDiX0xs9bUs/FGYLK4uepYr78DAZY8DwEpzjWIXkSA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-arn-parser": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/core": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+          "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.679.0.tgz",
+      "integrity": "sha512-4GNUxXbs1M71uFHRiCAZtN0/g23ogI9YjMe5isAuYMHXwDB3MhqF7usKf954mBP6tplvN44vYlbJ84faaLrTtg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-user-agent": {
@@ -7885,6 +16865,98 @@
         "tslib": "^2.6.2"
       }
     },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.686.0.tgz",
+      "integrity": "sha512-/e6nLBVSBXd2QC9hXLK7ka4pw5V1TlVg0VhoRIRspWxVmWmyQykyymAq0Z1kvg+D3Y6K8UiB2nE0QAsNqowPOA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-sdk-s3": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/core": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+          "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.686.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-s3": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.686.0.tgz",
+          "integrity": "sha512-nQ38oBZD2UJLt+N2hPgeZju8Vz9WvfOYE0ao4cGCSWwcUI72Tx162GxC+VK04V7krYQkmwWtcdtzZD40rMWdgw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/core": "3.686.0",
+            "@aws-sdk/types": "3.686.0",
+            "@aws-sdk/util-arn-parser": "3.679.0",
+            "@smithy/core": "^2.5.1",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-stream": "^3.2.1",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.686.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+          "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
     "@aws-sdk/token-providers": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
@@ -7905,6 +16977,15 @@
       "dev": true,
       "requires": {
         "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.679.0.tgz",
+      "integrity": "sha512-CwzEbU8R8rq9bqUFryO50RFBlkfufV9UfMArHPWlo+lmsC+NlSluHQALoj6Jkq3zf5ppn1CN0c1DDLrEqdQUXg==",
+      "dev": true,
+      "requires": {
         "tslib": "^2.6.2"
       }
     },
@@ -7962,6 +17043,16 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/xml-builder": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.679.0.tgz",
+      "integrity": "sha512-nPmhVZb39ty5bcQ7mAwtjezBcsBqTYZ9A2D9v/lE92KCLdu5RhSkPH7O71ZqbZx1mUSg9fAOxHPiG79U5VlpLQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -7982,6 +17073,20 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
+    },
+    "@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "requires": {}
     },
     "@kwsites/file-exists": {
       "version": "1.1.1",
@@ -8288,54 +17393,128 @@
       "dev": true
     },
     "@smithy/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
+      "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/chunked-blob-reader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/chunked-blob-reader-native": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
-      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
+      "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
       "dev": true,
       "requires": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-DujtuDA7BGEKExJ05W5OdxCoyekcKT3Rhg1ZGeiUWaz2BJIWXjZmsG/DIP4W48GHno7AQwRsaCb8NcBgH3QZpg==",
       "dev": true,
       "requires": {
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-retry": "^3.0.1",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
-      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.5.tgz",
+      "integrity": "sha512-4FTQGAsuwqTzVMmiRVTn0RR9GrbRfkP0wfu/tXWVHd2LgNpTY0uglQpIScXK4NaEyXbB3JmZt8gfVqO50lP8wg==",
       "dev": true,
       "requires": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.7.tgz",
+      "integrity": "sha512-kVSXScIiRN7q+s1x7BrQtZ1Aa9hvvP9FeCqCdBxv37GimIHgBCOnZ5Ip80HLt0DhnAKpiobFdGqTFgbaJNrazA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-browser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.11.tgz",
+      "integrity": "sha512-Pd1Wnq3CQ/v2SxRifDUihvpXzirJYbbtXfEnnLV/z0OGCTx/btVX74P86IgrZkjOydOASBGXdPpupYQI+iO/6A==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.8.tgz",
+      "integrity": "sha512-zkFIG2i1BLbfoGQnf1qEeMqX0h5qAznzaZmMVNnvPZz9J5AWBPkOMckZWPedGUPcVITacwIdQXoPcdIQq5FRcg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-node": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.10.tgz",
+      "integrity": "sha512-hjpU1tIsJ9qpcoZq9zGHBJPBOeBGYt+n8vfhDwnITPhEre6APrvqq/y3XMDEGUT2cWQ4ramNqBPRbx3qn55rhw==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-universal": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.10.tgz",
+      "integrity": "sha512-ewG1GHbbqsFZ4asaq40KmxCmXO+AFSM1b+DcO2C03dyJj/ZH71CiTg853FSE/3SHK9q3jiYQIFjlGSwfxQ9kww==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-codec": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -8352,25 +17531,48 @@
         "tslib": "^2.6.2"
       }
     },
-    "@smithy/hash-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
-      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+    "@smithy/hash-blob-browser": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.7.tgz",
+      "integrity": "sha512-4yNlxVNJifPM5ThaA5HKnHkn7JhctFUHvcaz6YXxHlYOSIrzI6VKQPTN8Gs1iN5nqq9iFcwIR9THqchUCouIfg==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
+      "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^3.6.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
-    "@smithy/invalid-dependency": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+    "@smithy/hash-stream-node": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.7.tgz",
+      "integrity": "sha512-xMAsvJ3hLG63lsBVi1Hl6BBSfhd8/Qnp8fC06kjOpJvyyCEXdwHITa5Kvdsk6gaAXLhbZMhQMIGvgUbfnJDP6Q==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.8.tgz",
+      "integrity": "sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -8383,151 +17585,163 @@
         "tslib": "^2.6.2"
       }
     },
-    "@smithy/middleware-content-length": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+    "@smithy/md5-js": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.8.tgz",
+      "integrity": "sha512-LwApfTK0OJ/tCyNUXqnWCKoE2b4rDSr4BJlDAVCkiWYeHESr+y+d5zlAanuLW6fnitVJRD/7d9/kN/ZM9Su4mA==",
       "dev": true,
       "requires": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
+      "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
-      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.1.tgz",
+      "integrity": "sha512-wWO3xYmFm6WRW8VsEJ5oU6h7aosFXfszlz3Dj176pTij6o21oZnzkCLzShfmRaaCHDkBXWBdO0c4sQAvLFP6zA==",
       "dev": true,
       "requires": {
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
-      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
+      "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
       "dev": true,
       "requires": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
-      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
+      "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
-      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
+      "integrity": "sha512-d7ZuwvYgp1+3682Nx0MD3D/HtkmZd49N3JUndYWQXfRZrYEnCWYc8BHcNmVsPAp9gKvlurdg/mubE6b/rPS9MA==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
-      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dev": true,
       "requires": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
-      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+      "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
       "dev": true,
       "requires": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/property-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
-      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+      "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/protocol-http": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
-      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+      "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
-      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
+      "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
-      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
+      "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
-      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
+      "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0"
+        "@smithy/types": "^3.6.0"
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
-      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -8547,36 +17761,37 @@
       }
     },
     "@smithy/smithy-client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
-      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
+      "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
       "dev": true,
       "requires": {
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-stream": "^3.0.1",
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
       "dev": true,
       "requires": {
         "tslib": "^2.6.2"
       }
     },
     "@smithy/url-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
-      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.8.tgz",
+      "integrity": "sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==",
       "dev": true,
       "requires": {
-        "@smithy/querystring-parser": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/querystring-parser": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -8629,41 +17844,41 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
-      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
+      "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
       "dev": true,
       "requires": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
-      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
+      "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
       "dev": true,
       "requires": {
-        "@smithy/config-resolver": "^3.0.0",
-        "@smithy/credential-provider-imds": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/credential-provider-imds": "^3.2.5",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-endpoints": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
-      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.4.tgz",
+      "integrity": "sha512-kPt8j4emm7rdMWQyL0F89o92q10gvCUa6sBkBtDJ7nV2+P7wpXczzOfoDJ49CKXe5CCqb8dc1W+ZdLlrKzSAnQ==",
       "dev": true,
       "requires": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -8677,40 +17892,55 @@
       }
     },
     "@smithy/util-middleware": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
-      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
+      "integrity": "sha512-p7iYAPaQjoeM+AKABpYWeDdtwQNxasr4aXQEA/OmbOaug9V0odRVDy3Wx4ci8soljE/JXQo+abV0qZpW8NX0yA==",
       "dev": true,
       "requires": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-retry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
-      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
+      "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
       "dev": true,
       "requires": {
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
-      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.2.1.tgz",
+      "integrity": "sha512-R3ufuzJRxSJbE58K9AEnL/uSZyVdHzud9wLS8tIbXclxKzoe09CRohj2xV8wpx5tj7ZbiJaKYcutMm1eYgz/0A==",
       "dev": true,
       "requires": {
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/fetch-http-handler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+          "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+          "dev": true,
+          "requires": {
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/querystring-builder": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@smithy/util-uri-escape": {
@@ -8733,13 +17963,13 @@
       }
     },
     "@smithy/util-waiter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
-      "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.7.tgz",
+      "integrity": "sha512-d5yGlQtmN/z5eoTtIYgkvOw27US2Ous4VycnXatyoImIF9tzlcpnKqQ/V7qhvJmb2p6xZne1NopCLakdTnkBBQ==",
       "dev": true,
       "requires": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -9028,24 +18258,24 @@
       "dev": true
     },
     "asl-path-validator": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.12.0.tgz",
-      "integrity": "sha512-pzBX2mKp8NQ7p1xM6sfSd2vFQJDX0UdUCun/YcRKMNSv7j93erTomK7iIU79N5rjJD++kPr9qwWhA67pFVpdhA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.14.1.tgz",
+      "integrity": "sha512-Q5P3WLX1sLhTKdMXsgCW6KwKeapozQADq2nhfC6a6/dTVkfj+mL42YS0NGB4cmlvm/qoXjOnElHoBQFjm2ce0g==",
       "dev": true,
       "requires": {
-        "jsonpath-plus": "^7.0.0"
+        "jsonpath-plus": "^10.0.0"
       }
     },
     "asl-validator": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.8.2.tgz",
-      "integrity": "sha512-wSGCbzbTz5hfuSQl33u/OZEGXT8IE9taRbAPtCNg4boK7oHLlXZqH7VlwKGeKY4QwvDwlyktERBXs3r32JwIeQ==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.8.4.tgz",
+      "integrity": "sha512-7nOk/l6VtYQbBgxHcJHYABtgU9dL04beH4o6v2/n1jAD3dkFspx2AVEpgF2+Nz2RterF+sKa9cgyiGR3kHOZmg==",
       "dev": true,
       "requires": {
         "ajv": "^8.12.0",
-        "asl-path-validator": "^0.12.0",
+        "asl-path-validator": "^0.14.1",
         "commander": "^10.0.1",
-        "jsonpath-plus": "^7.2.0",
+        "jsonpath-plus": "^10.0.0",
         "yaml": "^2.3.1"
       },
       "dependencies": {
@@ -9111,9 +18341,9 @@
       }
     },
     "axios": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.6",
@@ -9185,12 +18415,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "buffer": {
@@ -9591,9 +18821,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -10085,14 +19315,29 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
+      },
+      "dependencies": {
+        "esniff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+          "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+          "dev": true,
+          "requires": {
+            "d": "^1.0.1",
+            "es5-ext": "^0.10.62",
+            "event-emitter": "^0.3.5",
+            "type": "^2.7.2"
+          }
+        }
       }
     },
     "es6-iterator": {
@@ -10336,9 +19581,9 @@
       "dev": true
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -10697,9 +19942,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http2-wrapper": {
@@ -11102,6 +20347,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -11230,10 +20481,15 @@
       }
     },
     "jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-      "dev": true
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "dev": true,
+      "requires": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      }
     },
     "jszip": {
       "version": "3.10.1",
@@ -11501,12 +20757,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -12216,11 +21472,17 @@
       "dev": true
     },
     "serverless": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.38.0.tgz",
-      "integrity": "sha512-NJE1vOn8XmQEqfU9UxmVhkUFaCRmx6FhYw/jITN863WlOt4Y3PQbj3hwQyIb5QS1ZrXFq5ojklwewUXH7xGpdA==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.39.0.tgz",
+      "integrity": "sha512-FHI3fhe4TRS8+ez/KA7HmO3lt3fAynO+N1pCCzYRThMWG0J8RWCI0BI+K0mw9+sEV+QpBCpZRZbuGyUaTsaQew==",
       "dev": true,
       "requires": {
+        "@aws-sdk/client-api-gateway": "^3.588.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.588.0",
+        "@aws-sdk/client-eventbridge": "^3.588.0",
+        "@aws-sdk/client-iam": "^3.588.0",
+        "@aws-sdk/client-lambda": "^3.588.0",
+        "@aws-sdk/client-s3": "^3.588.0",
         "@serverless/dashboard-plugin": "^7.2.0",
         "@serverless/platform-client": "^4.5.1",
         "@serverless/utils": "^6.13.1",
@@ -13030,9 +22292,9 @@
       }
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "r-builds",
   "description": "",
   "version": "0.1.0",
-  "dependencies": {},
   "devDependencies": {
-    "serverless": "^3.36.0",
+    "serverless": "^3.39.0",
+    "serverless-better-credentials": "^2.0.0",
     "serverless-python-requirements": "^6.0.0",
-    "serverless-step-functions": "^3.21.0",
-    "serverless-better-credentials": "^2.0.0"
+    "serverless-step-functions": "^3.21.0"
   }
 }


### PR DESCRIPTION
Fix Jenkins image build, currently failing because there was a new serverless major version v4 that requires Node >= 18:
```sh
 > [5/7] RUN npm install -g serverless:
5.776 /usr/local/bin/sls -> /usr/local/lib/node_modules/serverless/run.js
5.776 /usr/local/bin/serverless -> /usr/local/lib/node_modules/serverless/run.js
5.788 
5.788 > serverless@4.4.7 postinstall /usr/local/lib/node_modules/serverless
5.788 > node ./postInstall.js
5.788 
6.071 Error fetching release: EACCES: permission denied, open '/usr/local/lib/node_modules/serverless/node_modules/.bin/serverless-linux-amd64-0.0.2'
6.129 npm WARN notsup Unsupported engine for serverless@4.4.7: wanted: {"node":">=18.0.0"} (current: {"node":"14.21.3","npm":"6.14.18"})
6.129 npm WARN notsup Not compatible with your version of node/npm: serverless@4.4.7
```
- Update image to Node 22
- Run `npm audit fix`
- Pin to serverless v3, as serverless v4 apparently now requires a license