### PR TITLE
Fix scheduled GitHub Actions workflows; allow building for specific arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
 
   update-versions-json:
     if: ${{ inputs.publish != '' }}
-    needs: build
+    needs: [build, setup-matrix]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,7 @@ jobs:
       - name: Publish R
         if: ${{ inputs.publish != '' }}
         run: |
+          echo "Publishing R for ${{ inputs.publish }}"
           s3_bucket=${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}
           S3_BUCKET=$s3_bucket make publish-r-${{ matrix.platform }}
 
@@ -208,6 +209,7 @@ jobs:
 
       - name: Update versions.json
         run: |
+          echo "Publishing versions.json for ${{ inputs.publish }}"
           s3_bucket=${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}
           versions=$(echo "${{ needs.setup-matrix.outputs.r_versions }}" | jq -r 'join(",")')
           python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,5 +233,5 @@ jobs:
         run: |
           echo "Publishing versions.json for ${{ inputs.publish }}"
           s3_bucket=${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}
-          versions=$(echo "${{ needs.setup-matrix.outputs.r_versions }}" | jq -r 'join(",")')
+          versions=$(echo '${{ needs.setup-matrix.outputs.r_versions }}' | jq -r 'join(",")')
           python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,12 +96,12 @@ jobs:
     - name: Set up matrix of platforms and R versions
       id: setup-matrix
       run: |
-        platforms=$(python get_platforms.py ${{ github.event.inputs.platforms }})
+        platforms=$(python get_platforms.py ${{ inputs.platforms }})
         echo "platforms=$platforms" >> $GITHUB_OUTPUT
-        r_versions=$(python get_r_versions.py ${{ github.event.inputs.r_versions }})
+        r_versions=$(python get_r_versions.py ${{ inputs.r_versions }})
         echo "r_versions=$r_versions" >> $GITHUB_OUTPUT
         # Convert comma-separated list of architectures to JSON array
-        arch=$(echo "${{ github.event.inputs.arch || 'amd64,arm64' }}" | jq -Rc 'split(",")')
+        arch=$(echo "${{ inputs.arch || 'amd64,arm64' }}" | jq -Rc 'split(",")')
         echo "arch=$arch" >> $GITHUB_OUTPUT
 
   docker-images:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,17 @@ on:
         required: false
         default: 'last-5,3.6.3,devel'
         type: string
+      arch:
+        description: |
+          Comma-separated list of architectures. Specify "amd64", "arm64", or both.
+          Defaults to "amd64,arm64".
+        required: false
+        default: 'amd64,arm64'
+        type: choice
+        options:
+          - 'amd64,arm64'
+          - 'amd64'
+          - 'arm64'
       publish:
         description: |
           Publish the builds to S3 staging or production? Defaults to not publishing.
@@ -44,6 +55,13 @@ on:
           Defaults to "last-5,3.6.3,devel".
         required: false
         default: 'last-5,3.6.3,devel'
+        type: string
+      arch:
+        description: |
+          Comma-separated list of architectures. Specify "amd64", "arm64", or both.
+          Defaults to "amd64,arm64".
+        required: false
+        default: 'amd64,arm64'
         type: string
       publish:
         description: |
@@ -71,6 +89,7 @@ jobs:
     outputs:
       platforms: ${{ steps.setup-matrix.outputs.platforms }}
       r_versions: ${{ steps.setup-matrix.outputs.r_versions }}
+      arch: ${{ steps.setup-matrix.outputs.arch }}
     steps:
     - uses: actions/checkout@v4
 
@@ -81,13 +100,16 @@ jobs:
         echo "platforms=$platforms" >> $GITHUB_OUTPUT
         r_versions=$(python get_r_versions.py ${{ github.event.inputs.r_versions }})
         echo "r_versions=$r_versions" >> $GITHUB_OUTPUT
+        # Convert comma-separated list of architectures to JSON array
+        arch=$(echo "${{ github.event.inputs.arch || 'amd64,arm64' }}" | jq -Rc 'split(",")')
+        echo "arch=$arch" >> $GITHUB_OUTPUT
 
   docker-images:
     needs: setup-matrix
     strategy:
       matrix:
         platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
-        arch: [amd64, arm64]
+        arch: ${{ fromJson(needs.setup-matrix.outputs.arch) }}
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     name: Docker image (${{ matrix.platform }}-${{ matrix.arch }})
     steps:
@@ -136,7 +158,7 @@ jobs:
       matrix:
         platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
         r_version: ${{ fromJson(needs.setup-matrix.outputs.r_versions) }}
-        arch: [amd64, arm64]
+        arch: ${{ fromJson(needs.setup-matrix.outputs.arch) }}
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     name: ${{ matrix.platform }}-${{ matrix.arch }} (R ${{ matrix.r_version }})
     steps:

--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -54,7 +54,11 @@ jobs:
             s3_bucket=${{ secrets.S3_BUCKET_PRODUCTION }}
           fi
           new_r_versions=$(python manage_r_versions.py check --s3-bucket="${s3_bucket}")
-          echo "$new_r_versions"
+          if [ -z "$new_r_versions" ]; then
+            echo "No new R versions found"
+          else
+            echo "New R versions: $new_r_versions"
+          fi
           echo "new_r_versions=$new_r_versions" >> $GITHUB_OUTPUT
 
   build-new-r-versions:

--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -23,7 +23,7 @@ jobs:
   check-r-versions:
     runs-on: ubuntu-latest
     outputs:
-      new_r_versions: ${{ steps.setup-check_r_versions.outputs.new_r_versions }}
+      new_r_versions: ${{ steps.check_r_versions.outputs.new_r_versions }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,10 +38,22 @@ jobs:
         run: |
           pip install -r requirements.txt
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Check for new R versions to build
         id: check_r_versions
         run: |
-          new_r_versions=$(python manage_r_versions.py check --s3-bucket="${{ secrets.S3_BUCKET_PRODUCTION }})"
+          publish=${{ inputs.publish || 'production' }}
+          if [ $publish == 'staging' ]; then
+            s3_bucket=${{ secrets.S3_BUCKET_STAGING }}
+          else
+            s3_bucket=${{ secrets.S3_BUCKET_PRODUCTION }}
+          fi
+          new_r_versions=$(python manage_r_versions.py check --s3-bucket="${s3_bucket}")
           echo "$new_r_versions"
           echo "new_r_versions=$new_r_versions" >> $GITHUB_OUTPUT
 
@@ -50,6 +62,6 @@ jobs:
     if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
     uses: ./.github/workflows/build.yml
     with:
-      r_versions: ${{ needs.check_r_versions.outputs.new_r_versions }}
+      r_versions: ${{ needs.check-r-versions.outputs.new_r_versions }}
       publish: ${{ inputs.publish || 'production' }}
     secrets: inherit

--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -4,6 +4,16 @@ on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch:
+    inputs:
+      publish:
+        description: |
+          Publish the builds to S3 staging or production? Defaults to staging.
+        required: false
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
 
 permissions:
   id-token: write
@@ -12,6 +22,8 @@ permissions:
 jobs:
   check-r-versions:
     runs-on: ubuntu-latest
+    outputs:
+      new_r_versions: ${{ steps.setup-check_r_versions.outputs.new_r_versions }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,10 +45,11 @@ jobs:
           echo "$new_r_versions"
           echo "new_r_versions=$new_r_versions" >> $GITHUB_OUTPUT
 
-      - name: Trigger Build Workflow
-        if: steps.check_r_versions.outputs.new_r_versions != ""
-        uses: ./.github/workflows/build.yml
-        with:
-          r_versions: ${{ steps.check_r_versions.outputs.new_r_versions }}
-          publish: production
-        secrets: inherit
+  build-new-r-versions:
+    needs: check-r-versions
+    if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
+    uses: ./.github/workflows/build.yml
+    with:
+      r_versions: ${{ needs.check_r_versions.outputs.new_r_versions }}
+      publish: ${{ inputs.publish || 'production' }}
+    secrets: inherit

--- a/.github/workflows/devel-daily.yml
+++ b/.github/workflows/devel-daily.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:


### PR DESCRIPTION
Fix many issues with https://github.com/rstudio/r-builds/pull/256 that were difficult to test without merging the PR. The main workflow was mostly working fine, but the scheduled workflows couldn't be tested until merging.
- AWS auth wasn't working in devel-daily or check-r-versions because workflow permissions weren't updated
- check-r-versions was missing AWS credentials, had multiple syntax errors, and was calling the build job incorrectly
- devel-daily was always building all R versions because `inputs` weren't being used correctly (`github.event.inputs` -> `inputs`)
- Print more info in various jobs to help with debugging
- Allow arch to be configured so we can build only arm64 or only amd64

Successful test runs here:
- check-new-r-versions: https://github.com/rstudio/r-builds/actions/runs/15125380225
- devel-daily: https://github.com/rstudio/r-builds/actions/runs/15125610170 (failed on fedora-42 because of an unrelated issue)
- r-builds with only arm64 built: https://github.com/rstudio/r-builds/actions/runs/15127740829