### PR TITLE
Add Fedora 42 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-2004 ubuntu-2204 ubuntu-2404 debian-12 centos-7 centos-8 rhel-9 opensuse-156 fedora-40 fedora-41
+PLATFORMS := ubuntu-2004 ubuntu-2204 ubuntu-2404 debian-12 centos-7 centos-8 rhel-9 opensuse-156 fedora-40 fedora-41 fedora-42
 SLS_BINARY ?= ./node_modules/serverless/bin/serverless.js
 
 deps:

--- a/builder/Dockerfile.fedora-42
+++ b/builder/Dockerfile.fedora-42
@@ -12,7 +12,7 @@ RUN dnf -y upgrade \
     flexiblas-devel \
     gcc-c++ \
     gcc-gfortran \
-    java-11-openjdk-devel \
+    java-21-openjdk-devel \
     libICE-devel \
     libSM-devel \
     libX11-devel \

--- a/builder/Dockerfile.fedora-42
+++ b/builder/Dockerfile.fedora-42
@@ -1,0 +1,88 @@
+FROM fedora:42
+
+ENV OS_IDENTIFIER fedora-42
+
+RUN dnf -y upgrade \
+    && dnf -y install dnf-plugins-core \
+    && dnf -y install \
+    autoconf \
+    automake \
+    bzip2-devel \
+    cairo-devel \
+    flexiblas-devel \
+    gcc-c++ \
+    gcc-gfortran \
+    java-11-openjdk-devel \
+    libICE-devel \
+    libSM-devel \
+    libX11-devel \
+    libXmu-devel \
+    libXt-devel \
+    libcurl-devel \
+    libicu-devel \
+    libjpeg-devel \
+    libpng-devel \
+    libtiff-devel \
+    libtool \
+    make \
+    ncurses-devel \
+    pango-devel \
+    pcre-devel \
+    pcre2-devel \
+    readline-devel \
+    rpm-build \
+    tcl-devel \
+    tex \
+    texinfo-tex \
+    texlive-collection-latexrecommended \
+    tk-devel \
+    unzip \
+    valgrind-devel \
+    which \
+    wget \
+    xz-devel \
+    zlib-devel \
+    && dnf clean all
+
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+RUN if [ "$(arch)" == "aarch64" ]; then echo arm64; else echo amd64; fi > /tmp/arch
+
+RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_$(cat /tmp/arch).rpm" && \
+    dnf install -y "nfpm_$(cat /tmp/arch).rpm" && \
+    rm "nfpm_$(cat /tmp/arch).rpm"
+
+RUN chmod 0777 /opt
+
+# Configure flags for that don't use the defaults in build.sh
+ENV CONFIGURE_OPTIONS="\
+    --enable-R-shlib \
+    --with-tcltk \
+    --enable-memory-profiling \
+    --with-x \
+    --with-system-valgrind-headers \
+    --with-tcl-config=/usr/lib64/tclConfig.sh \
+    --with-tk-config=/usr/lib64/tkConfig.sh \
+    --enable-prebuilt-html \
+    --with-blas=flexiblas \
+    --with-lapack=flexiblas"
+
+# Make sure that patching Java does not break R.
+# R's default JAVA_HOME path includes the exact Java version on CentOS/RHEL, which
+# requires users to run `R CMD javareconf` even on minor/patch upgrades. Use the
+# major version symlink to avoid this.
+# https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Java-support
+# https://solutions.posit.co/envs-pkgs/using-rjava/
+ENV JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+
+# R 3.x requires PCRE2 for Pango support on RHEL 9
+ENV INCLUDE_PCRE2_IN_R_3 yes
+
+COPY package.fedora-42 /package.sh
+COPY build.sh .
+COPY patches /patches
+ENTRYPOINT ./build.sh

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -101,14 +101,23 @@ compile_r() {
   # https://cran.r-project.org/doc/manuals/r-release/NEWS.3.html
   # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Using-Fortran
   # https://gcc.gnu.org/gcc-10/porting_to.html
+  export CFLAGS="-g -O2"
+  export FFLAGS="-g -O2"
   gcc_major_version=$(gcc -dumpversion | cut -d '.' -f 1)
   if _version_is_less_than "${r_version}" 3.6.2 && _version_is_greater_than "${gcc_major_version}" 9; then
     # Default CFLAGS/FFLAGS for all R 3.x versions is '-g -O2' when using GCC
-    export CFLAGS='-g -O2 -fcommon'
-    export FFLAGS='-g -O2 -fallow-argument-mismatch'
-    echo "Setting CFLAGS: ${CFLAGS}"
-    echo "Setting FFLAGS: ${FFLAGS}"
+    export CFLAGS="$CFLAGS -fcommon"
+    export FFLAGS="$FFLAGS -fallow-argument-mismatch"
   fi
+
+  # GCC 15 and above needs -std=gnu11, because it defaults to C23, and R
+  # versions below R 4.5.0 do not compile in C23 mode.
+  if _version_is_less_than "${r_version}" 4.5.0 && _version_is_greater_than "${gcc_major_version}" 14; then
+    export CFLAGS="$CFLAGS -std=gnu11"
+  fi
+
+  echo "Setting CFLAGS: ${CFLAGS}"
+  echo "Setting FFLAGS: ${FFLAGS}"
 
   # Avoid a PCRE2 dependency for R 3.5 and 3.6. R 3.x uses PCRE1, but R 3.5+
   # will link against PCRE2 if present, although it is not actually used.

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -119,3 +119,15 @@ services:
     image: r-builds:fedora-41
     volumes:
       - ./integration/tmp:/tmp/output
+  fedora-42:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.fedora-42
+    image: r-builds:fedora-42
+    volumes:
+      - ./integration/tmp:/tmp/output

--- a/builder/package.fedora-42
+++ b/builder/package.fedora-42
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
+fi
+
+# R 3.x requires PCRE1. On RHEL 9, R 3.x also requires PCRE2 for Pango support.
+pcre_libs='- pcre2-devel'
+if [[ "${R_VERSION}" =~ ^3 ]]; then
+  pcre_libs='- pcre2-devel
+- pcre-devel'
+fi
+
+# R 4.5.0 and later require libzstd (with headers to link against libR)
+zstd_libs='# - libzstd-devel'
+if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    zstd_libs='- libzstd-devel'
+fi
+
+blas_lib='flexiblas-devel'
+
+# Create postremove script to remove empty directories, as nFPM doesn't include them in the RPM files.
+cat <<EOF >> /after-remove.sh
+if [ -d ${R_INSTALL_PATH} ]; then
+  rm -r ${R_INSTALL_PATH}
+fi
+EOF
+
+scripts="scripts:
+  postremove: /after-remove.sh
+"
+
+if [ "$(arch)" == "aarch64" ]; then echo arm64; else echo amd64; fi > /tmp/arch
+
+cat <<EOF > /tmp/nfpm.yml
+name: R-${R_VERSION}
+version: 1
+version_schema: none
+arch: $(cat /tmp/arch)
+release: 1
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: Posit Software, PBC
+homepage: https://www.r-project.org
+license: GPLv2+
+depends:
+- bzip2-devel
+- gcc
+- gcc-c++
+- gcc-gfortran
+- libcurl-devel
+- libicu-devel
+- libSM
+- libtiff
+- libXmu
+- libXt
+${zstd_libs}
+- make
+- ${blas_lib}
+- pango
+${pcre_libs}
+- tcl
+- tk
+- unzip
+- util-linux-core
+- which
+- xz-devel
+- zip
+- zlib-devel
+contents:
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
+${scripts}
+EOF
+
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p rpm \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm | head -1)

--- a/builder/patches/R-3.0.0-fedora-42.patch
+++ b/builder/patches/R-3.0.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.0.0-fedora-40.patch
+R-3.0.3-fedora-42.patch

--- a/builder/patches/R-3.0.0-fedora-42.patch
+++ b/builder/patches/R-3.0.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.0.0-fedora-40.patch

--- a/builder/patches/R-3.0.1-fedora-42.patch
+++ b/builder/patches/R-3.0.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.0.1-fedora-40.patch

--- a/builder/patches/R-3.0.1-fedora-42.patch
+++ b/builder/patches/R-3.0.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.0.1-fedora-40.patch
+R-3.0.3-fedora-42.patch

--- a/builder/patches/R-3.0.2-fedora-42.patch
+++ b/builder/patches/R-3.0.2-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.0.2-fedora-40.patch
+R-3.0.3-fedora-42.patch

--- a/builder/patches/R-3.0.2-fedora-42.patch
+++ b/builder/patches/R-3.0.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.0.2-fedora-40.patch

--- a/builder/patches/R-3.0.3-fedora-42.patch
+++ b/builder/patches/R-3.0.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.0.3-fedora-40.patch

--- a/builder/patches/R-3.0.3-fedora-42.patch
+++ b/builder/patches/R-3.0.3-fedora-42.patch
@@ -1,1 +1,163 @@
-R-3.0.3-fedora-40.patch
+diff --git a/configure b/configure
+index 6aea90a..add4f05 100755
+--- a/configure
++++ b/configure
+@@ -33626,7 +33626,7 @@ char BZ2_bzlibVersion ();
+ 
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return BZ2_bzlibVersion ();
+   ;
+@@ -33690,9 +33690,11 @@ else
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+-int main() {
++int main(void) {
+     char *ver = BZ2_bzlibVersion();
+     exit(strcmp(ver, "1.0.6") < 0);
+ }
+From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
+From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Wed, 16 Apr 2025 21:29:31 +0000
+Subject: [PATCH] Fixes for Tcl v9
+
+git-svn-id: https://svn.r-project.org/R/trunk@88149 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/library/tcltk/src/tcltk.c | 46 ++++++++++++++++++++---------------
+ 1 file changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/library/tcltk/src/tcltk.c b/src/library/tcltk/src/tcltk.c
+index a326ddb6731..c55c9b31424 100644
+--- a/src/library/tcltk/src/tcltk.c
++++ b/src/library/tcltk/src/tcltk.c
+@@ -36,6 +36,11 @@
+ 
+ Tcl_Interp *RTcl_interp;
+ 
++/* For Tcl < 8.7 */
++#ifndef TCL_SIZE_MAX
++typedef int Tcl_Size;
++#endif
++
+ static void RTcl_dec_refcount(SEXP R_tclobj)
+ {
+     Tcl_DecrRefCount((Tcl_Obj *) R_ExternalPtrAddr(R_tclobj));
+@@ -331,9 +336,9 @@ SEXP RTcl_StringFromObj(SEXP args)
+ 
+ SEXP RTcl_ObjAsCharVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     SEXP ans;
+ 
+     if (TYPEOF(CADR(args)) != EXTPTRSXP)
+@@ -341,10 +346,10 @@ SEXP RTcl_ObjAsCharVector(SEXP args)
+     obj = (Tcl_Obj *) R_ExternalPtrAddr(CADR(args));
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK)
++    if (ret != TCL_OK || count > R_XLEN_T_MAX)
+ 	return RTcl_StringFromObj(args);
+-
+-    PROTECT(ans = allocVector(STRSXP, count));
++	
++    PROTECT(ans = allocVector(STRSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+ 	char *s;
+ 	Tcl_DString s_ds;
+@@ -405,9 +410,9 @@ SEXP RTcl_ObjFromCharVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     double x;
+     SEXP ans;
+ 
+@@ -422,10 +427,10 @@ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(REALSXP, count);
++	
++    ans = allocVector(REALSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetDoubleFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_REAL;
+@@ -470,9 +475,9 @@ SEXP RTcl_ObjFromDoubleVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsIntVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     int x;
+     SEXP ans;
+ 
+@@ -487,10 +492,10 @@ SEXP RTcl_ObjAsIntVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(INTSXP, count);
++    
++    ans = allocVector(INTSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetIntFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_INTEGER;
+@@ -525,7 +530,7 @@ SEXP RTcl_ObjFromIntVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsRawVector(SEXP args)
+ {
+-    int nb, count, i, j;
++    Tcl_Size count, nb, i, j;
+     Tcl_Obj **elem, *obj;
+     unsigned char *ret;
+     SEXP ans, el;
+@@ -536,7 +541,7 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_GetByteArrayFromObj(obj, &nb);
+     if (ret) {
+-	ans = allocVector(RAWSXP, nb);
++	ans = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(ans)[j] = ret[j];
+ 	return ans;
+     }
+@@ -544,10 +549,11 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     /* Then try as list */
+     if (Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem)
+ 	!= TCL_OK) return R_NilValue;
+-
+-    PROTECT(ans = allocVector(VECSXP, count));
++    if (count > R_XLEN_T_MAX) return R_NilValue;
++    
++    PROTECT(ans = allocVector(VECSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+-	el = allocVector(RAWSXP, nb);
++	el = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	SET_VECTOR_ELT(ans, i, el);
+ 	ret = Tcl_GetByteArrayFromObj(elem[i], &nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(el)[j] = ret[j];

--- a/builder/patches/R-3.1.0-fedora-42.patch
+++ b/builder/patches/R-3.1.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.1.0-fedora-40.patch

--- a/builder/patches/R-3.1.0-fedora-42.patch
+++ b/builder/patches/R-3.1.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.1.0-fedora-40.patch
+R-3.1.3-fedora-42.patch

--- a/builder/patches/R-3.1.1-fedora-42.patch
+++ b/builder/patches/R-3.1.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.1.1-fedora-40.patch

--- a/builder/patches/R-3.1.1-fedora-42.patch
+++ b/builder/patches/R-3.1.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.1.1-fedora-40.patch
+R-3.1.3-fedora-42.patch

--- a/builder/patches/R-3.1.2-fedora-42.patch
+++ b/builder/patches/R-3.1.2-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.1.2-fedora-40.patch
+R-3.1.3-fedora-42.patch

--- a/builder/patches/R-3.1.2-fedora-42.patch
+++ b/builder/patches/R-3.1.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.1.2-fedora-40.patch

--- a/builder/patches/R-3.1.3-fedora-42.patch
+++ b/builder/patches/R-3.1.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.1.3-fedora-40.patch

--- a/builder/patches/R-3.2.0-fedora-42.patch
+++ b/builder/patches/R-3.2.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.2.0-fedora-40.patch
+R-3.2.5-fedora-42.patch

--- a/builder/patches/R-3.2.0-fedora-42.patch
+++ b/builder/patches/R-3.2.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.2.0-fedora-40.patch

--- a/builder/patches/R-3.2.1-fedora-42.patch
+++ b/builder/patches/R-3.2.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.2.1-fedora-40.patch
+R-3.2.5-fedora-42.patch

--- a/builder/patches/R-3.2.1-fedora-42.patch
+++ b/builder/patches/R-3.2.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.2.1-fedora-40.patch

--- a/builder/patches/R-3.2.2-fedora-42.patch
+++ b/builder/patches/R-3.2.2-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.2.2-fedora-40.patch
+R-3.2.5-fedora-42.patch

--- a/builder/patches/R-3.2.2-fedora-42.patch
+++ b/builder/patches/R-3.2.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.2.2-fedora-40.patch

--- a/builder/patches/R-3.2.3-fedora-42.patch
+++ b/builder/patches/R-3.2.3-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.2.3-fedora-40.patch
+R-3.2.5-fedora-42.patch

--- a/builder/patches/R-3.2.3-fedora-42.patch
+++ b/builder/patches/R-3.2.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.2.3-fedora-40.patch

--- a/builder/patches/R-3.2.4-fedora-42.patch
+++ b/builder/patches/R-3.2.4-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.2.4-fedora-40.patch

--- a/builder/patches/R-3.2.4-fedora-42.patch
+++ b/builder/patches/R-3.2.4-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.2.4-fedora-40.patch
+R-3.2.5-fedora-42.patch

--- a/builder/patches/R-3.2.5-fedora-42.patch
+++ b/builder/patches/R-3.2.5-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.2.5-fedora-40.patch

--- a/builder/patches/R-3.2.5-fedora-42.patch
+++ b/builder/patches/R-3.2.5-fedora-42.patch
@@ -1,1 +1,163 @@
-R-3.2.5-fedora-40.patch
+diff --git a/configure b/configure
+index b9d91b7..a61cfe4 100755
+--- a/configure
++++ b/configure
+@@ -34212,7 +34212,7 @@ char BZ2_bzlibVersion ();
+ 
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return BZ2_bzlibVersion ();
+   ;
+@@ -34276,9 +34276,11 @@ else
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+-int main() {
++int main(void) {
+     char *ver = BZ2_bzlibVersion();
+     exit(strcmp(ver, "1.0.6") < 0);
+ }
+From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
+From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Wed, 16 Apr 2025 21:29:31 +0000
+Subject: [PATCH] Fixes for Tcl v9
+
+git-svn-id: https://svn.r-project.org/R/trunk@88149 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/library/tcltk/src/tcltk.c | 46 ++++++++++++++++++++---------------
+ 1 file changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/library/tcltk/src/tcltk.c b/src/library/tcltk/src/tcltk.c
+index a326ddb6731..c55c9b31424 100644
+--- a/src/library/tcltk/src/tcltk.c
++++ b/src/library/tcltk/src/tcltk.c
+@@ -36,6 +36,11 @@
+ 
+ Tcl_Interp *RTcl_interp;
+ 
++/* For Tcl < 8.7 */
++#ifndef TCL_SIZE_MAX
++typedef int Tcl_Size;
++#endif
++
+ static void RTcl_dec_refcount(SEXP R_tclobj)
+ {
+     Tcl_DecrRefCount((Tcl_Obj *) R_ExternalPtrAddr(R_tclobj));
+@@ -331,9 +336,9 @@ SEXP RTcl_StringFromObj(SEXP args)
+ 
+ SEXP RTcl_ObjAsCharVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     SEXP ans;
+ 
+     if (TYPEOF(CADR(args)) != EXTPTRSXP)
+@@ -341,10 +346,10 @@ SEXP RTcl_ObjAsCharVector(SEXP args)
+     obj = (Tcl_Obj *) R_ExternalPtrAddr(CADR(args));
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK)
++    if (ret != TCL_OK || count > R_XLEN_T_MAX)
+ 	return RTcl_StringFromObj(args);
+-
+-    PROTECT(ans = allocVector(STRSXP, count));
++	
++    PROTECT(ans = allocVector(STRSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+ 	char *s;
+ 	Tcl_DString s_ds;
+@@ -405,9 +410,9 @@ SEXP RTcl_ObjFromCharVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     double x;
+     SEXP ans;
+ 
+@@ -422,10 +427,10 @@ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(REALSXP, count);
++	
++    ans = allocVector(REALSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetDoubleFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_REAL;
+@@ -470,9 +475,9 @@ SEXP RTcl_ObjFromDoubleVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsIntVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     int x;
+     SEXP ans;
+ 
+@@ -487,10 +492,10 @@ SEXP RTcl_ObjAsIntVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(INTSXP, count);
++    
++    ans = allocVector(INTSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetIntFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_INTEGER;
+@@ -525,7 +530,7 @@ SEXP RTcl_ObjFromIntVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsRawVector(SEXP args)
+ {
+-    int nb, count, i, j;
++    Tcl_Size count, nb, i, j;
+     Tcl_Obj **elem, *obj;
+     unsigned char *ret;
+     SEXP ans, el;
+@@ -536,7 +541,7 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_GetByteArrayFromObj(obj, &nb);
+     if (ret) {
+-	ans = allocVector(RAWSXP, nb);
++	ans = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(ans)[j] = ret[j];
+ 	return ans;
+     }
+@@ -544,10 +549,11 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     /* Then try as list */
+     if (Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem)
+ 	!= TCL_OK) return R_NilValue;
+-
+-    PROTECT(ans = allocVector(VECSXP, count));
++    if (count > R_XLEN_T_MAX) return R_NilValue;
++    
++    PROTECT(ans = allocVector(VECSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+-	el = allocVector(RAWSXP, nb);
++	el = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	SET_VECTOR_ELT(ans, i, el);
+ 	ret = Tcl_GetByteArrayFromObj(elem[i], &nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(el)[j] = ret[j];

--- a/builder/patches/R-3.3.0-fedora-42.patch
+++ b/builder/patches/R-3.3.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.3.0-fedora-40.patch

--- a/builder/patches/R-3.3.0-fedora-42.patch
+++ b/builder/patches/R-3.3.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.3.0-fedora-40.patch
+R-3.3.3-fedora-42.patch

--- a/builder/patches/R-3.3.1-fedora-42.patch
+++ b/builder/patches/R-3.3.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.3.1-fedora-40.patch

--- a/builder/patches/R-3.3.1-fedora-42.patch
+++ b/builder/patches/R-3.3.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.3.1-fedora-40.patch
+R-3.3.3-fedora-42.patch

--- a/builder/patches/R-3.3.2-fedora-42.patch
+++ b/builder/patches/R-3.3.2-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.3.2-fedora-40.patch
+R-3.3.3-fedora-42.patch

--- a/builder/patches/R-3.3.2-fedora-42.patch
+++ b/builder/patches/R-3.3.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.3.2-fedora-40.patch

--- a/builder/patches/R-3.3.3-fedora-42.patch
+++ b/builder/patches/R-3.3.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.3.3-fedora-40.patch

--- a/builder/patches/R-3.3.3-fedora-42.patch
+++ b/builder/patches/R-3.3.3-fedora-42.patch
@@ -1,1 +1,171 @@
-R-3.3.3-fedora-40.patch
+diff --git a/configure b/configure
+index 8dfd4b6..88f4e07 100755
+--- a/configure
++++ b/configure
+@@ -35612,7 +35612,7 @@ char BZ2_bzlibVersion ();
+ 
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return BZ2_bzlibVersion ();
+   ;
+@@ -35673,9 +35673,11 @@ else
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+-int main() {
++int main(void) {
+     char *ver = BZ2_bzlibVersion();
+     exit(strcmp(ver, "1.0.6") < 0);
+ }
+@@ -36251,6 +36253,7 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <curl/curl.h>
+ int main()
+From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
+From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Wed, 16 Apr 2025 21:29:31 +0000
+Subject: [PATCH] Fixes for Tcl v9
+
+git-svn-id: https://svn.r-project.org/R/trunk@88149 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/library/tcltk/src/tcltk.c | 46 ++++++++++++++++++++---------------
+ 1 file changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/library/tcltk/src/tcltk.c b/src/library/tcltk/src/tcltk.c
+index a326ddb6731..c55c9b31424 100644
+--- a/src/library/tcltk/src/tcltk.c
++++ b/src/library/tcltk/src/tcltk.c
+@@ -36,6 +36,11 @@
+ 
+ Tcl_Interp *RTcl_interp;
+ 
++/* For Tcl < 8.7 */
++#ifndef TCL_SIZE_MAX
++typedef int Tcl_Size;
++#endif
++
+ static void RTcl_dec_refcount(SEXP R_tclobj)
+ {
+     Tcl_DecrRefCount((Tcl_Obj *) R_ExternalPtrAddr(R_tclobj));
+@@ -331,9 +336,9 @@ SEXP RTcl_StringFromObj(SEXP args)
+ 
+ SEXP RTcl_ObjAsCharVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     SEXP ans;
+ 
+     if (TYPEOF(CADR(args)) != EXTPTRSXP)
+@@ -341,10 +346,10 @@ SEXP RTcl_ObjAsCharVector(SEXP args)
+     obj = (Tcl_Obj *) R_ExternalPtrAddr(CADR(args));
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK)
++    if (ret != TCL_OK || count > R_XLEN_T_MAX)
+ 	return RTcl_StringFromObj(args);
+-
+-    PROTECT(ans = allocVector(STRSXP, count));
++	
++    PROTECT(ans = allocVector(STRSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+ 	char *s;
+ 	Tcl_DString s_ds;
+@@ -405,9 +410,9 @@ SEXP RTcl_ObjFromCharVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     double x;
+     SEXP ans;
+ 
+@@ -422,10 +427,10 @@ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(REALSXP, count);
++	
++    ans = allocVector(REALSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetDoubleFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_REAL;
+@@ -470,9 +475,9 @@ SEXP RTcl_ObjFromDoubleVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsIntVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     int x;
+     SEXP ans;
+ 
+@@ -487,10 +492,10 @@ SEXP RTcl_ObjAsIntVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(INTSXP, count);
++    
++    ans = allocVector(INTSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetIntFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_INTEGER;
+@@ -525,7 +530,7 @@ SEXP RTcl_ObjFromIntVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsRawVector(SEXP args)
+ {
+-    int nb, count, i, j;
++    Tcl_Size count, nb, i, j;
+     Tcl_Obj **elem, *obj;
+     unsigned char *ret;
+     SEXP ans, el;
+@@ -536,7 +541,7 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_GetByteArrayFromObj(obj, &nb);
+     if (ret) {
+-	ans = allocVector(RAWSXP, nb);
++	ans = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(ans)[j] = ret[j];
+ 	return ans;
+     }
+@@ -544,10 +549,11 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     /* Then try as list */
+     if (Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem)
+ 	!= TCL_OK) return R_NilValue;
+-
+-    PROTECT(ans = allocVector(VECSXP, count));
++    if (count > R_XLEN_T_MAX) return R_NilValue;
++    
++    PROTECT(ans = allocVector(VECSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+-	el = allocVector(RAWSXP, nb);
++	el = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	SET_VECTOR_ELT(ans, i, el);
+ 	ret = Tcl_GetByteArrayFromObj(elem[i], &nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(el)[j] = ret[j];

--- a/builder/patches/R-3.4.0-fedora-42.patch
+++ b/builder/patches/R-3.4.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.4.0-fedora-40.patch

--- a/builder/patches/R-3.4.0-fedora-42.patch
+++ b/builder/patches/R-3.4.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.4.0-fedora-40.patch
+R-3.4.4-fedora-42.patch

--- a/builder/patches/R-3.4.1-fedora-42.patch
+++ b/builder/patches/R-3.4.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.4.1-fedora-40.patch
+R-3.4.4-fedora-42.patch

--- a/builder/patches/R-3.4.1-fedora-42.patch
+++ b/builder/patches/R-3.4.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.4.1-fedora-40.patch

--- a/builder/patches/R-3.4.2-fedora-42.patch
+++ b/builder/patches/R-3.4.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.4.2-fedora-40.patch

--- a/builder/patches/R-3.4.2-fedora-42.patch
+++ b/builder/patches/R-3.4.2-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.4.2-fedora-40.patch
+R-3.4.4-fedora-42.patch

--- a/builder/patches/R-3.4.3-fedora-42.patch
+++ b/builder/patches/R-3.4.3-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.4.3-fedora-40.patch
+R-3.4.4-fedora-42.patch

--- a/builder/patches/R-3.4.3-fedora-42.patch
+++ b/builder/patches/R-3.4.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.4.3-fedora-40.patch

--- a/builder/patches/R-3.4.4-fedora-42.patch
+++ b/builder/patches/R-3.4.4-fedora-42.patch
@@ -1,1 +1,171 @@
-R-3.4.4-fedora-40.patch
+diff --git a/configure b/configure
+index a314719..a59cda1 100755
+--- a/configure
++++ b/configure
+@@ -40433,7 +40433,7 @@ char BZ2_bzlibVersion ();
+ 
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return BZ2_bzlibVersion ();
+   ;
+@@ -40494,9 +40494,11 @@ else
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+-int main() {
++int main(void) {
+     char *ver = BZ2_bzlibVersion();
+     exit(strcmp(ver, "1.0.6") < 0);
+ }
+@@ -41072,6 +41074,7 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <curl/curl.h>
+ int main()
+From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
+From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Wed, 16 Apr 2025 21:29:31 +0000
+Subject: [PATCH] Fixes for Tcl v9
+
+git-svn-id: https://svn.r-project.org/R/trunk@88149 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/library/tcltk/src/tcltk.c | 46 ++++++++++++++++++++---------------
+ 1 file changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/library/tcltk/src/tcltk.c b/src/library/tcltk/src/tcltk.c
+index a326ddb6731..c55c9b31424 100644
+--- a/src/library/tcltk/src/tcltk.c
++++ b/src/library/tcltk/src/tcltk.c
+@@ -36,6 +36,11 @@
+ 
+ Tcl_Interp *RTcl_interp;
+ 
++/* For Tcl < 8.7 */
++#ifndef TCL_SIZE_MAX
++typedef int Tcl_Size;
++#endif
++
+ static void RTcl_dec_refcount(SEXP R_tclobj)
+ {
+     Tcl_DecrRefCount((Tcl_Obj *) R_ExternalPtrAddr(R_tclobj));
+@@ -331,9 +336,9 @@ SEXP RTcl_StringFromObj(SEXP args)
+ 
+ SEXP RTcl_ObjAsCharVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     SEXP ans;
+ 
+     if (TYPEOF(CADR(args)) != EXTPTRSXP)
+@@ -341,10 +346,10 @@ SEXP RTcl_ObjAsCharVector(SEXP args)
+     obj = (Tcl_Obj *) R_ExternalPtrAddr(CADR(args));
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK)
++    if (ret != TCL_OK || count > R_XLEN_T_MAX)
+ 	return RTcl_StringFromObj(args);
+-
+-    PROTECT(ans = allocVector(STRSXP, count));
++	
++    PROTECT(ans = allocVector(STRSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+ 	char *s;
+ 	Tcl_DString s_ds;
+@@ -405,9 +410,9 @@ SEXP RTcl_ObjFromCharVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     double x;
+     SEXP ans;
+ 
+@@ -422,10 +427,10 @@ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(REALSXP, count);
++	
++    ans = allocVector(REALSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetDoubleFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_REAL;
+@@ -470,9 +475,9 @@ SEXP RTcl_ObjFromDoubleVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsIntVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     int x;
+     SEXP ans;
+ 
+@@ -487,10 +492,10 @@ SEXP RTcl_ObjAsIntVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(INTSXP, count);
++    
++    ans = allocVector(INTSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetIntFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_INTEGER;
+@@ -525,7 +530,7 @@ SEXP RTcl_ObjFromIntVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsRawVector(SEXP args)
+ {
+-    int nb, count, i, j;
++    Tcl_Size count, nb, i, j;
+     Tcl_Obj **elem, *obj;
+     unsigned char *ret;
+     SEXP ans, el;
+@@ -536,7 +541,7 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_GetByteArrayFromObj(obj, &nb);
+     if (ret) {
+-	ans = allocVector(RAWSXP, nb);
++	ans = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(ans)[j] = ret[j];
+ 	return ans;
+     }
+@@ -544,10 +549,11 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     /* Then try as list */
+     if (Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem)
+ 	!= TCL_OK) return R_NilValue;
+-
+-    PROTECT(ans = allocVector(VECSXP, count));
++    if (count > R_XLEN_T_MAX) return R_NilValue;
++    
++    PROTECT(ans = allocVector(VECSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+-	el = allocVector(RAWSXP, nb);
++	el = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	SET_VECTOR_ELT(ans, i, el);
+ 	ret = Tcl_GetByteArrayFromObj(elem[i], &nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(el)[j] = ret[j];

--- a/builder/patches/R-3.4.4-fedora-42.patch
+++ b/builder/patches/R-3.4.4-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.4.4-fedora-40.patch

--- a/builder/patches/R-3.5.0-fedora-42.patch
+++ b/builder/patches/R-3.5.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.5.0-fedora-40.patch

--- a/builder/patches/R-3.5.0-fedora-42.patch
+++ b/builder/patches/R-3.5.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.5.0-fedora-40.patch
+R-3.5.3-fedora-42.patch

--- a/builder/patches/R-3.5.1-fedora-42.patch
+++ b/builder/patches/R-3.5.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.5.1-fedora-40.patch
+R-3.5.3-fedora-42.patch

--- a/builder/patches/R-3.5.1-fedora-42.patch
+++ b/builder/patches/R-3.5.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.5.1-fedora-40.patch

--- a/builder/patches/R-3.5.2-fedora-42.patch
+++ b/builder/patches/R-3.5.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.5.2-fedora-40.patch

--- a/builder/patches/R-3.5.2-fedora-42.patch
+++ b/builder/patches/R-3.5.2-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.5.2-fedora-40.patch
+R-3.5.3-fedora-42.patch

--- a/builder/patches/R-3.5.3-fedora-42.patch
+++ b/builder/patches/R-3.5.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.5.3-fedora-40.patch

--- a/builder/patches/R-3.5.3-fedora-42.patch
+++ b/builder/patches/R-3.5.3-fedora-42.patch
@@ -1,1 +1,171 @@
-R-3.5.3-fedora-40.patch
+diff --git a/configure b/configure
+index 281751a..3b1f649 100755
+--- a/configure
++++ b/configure
+@@ -42413,7 +42413,7 @@ char BZ2_bzlibVersion ();
+ 
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return BZ2_bzlibVersion ();
+   ;
+@@ -42474,9 +42474,11 @@ else
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+-int main() {
++int main(void) {
+     char *ver = BZ2_bzlibVersion();
+     exit(strcmp(ver, "1.0.6") < 0);
+ }
+@@ -43184,6 +43186,7 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <curl/curl.h>
+ int main()
+From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
+From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Wed, 16 Apr 2025 21:29:31 +0000
+Subject: [PATCH] Fixes for Tcl v9
+
+git-svn-id: https://svn.r-project.org/R/trunk@88149 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/library/tcltk/src/tcltk.c | 46 ++++++++++++++++++++---------------
+ 1 file changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/library/tcltk/src/tcltk.c b/src/library/tcltk/src/tcltk.c
+index a326ddb6731..c55c9b31424 100644
+--- a/src/library/tcltk/src/tcltk.c
++++ b/src/library/tcltk/src/tcltk.c
+@@ -36,6 +36,11 @@
+ 
+ Tcl_Interp *RTcl_interp;
+ 
++/* For Tcl < 8.7 */
++#ifndef TCL_SIZE_MAX
++typedef int Tcl_Size;
++#endif
++
+ static void RTcl_dec_refcount(SEXP R_tclobj)
+ {
+     Tcl_DecrRefCount((Tcl_Obj *) R_ExternalPtrAddr(R_tclobj));
+@@ -331,9 +336,9 @@ SEXP RTcl_StringFromObj(SEXP args)
+ 
+ SEXP RTcl_ObjAsCharVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     SEXP ans;
+ 
+     if (TYPEOF(CADR(args)) != EXTPTRSXP)
+@@ -341,10 +346,10 @@ SEXP RTcl_ObjAsCharVector(SEXP args)
+     obj = (Tcl_Obj *) R_ExternalPtrAddr(CADR(args));
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK)
++    if (ret != TCL_OK || count > R_XLEN_T_MAX)
+ 	return RTcl_StringFromObj(args);
+-
+-    PROTECT(ans = allocVector(STRSXP, count));
++	
++    PROTECT(ans = allocVector(STRSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+ 	char *s;
+ 	Tcl_DString s_ds;
+@@ -405,9 +410,9 @@ SEXP RTcl_ObjFromCharVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     double x;
+     SEXP ans;
+ 
+@@ -422,10 +427,10 @@ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(REALSXP, count);
++	
++    ans = allocVector(REALSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetDoubleFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_REAL;
+@@ -470,9 +475,9 @@ SEXP RTcl_ObjFromDoubleVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsIntVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     int x;
+     SEXP ans;
+ 
+@@ -487,10 +492,10 @@ SEXP RTcl_ObjAsIntVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(INTSXP, count);
++    
++    ans = allocVector(INTSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetIntFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_INTEGER;
+@@ -525,7 +530,7 @@ SEXP RTcl_ObjFromIntVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsRawVector(SEXP args)
+ {
+-    int nb, count, i, j;
++    Tcl_Size count, nb, i, j;
+     Tcl_Obj **elem, *obj;
+     unsigned char *ret;
+     SEXP ans, el;
+@@ -536,7 +541,7 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_GetByteArrayFromObj(obj, &nb);
+     if (ret) {
+-	ans = allocVector(RAWSXP, nb);
++	ans = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(ans)[j] = ret[j];
+ 	return ans;
+     }
+@@ -544,10 +549,11 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     /* Then try as list */
+     if (Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem)
+ 	!= TCL_OK) return R_NilValue;
+-
+-    PROTECT(ans = allocVector(VECSXP, count));
++    if (count > R_XLEN_T_MAX) return R_NilValue;
++    
++    PROTECT(ans = allocVector(VECSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+-	el = allocVector(RAWSXP, nb);
++	el = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	SET_VECTOR_ELT(ans, i, el);
+ 	ret = Tcl_GetByteArrayFromObj(elem[i], &nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(el)[j] = ret[j];

--- a/builder/patches/R-3.6.0-fedora-42.patch
+++ b/builder/patches/R-3.6.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.6.0-fedora-40.patch

--- a/builder/patches/R-3.6.0-fedora-42.patch
+++ b/builder/patches/R-3.6.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.6.0-fedora-40.patch
+R-3.6.3-fedora-42.patch

--- a/builder/patches/R-3.6.1-fedora-42.patch
+++ b/builder/patches/R-3.6.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.6.1-fedora-40.patch

--- a/builder/patches/R-3.6.1-fedora-42.patch
+++ b/builder/patches/R-3.6.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.6.1-fedora-40.patch
+R-3.6.3-fedora-42.patch

--- a/builder/patches/R-3.6.2-fedora-42.patch
+++ b/builder/patches/R-3.6.2-fedora-42.patch
@@ -1,1 +1,1 @@
-R-3.6.2-fedora-40.patch
+R-3.6.3-fedora-42.patch

--- a/builder/patches/R-3.6.2-fedora-42.patch
+++ b/builder/patches/R-3.6.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.6.2-fedora-40.patch

--- a/builder/patches/R-3.6.3-fedora-42.patch
+++ b/builder/patches/R-3.6.3-fedora-42.patch
@@ -1,1 +1,171 @@
-R-3.6.3-fedora-40.patch
+diff --git a/configure b/configure
+index 976de50..6490bcf 100755
+--- a/configure
++++ b/configure
+@@ -42177,7 +42177,7 @@ char BZ2_bzlibVersion ();
+ #endif
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return BZ2_bzlibVersion ();
+   ;
+@@ -42238,9 +42238,11 @@ else
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+-int main() {
++int main(void) {
+     char *ver = BZ2_bzlibVersion();
+     exit(strcmp(ver, "1.0.6") < 0);
+ }
+@@ -42946,6 +42948,7 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <curl/curl.h>
+ int main()
+From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
+From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Wed, 16 Apr 2025 21:29:31 +0000
+Subject: [PATCH] Fixes for Tcl v9
+
+git-svn-id: https://svn.r-project.org/R/trunk@88149 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/library/tcltk/src/tcltk.c | 46 ++++++++++++++++++++---------------
+ 1 file changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/library/tcltk/src/tcltk.c b/src/library/tcltk/src/tcltk.c
+index a326ddb6731..c55c9b31424 100644
+--- a/src/library/tcltk/src/tcltk.c
++++ b/src/library/tcltk/src/tcltk.c
+@@ -36,6 +36,11 @@
+ 
+ Tcl_Interp *RTcl_interp;
+ 
++/* For Tcl < 8.7 */
++#ifndef TCL_SIZE_MAX
++typedef int Tcl_Size;
++#endif
++
+ static void RTcl_dec_refcount(SEXP R_tclobj)
+ {
+     Tcl_DecrRefCount((Tcl_Obj *) R_ExternalPtrAddr(R_tclobj));
+@@ -331,9 +336,9 @@ SEXP RTcl_StringFromObj(SEXP args)
+ 
+ SEXP RTcl_ObjAsCharVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     SEXP ans;
+ 
+     if (TYPEOF(CADR(args)) != EXTPTRSXP)
+@@ -341,10 +346,10 @@ SEXP RTcl_ObjAsCharVector(SEXP args)
+     obj = (Tcl_Obj *) R_ExternalPtrAddr(CADR(args));
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK)
++    if (ret != TCL_OK || count > R_XLEN_T_MAX)
+ 	return RTcl_StringFromObj(args);
+-
+-    PROTECT(ans = allocVector(STRSXP, count));
++	
++    PROTECT(ans = allocVector(STRSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+ 	char *s;
+ 	Tcl_DString s_ds;
+@@ -405,9 +410,9 @@ SEXP RTcl_ObjFromCharVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     double x;
+     SEXP ans;
+ 
+@@ -422,10 +427,10 @@ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(REALSXP, count);
++	
++    ans = allocVector(REALSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetDoubleFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_REAL;
+@@ -470,9 +475,9 @@ SEXP RTcl_ObjFromDoubleVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsIntVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     int x;
+     SEXP ans;
+ 
+@@ -487,10 +492,10 @@ SEXP RTcl_ObjAsIntVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(INTSXP, count);
++    
++    ans = allocVector(INTSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetIntFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_INTEGER;
+@@ -525,7 +530,7 @@ SEXP RTcl_ObjFromIntVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsRawVector(SEXP args)
+ {
+-    int nb, count, i, j;
++    Tcl_Size count, nb, i, j;
+     Tcl_Obj **elem, *obj;
+     unsigned char *ret;
+     SEXP ans, el;
+@@ -536,7 +541,7 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_GetByteArrayFromObj(obj, &nb);
+     if (ret) {
+-	ans = allocVector(RAWSXP, nb);
++	ans = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(ans)[j] = ret[j];
+ 	return ans;
+     }
+@@ -544,10 +549,11 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     /* Then try as list */
+     if (Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem)
+ 	!= TCL_OK) return R_NilValue;
+-
+-    PROTECT(ans = allocVector(VECSXP, count));
++    if (count > R_XLEN_T_MAX) return R_NilValue;
++    
++    PROTECT(ans = allocVector(VECSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+-	el = allocVector(RAWSXP, nb);
++	el = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	SET_VECTOR_ELT(ans, i, el);
+ 	ret = Tcl_GetByteArrayFromObj(elem[i], &nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(el)[j] = ret[j];

--- a/builder/patches/R-3.6.3-fedora-42.patch
+++ b/builder/patches/R-3.6.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-3.6.3-fedora-40.patch

--- a/builder/patches/R-4.0.0-fedora-42.patch
+++ b/builder/patches/R-4.0.0-fedora-42.patch
@@ -1,1 +1,1 @@
-R-4.0.0-fedora-40.patch
+R-4.0.2-fedora-42.patch

--- a/builder/patches/R-4.0.0-fedora-42.patch
+++ b/builder/patches/R-4.0.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.0.0-fedora-40.patch

--- a/builder/patches/R-4.0.1-fedora-42.patch
+++ b/builder/patches/R-4.0.1-fedora-42.patch
@@ -1,1 +1,1 @@
-R-4.0.1-fedora-40.patch
+R-4.0.2-fedora-42.patch

--- a/builder/patches/R-4.0.1-fedora-42.patch
+++ b/builder/patches/R-4.0.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.0.1-fedora-40.patch

--- a/builder/patches/R-4.0.2-fedora-42.patch
+++ b/builder/patches/R-4.0.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.0.2-fedora-40.patch

--- a/builder/patches/R-4.0.2-fedora-42.patch
+++ b/builder/patches/R-4.0.2-fedora-42.patch
@@ -1,1 +1,171 @@
-R-4.0.2-fedora-40.patch
+diff --git a/configure b/configure
+index 7a9f1f0..30d76b6 100755
+--- a/configure
++++ b/configure
+@@ -45339,7 +45339,7 @@ char BZ2_bzlibVersion ();
+ #endif
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return BZ2_bzlibVersion ();
+   ;
+@@ -45400,9 +45400,11 @@ else
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+-int main() {
++int main(void) {
+     char *ver = BZ2_bzlibVersion();
+     exit(strcmp(ver, "1.0.6") < 0);
+ }
+@@ -46109,6 +46111,7 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <curl/curl.h>
+ int main()
+From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
+From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Wed, 16 Apr 2025 21:29:31 +0000
+Subject: [PATCH] Fixes for Tcl v9
+
+git-svn-id: https://svn.r-project.org/R/trunk@88149 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/library/tcltk/src/tcltk.c | 46 ++++++++++++++++++++---------------
+ 1 file changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/library/tcltk/src/tcltk.c b/src/library/tcltk/src/tcltk.c
+index a326ddb6731..c55c9b31424 100644
+--- a/src/library/tcltk/src/tcltk.c
++++ b/src/library/tcltk/src/tcltk.c
+@@ -36,6 +36,11 @@
+ 
+ Tcl_Interp *RTcl_interp;
+ 
++/* For Tcl < 8.7 */
++#ifndef TCL_SIZE_MAX
++typedef int Tcl_Size;
++#endif
++
+ static void RTcl_dec_refcount(SEXP R_tclobj)
+ {
+     Tcl_DecrRefCount((Tcl_Obj *) R_ExternalPtrAddr(R_tclobj));
+@@ -331,9 +336,9 @@ SEXP RTcl_StringFromObj(SEXP args)
+ 
+ SEXP RTcl_ObjAsCharVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     SEXP ans;
+ 
+     if (TYPEOF(CADR(args)) != EXTPTRSXP)
+@@ -341,10 +346,10 @@ SEXP RTcl_ObjAsCharVector(SEXP args)
+     obj = (Tcl_Obj *) R_ExternalPtrAddr(CADR(args));
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK)
++    if (ret != TCL_OK || count > R_XLEN_T_MAX)
+ 	return RTcl_StringFromObj(args);
+-
+-    PROTECT(ans = allocVector(STRSXP, count));
++	
++    PROTECT(ans = allocVector(STRSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+ 	char *s;
+ 	Tcl_DString s_ds;
+@@ -405,9 +410,9 @@ SEXP RTcl_ObjFromCharVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     double x;
+     SEXP ans;
+ 
+@@ -422,10 +427,10 @@ SEXP RTcl_ObjAsDoubleVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(REALSXP, count);
++	
++    ans = allocVector(REALSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetDoubleFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_REAL;
+@@ -470,9 +475,9 @@ SEXP RTcl_ObjFromDoubleVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsIntVector(SEXP args)
+ {
+-    int count;
++    Tcl_Size count, i;
+     Tcl_Obj **elem, *obj;
+-    int ret, i;
++    int ret;
+     int x;
+     SEXP ans;
+ 
+@@ -487,10 +492,10 @@ SEXP RTcl_ObjAsIntVector(SEXP args)
+ 
+     /* Then try as list */
+     ret = Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem);
+-    if (ret != TCL_OK) /* didn't work, return NULL */
++    if (ret != TCL_OK || count > R_XLEN_T_MAX) /* didn't work, return NULL */
+ 	return R_NilValue;
+-
+-    ans = allocVector(INTSXP, count);
++    
++    ans = allocVector(INTSXP, (R_xlen_t) count);
+     for (i = 0 ; i < count ; i++){
+ 	ret = Tcl_GetIntFromObj(RTcl_interp, elem[i], &x);
+ 	if (ret != TCL_OK) x = NA_INTEGER;
+@@ -525,7 +530,7 @@ SEXP RTcl_ObjFromIntVector(SEXP args)
+ 
+ SEXP RTcl_ObjAsRawVector(SEXP args)
+ {
+-    int nb, count, i, j;
++    Tcl_Size count, nb, i, j;
+     Tcl_Obj **elem, *obj;
+     unsigned char *ret;
+     SEXP ans, el;
+@@ -536,7 +541,7 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     if (!obj) error(_("invalid tclObj -- perhaps saved from another session?"));
+     ret = Tcl_GetByteArrayFromObj(obj, &nb);
+     if (ret) {
+-	ans = allocVector(RAWSXP, nb);
++	ans = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(ans)[j] = ret[j];
+ 	return ans;
+     }
+@@ -544,10 +549,11 @@ SEXP RTcl_ObjAsRawVector(SEXP args)
+     /* Then try as list */
+     if (Tcl_ListObjGetElements(RTcl_interp, obj, &count, &elem)
+ 	!= TCL_OK) return R_NilValue;
+-
+-    PROTECT(ans = allocVector(VECSXP, count));
++    if (count > R_XLEN_T_MAX) return R_NilValue;
++    
++    PROTECT(ans = allocVector(VECSXP, (R_xlen_t) count));
+     for (i = 0 ; i < count ; i++) {
+-	el = allocVector(RAWSXP, nb);
++	el = allocVector(RAWSXP, (R_xlen_t) nb);
+ 	SET_VECTOR_ELT(ans, i, el);
+ 	ret = Tcl_GetByteArrayFromObj(elem[i], &nb);
+ 	for (j = 0 ; j < nb ; j++) RAW(el)[j] = ret[j];

--- a/builder/patches/R-4.0.3-fedora-42.patch
+++ b/builder/patches/R-4.0.3-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.0.5-fedora-42.patch

--- a/builder/patches/R-4.0.4-fedora-42.patch
+++ b/builder/patches/R-4.0.4-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.0.5-fedora-42.patch

--- a/builder/patches/R-4.0.5-fedora-42.patch
+++ b/builder/patches/R-4.0.5-fedora-42.patch
@@ -1,29 +1,3 @@
-diff --git a/configure b/configure
-index dfe3b71..a9a6790 100755
---- a/configure
-+++ b/configure
-@@ -34117,7 +34117,7 @@ char BZ2_bzlibVersion ();
- 
- #endif
- int
--main ()
-+main (void)
- {
- return BZ2_bzlibVersion ();
-   ;
-@@ -34181,9 +34181,11 @@ else
- /* end confdefs.h.  */
- 
- #ifdef HAVE_BZLIB_H
-+#include <stdlib.h> // for exit
-+#include <string.h> // for strcmp
- #include <bzlib.h>
- #endif
--int main() {
-+int main(void) {
-     char *ver = BZ2_bzlibVersion();
-     exit(strcmp(ver, "1.0.6") < 0);
- }
 From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
 From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
 Date: Wed, 16 Apr 2025 21:29:31 +0000

--- a/builder/patches/R-4.1.0-fedora-42.patch
+++ b/builder/patches/R-4.1.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.1.3-fedora-42.patch

--- a/builder/patches/R-4.1.1-fedora-42.patch
+++ b/builder/patches/R-4.1.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.1.3-fedora-42.patch

--- a/builder/patches/R-4.1.2-fedora-42.patch
+++ b/builder/patches/R-4.1.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.1.3-fedora-42.patch

--- a/builder/patches/R-4.1.3-fedora-42.patch
+++ b/builder/patches/R-4.1.3-fedora-42.patch
@@ -1,29 +1,3 @@
-diff --git a/configure b/configure
-index dfe3b71..a9a6790 100755
---- a/configure
-+++ b/configure
-@@ -34117,7 +34117,7 @@ char BZ2_bzlibVersion ();
- 
- #endif
- int
--main ()
-+main (void)
- {
- return BZ2_bzlibVersion ();
-   ;
-@@ -34181,9 +34181,11 @@ else
- /* end confdefs.h.  */
- 
- #ifdef HAVE_BZLIB_H
-+#include <stdlib.h> // for exit
-+#include <string.h> // for strcmp
- #include <bzlib.h>
- #endif
--int main() {
-+int main(void) {
-     char *ver = BZ2_bzlibVersion();
-     exit(strcmp(ver, "1.0.6") < 0);
- }
 From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
 From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
 Date: Wed, 16 Apr 2025 21:29:31 +0000

--- a/builder/patches/R-4.2.0-fedora-42.patch
+++ b/builder/patches/R-4.2.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.2.3-fedora-42.patch

--- a/builder/patches/R-4.2.1-fedora-42.patch
+++ b/builder/patches/R-4.2.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.2.3-fedora-42.patch

--- a/builder/patches/R-4.2.2-fedora-42.patch
+++ b/builder/patches/R-4.2.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.2.3-fedora-42.patch

--- a/builder/patches/R-4.2.3-fedora-42.patch
+++ b/builder/patches/R-4.2.3-fedora-42.patch
@@ -1,29 +1,3 @@
-diff --git a/configure b/configure
-index dfe3b71..a9a6790 100755
---- a/configure
-+++ b/configure
-@@ -34117,7 +34117,7 @@ char BZ2_bzlibVersion ();
- 
- #endif
- int
--main ()
-+main (void)
- {
- return BZ2_bzlibVersion ();
-   ;
-@@ -34181,9 +34181,11 @@ else
- /* end confdefs.h.  */
- 
- #ifdef HAVE_BZLIB_H
-+#include <stdlib.h> // for exit
-+#include <string.h> // for strcmp
- #include <bzlib.h>
- #endif
--int main() {
-+int main(void) {
-     char *ver = BZ2_bzlibVersion();
-     exit(strcmp(ver, "1.0.6") < 0);
- }
 From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
 From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
 Date: Wed, 16 Apr 2025 21:29:31 +0000

--- a/builder/patches/R-4.3.0-fedora-42.patch
+++ b/builder/patches/R-4.3.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.3.3-fedora-42.patch

--- a/builder/patches/R-4.3.1-fedora-42.patch
+++ b/builder/patches/R-4.3.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.3.3-fedora-42.patch

--- a/builder/patches/R-4.3.2-fedora-42.patch
+++ b/builder/patches/R-4.3.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.3.3-fedora-42.patch

--- a/builder/patches/R-4.3.3-fedora-42.patch
+++ b/builder/patches/R-4.3.3-fedora-42.patch
@@ -1,29 +1,3 @@
-diff --git a/configure b/configure
-index dfe3b71..a9a6790 100755
---- a/configure
-+++ b/configure
-@@ -34117,7 +34117,7 @@ char BZ2_bzlibVersion ();
- 
- #endif
- int
--main ()
-+main (void)
- {
- return BZ2_bzlibVersion ();
-   ;
-@@ -34181,9 +34181,11 @@ else
- /* end confdefs.h.  */
- 
- #ifdef HAVE_BZLIB_H
-+#include <stdlib.h> // for exit
-+#include <string.h> // for strcmp
- #include <bzlib.h>
- #endif
--int main() {
-+int main(void) {
-     char *ver = BZ2_bzlibVersion();
-     exit(strcmp(ver, "1.0.6") < 0);
- }
 From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
 From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
 Date: Wed, 16 Apr 2025 21:29:31 +0000

--- a/builder/patches/R-4.4.0-fedora-42.patch
+++ b/builder/patches/R-4.4.0-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.4.3-fedora-42.patch

--- a/builder/patches/R-4.4.1-fedora-42.patch
+++ b/builder/patches/R-4.4.1-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.4.3-fedora-42.patch

--- a/builder/patches/R-4.4.2-fedora-42.patch
+++ b/builder/patches/R-4.4.2-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.4.3-fedora-42.patch

--- a/builder/patches/R-4.4.3-fedora-42.patch
+++ b/builder/patches/R-4.4.3-fedora-42.patch
@@ -1,29 +1,3 @@
-diff --git a/configure b/configure
-index dfe3b71..a9a6790 100755
---- a/configure
-+++ b/configure
-@@ -34117,7 +34117,7 @@ char BZ2_bzlibVersion ();
- 
- #endif
- int
--main ()
-+main (void)
- {
- return BZ2_bzlibVersion ();
-   ;
-@@ -34181,9 +34181,11 @@ else
- /* end confdefs.h.  */
- 
- #ifdef HAVE_BZLIB_H
-+#include <stdlib.h> // for exit
-+#include <string.h> // for strcmp
- #include <bzlib.h>
- #endif
--int main() {
-+int main(void) {
-     char *ver = BZ2_bzlibVersion();
-     exit(strcmp(ver, "1.0.6") < 0);
- }
 From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
 From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
 Date: Wed, 16 Apr 2025 21:29:31 +0000

--- a/builder/patches/R-4.5.0-fedora-42.patch
+++ b/builder/patches/R-4.5.0-fedora-42.patch
@@ -1,29 +1,3 @@
-diff --git a/configure b/configure
-index dfe3b71..a9a6790 100755
---- a/configure
-+++ b/configure
-@@ -34117,7 +34117,7 @@ char BZ2_bzlibVersion ();
- 
- #endif
- int
--main ()
-+main (void)
- {
- return BZ2_bzlibVersion ();
-   ;
-@@ -34181,9 +34181,11 @@ else
- /* end confdefs.h.  */
- 
- #ifdef HAVE_BZLIB_H
-+#include <stdlib.h> // for exit
-+#include <string.h> // for strcmp
- #include <bzlib.h>
- #endif
--int main() {
-+int main(void) {
-     char *ver = BZ2_bzlibVersion();
-     exit(strcmp(ver, "1.0.6") < 0);
- }
 From 5c5c426023c4f2c9d22582a5f94f9b3337f4973b Mon Sep 17 00:00:00 2001
 From: plummer <plummer@00db46b3-68df-0310-9c12-caf00c1e9a41>
 Date: Wed, 16 Apr 2025 21:29:31 +0000

--- a/builder/patches/R-next-fedora-42.patch
+++ b/builder/patches/R-next-fedora-42.patch
@@ -1,0 +1,1 @@
+R-4.5.0-fedora-42.patch

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -271,6 +271,20 @@ rBuildsBatchJobDefinitionFedora41:
       Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/r-builds:fedora-41"
     Timeout:
       AttemptDurationSeconds: 7200
+rBuildsBatchJobDefinitionFedora42:
+  Type: AWS::Batch::JobDefinition
+  Properties:
+    Type: container
+    ContainerProperties:
+      Command:
+        - ./build.sh
+      Vcpus: 4
+      Memory: 4096
+      JobRoleArn:
+        "Fn::GetAtt": [ rBuildsEcsTaskIamRole, Arn ]
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/r-builds:fedora-42"
+    Timeout:
+      AttemptDurationSeconds: 7200
 
 # step function cloudwatch event trigger resources
 rBuildsEventRuleIamRole:

--- a/serverless.yml
+++ b/serverless.yml
@@ -75,7 +75,9 @@ provider:
       Ref: rBuildsBatchJobDefinitionFedora40
     JOB_DEFINITION_ARN_fedora_41:
       Ref: rBuildsBatchJobDefinitionFedora41
-    SUPPORTED_PLATFORMS: ubuntu-2004,ubuntu-2204,ubuntu-2404,debian-12,centos-7,centos-8,rhel-9,opensuse-156,fedora-40,fedora-41
+    JOB_DEFINITION_ARN_fedora_42:
+      Ref: rBuildsBatchJobDefinitionFedora42
+    SUPPORTED_PLATFORMS: ubuntu-2004,ubuntu-2204,ubuntu-2404,debian-12,centos-7,centos-8,rhel-9,opensuse-156,fedora-40,fedora-41,fedora-42
 
 functions:
   queueBuilds:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -81,3 +81,11 @@ services:
       - R_VERSION=${R_VERSION}
     volumes:
       - ../:/r-builds
+  fedora-42:
+    image: fedora:42
+    command: /r-builds/test/test-yum.sh
+    environment:
+      - OS_IDENTIFIER=fedora-42
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ../:/r-builds

--- a/test/test.R
+++ b/test/test.R
@@ -6,8 +6,8 @@ temp_lib <- tempdir()
 .libPaths(temp_lib)
 
 # Install a package from CRAN
-install.packages("R6")
-library(R6)
+install.packages("pkgconfig")
+library(pkgconfig)
 
 # Install a package with C/C++ and Fortran code, which links against libR, BLAS, LAPACK
 curr_dir <- Sys.getenv("DIR", ".")


### PR DESCRIPTION
Fedora 42 comes with gcc 15, and it seems that all R versions, except for R-devel will require patches to compile with it.

 Seems like we need this for Tcl/Tk:
 https://github.com/wch/r-source/commit/5c5c426023c4f2c9d22582a5f94f9b3337f4973b
 https://github.com/wch/r-source/commit/5c5c426023c4f2c9d22582a5f94f9b3337f4973b.patch

Plus, we need to compile in C11 mode for R < 4.5.0.

Once we have the builds, I'll submit another PR to update the README.