### PR TITLE
Add Slack notification for new R builds to replace SNS notifications

### DIFF
--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -73,7 +73,7 @@ jobs:
   # Notify Hosted about new R versions
   notify-slack-success:
     needs: [build-new-r-versions, check-r-versions]
-    if: ${{ success() && needs.check-r-versions.outputs.new_r_versions != '' }}
+    if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on successful new R version build

--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -69,3 +69,17 @@ jobs:
       r_versions: ${{ needs.check-r-versions.outputs.new_r_versions }}
       publish: ${{ inputs.publish || 'production' }}
     secrets: inherit
+
+  # Notify Hosted about new R versions
+  notify-slack-success:
+    needs: [build-new-r-versions, check-r-versions]
+    if: ${{ success() && needs.check-r-versions.outputs.new_r_versions != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on successful new R version build
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "R-builds - new R versions built and published: ${{ needs.check-r-versions.outputs.new_r_versions }}"


### PR DESCRIPTION
Add a Slack notification upon new R version builds to replace the existing SNS notifications for Hosted. The message will be something like: `R-builds - new R versions built and published: 4.5.1`

This will need to be tested before merging.