### PR TITLE
R-devel needs --with-2025blas on RHEL, SUSE

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -69,7 +69,8 @@ ENV CONFIGURE_OPTIONS="\
     --with-system-valgrind-headers \
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
-    --enable-prebuilt-html"
+    --enable-prebuilt-html \
+    --with-2025blas"
 
 # RHEL 7 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"

--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -67,7 +67,8 @@ ENV CONFIGURE_OPTIONS="\
     --with-system-valgrind-headers \
     --with-tcl-config=/usr/lib64/tclConfig.sh \
     --with-tk-config=/usr/lib64/tkConfig.sh \
-    --enable-prebuilt-html"
+    --enable-prebuilt-html \
+    --with-2025blas"
 
 # RHEL 8 doesn't have the inconsolata font, so override the defaults.
 ENV R_RD4PDF="times,hyper"

--- a/builder/Dockerfile.opensuse-155
+++ b/builder/Dockerfile.opensuse-155
@@ -87,7 +87,8 @@ ENV CONFIGURE_OPTIONS="\
     --with-x \
     --enable-memory-profiling \
     --with-tcl-config=/usr/lib64/tclConfig.sh \
-    --with-tk-config=/usr/lib64/tkConfig.sh"
+    --with-tk-config=/usr/lib64/tkConfig.sh \
+    --with-2025blas"
 
 # Make sure that patching Java does not break R.
 # On SUSE, the default JAVA_HOME path always uses the major Java version only,

--- a/builder/Dockerfile.opensuse-156
+++ b/builder/Dockerfile.opensuse-156
@@ -89,7 +89,8 @@ ENV CONFIGURE_OPTIONS="\
     --with-x \
     --enable-memory-profiling \
     --with-tcl-config=/usr/lib64/tclConfig.sh \
-    --with-tk-config=/usr/lib64/tkConfig.sh"
+    --with-tk-config=/usr/lib64/tkConfig.sh \
+    --with-2025blas"
 
 # Make sure that patching Java does not break R.
 # On SUSE, the default JAVA_HOME path always uses the major Java version only,


### PR DESCRIPTION
I added it unconditionally. On older R versions there'll be a warning about an unknown option, but that should be harmless.

Alternatively, we could add it if the version number if larger than 4.5.0.  Accidentally that also works for `devel`. For `next` we'll get a warning until R 4.5.0 is released.

Closes #246.
