### PR TITLE
Add libzstd package dependency for R-devel; README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ R binaries are built for the following Linux operating systems:
 - Red Hat Enterprise Linux 7, 8, 9
 - openSUSE 15.5
 - openSUSE 15.6
-- SUSE Linux Enterprise 15 SP5
+- SUSE Linux Enterprise 15 SP5, 15 SP6
 - Fedora 39, 40, 41
 
 Operating systems are supported until their vendor end-of-support dates, which
@@ -37,6 +37,8 @@ will be discontinued, but existing binaries will continue to be available.
 
 R binaries are primarily supported for the current R version and previous four minor versions of R.
 Older R versions down to R 3.0.0 are also built when possible, but support for older R versions is best effort and not guaranteed. 
+
+R versions 4.0.0 through 4.3.3 have been patched for [CVE-2024-27322](https://nvd.nist.gov/vuln/detail/cve-2024-27322). See [#218](https://github.com/rstudio/r-builds/issues/218) for more details.
 
 ## Quick Installation
 
@@ -84,8 +86,7 @@ curl -O https://cdn.posit.co/r/debian-12/pkgs/r-${R_VERSION}_1_amd64.deb
 
 Then install the package:
 ```bash
-sudo apt-get install gdebi-core
-sudo gdebi r-${R_VERSION}_1_amd64.deb
+sudo apt-get install ./r-${R_VERSION}_1_amd64.deb
 ```
 
 #### RHEL/CentOS Linux

--- a/builder/package.debian-12
+++ b/builder/package.debian-12
@@ -16,6 +16,12 @@ if grep -q '^LIBS *=.*[-]ldeflate' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
     deflate_libs='- libdeflate-dev'
 fi
 
+# R 4.5.0 and later require libzstd (with headers to link against libR)
+zstd_libs='# - libzstd-dev'
+if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    zstd_libs='- libzstd-dev'
+fi
+
 cat <<EOF > /tmp/nfpm.yml
 name: r-${R_VERSION}
 version: 1
@@ -58,6 +64,7 @@ ${pcre_libs}
 - libtk8.6
 - libx11-6
 - libxt6
+${zstd_libs}
 - make
 - ucf
 - unzip

--- a/builder/package.fedora-40
+++ b/builder/package.fedora-40
@@ -12,7 +12,7 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 fi
 
 # R 4.5.0 and later require libzstd (with headers to link against libR)
-zstd_libs='# - libzstd-dev'
+zstd_libs='# - libzstd-devel'
 if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
     zstd_libs='- libzstd-devel'
 fi

--- a/builder/package.fedora-40
+++ b/builder/package.fedora-40
@@ -11,6 +11,12 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 - pcre-devel'
 fi
 
+# R 4.5.0 and later require libzstd (with headers to link against libR)
+zstd_libs='# - libzstd-dev'
+if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    zstd_libs='- libzstd-devel'
+fi
+
 blas_lib='flexiblas-devel'
 
 # Create postremove script to remove empty directories, as nFPM doesn't include them in the RPM files.
@@ -49,6 +55,7 @@ depends:
 - libtiff
 - libXmu
 - libXt
+${zstd_libs}
 - make
 - ${blas_lib}
 - pango

--- a/builder/package.fedora-41
+++ b/builder/package.fedora-41
@@ -12,7 +12,7 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 fi
 
 # R 4.5.0 and later require libzstd (with headers to link against libR)
-zstd_libs='# - libzstd-dev'
+zstd_libs='# - libzstd-devel'
 if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
     zstd_libs='- libzstd-devel'
 fi

--- a/builder/package.fedora-41
+++ b/builder/package.fedora-41
@@ -11,6 +11,12 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 - pcre-devel'
 fi
 
+# R 4.5.0 and later require libzstd (with headers to link against libR)
+zstd_libs='# - libzstd-dev'
+if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    zstd_libs='- libzstd-devel'
+fi
+
 blas_lib='flexiblas-devel'
 
 # Create postremove script to remove empty directories, as nFPM doesn't include them in the RPM files.
@@ -49,6 +55,7 @@ depends:
 - libtiff
 - libXmu
 - libXt
+${zstd_libs}
 - make
 - ${blas_lib}
 - pango

--- a/builder/package.opensuse-156
+++ b/builder/package.opensuse-156
@@ -12,7 +12,7 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 fi
 
 # R 4.5.0 and later require libzstd (with headers to link against libR)
-zstd_libs='# - libzstd-dev'
+zstd_libs='# - libzstd-devel'
 if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
     zstd_libs='- libzstd-devel'
 fi

--- a/builder/package.opensuse-156
+++ b/builder/package.opensuse-156
@@ -11,6 +11,12 @@ if [[ "${R_VERSION}" =~ ^3 ]]; then
 - pcre-devel'
 fi
 
+# R 4.5.0 and later require libzstd (with headers to link against libR)
+zstd_libs='# - libzstd-dev'
+if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    zstd_libs='- libzstd-devel'
+fi
+
 # Create post-install script required for OpenBLAS.
 #
 # On RHEL and SUSE, we link R against the internal shared BLAS to make the
@@ -72,6 +78,7 @@ depends:
 - libpango-1_0-0
 - libreadline7
 - libtiff6
+${zstd_libs}
 - make
 ${pcre_libs}
 - tar

--- a/builder/package.ubuntu-2404
+++ b/builder/package.ubuntu-2404
@@ -16,6 +16,12 @@ if grep -q '^LIBS *=.*[-]ldeflate' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
     deflate_libs='- libdeflate-dev'
 fi
 
+# R 4.5.0 and later require libzstd (with headers to link against libR)
+zstd_libs='# - libzstd-dev'
+if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    zstd_libs='- libzstd-dev'
+fi
+
 cat <<EOF > /tmp/nfpm.yml
 name: r-${R_VERSION}
 version: 1
@@ -59,6 +65,7 @@ ${pcre_libs}
 - libtk8.6
 - libx11-6
 - libxt6t64
+${zstd_libs}
 - make
 - ucf
 - unzip


### PR DESCRIPTION
- Minor README updates to match https://docs.posit.co/resources/install-r.html
  - Closes https://github.com/rstudio/r-builds/issues/239
  - Use apt-get install over gdebi

And fixes #243 only for the distros that inadvertently pull in libzstd headers: Ubuntu 24, Debian 12, openSUSE 15.6, Fedora 40/41. I don't know how important it is to add libzstd-dev to the other distros given that it's a new optional feature. If important enough, that could be done later, maybe with libdeflate added too.

For testing, CI on R-devel should now all pass.

