### PR TITLE
Fix R-next on fedora-42, patch no longer needed

### DIFF
--- a/builder/patches/R-next-fedora-42.patch
+++ b/builder/patches/R-next-fedora-42.patch
@@ -1,1 +1,0 @@
-R-4.5.0-fedora-42.patch


### PR DESCRIPTION
R-next on Fedora 42 currently fails with:

https://github.com/rstudio/r-builds/actions/runs/15177927718/job/42681777328
```
Downloading R-next
Extracting R-next
patching file src/library/tcltk/src/tcltk.c
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
10 out of 10 hunks ignored -- saving rejects to file src/library/tcltk/src/tcltk.c.rej
```

Looks like the patch isn't needed anymore? I'm not sure why but the build does work without the patch now: https://github.com/rstudio/r-builds/actions/runs/15197002680/job/42743500734