### PR TITLE
Patch R <= 4.2 bug with `-fpic flag` causing package installation issues on arm64

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -184,6 +184,14 @@ compile_r() {
   make
   make install
 
+  # Patch a bug with aarch64 in R 4.2 and below, where the -fpic flag should be -fPIC to prevent issues with compiling large packages like V8.
+  # https://github.com/wch/r-source/commit/d59aac8f5868355478567022772d42d552c5da86
+  # https://bugs.r-project.org/show_bug.cgi?id=18326
+  if _version_is_less_than "${r_version}" 4.3.0 && [ "$ARCH" = "aarch64" ]; then
+    echo "Patching -fpic to -fPIC for R <= 4.2 on aarch64 in ${R_INSTALL_PATH}/lib/R/etc/Makeconf"
+    sed -i 's/-fpic/-fPIC/g' "${R_INSTALL_PATH}/lib/R/etc/Makeconf"
+  fi
+
   # Add OS identifier to the default HTTP user agent.
   # Set this in the system Rprofile so it works when R is run with --vanilla.
   cat <<EOF >> "${R_INSTALL_PATH}"/lib/R/library/base/R/Rprofile


### PR DESCRIPTION
There's an R bug in 4.2 and below that causes package installation to fail with certain large packages like V8, duckdb, mlpack. On arm64, the `-fpic` flag for gcc should be `-fPIC`:
 https://github.com/wch/r-source/commit/d59aac8f5868355478567022772d42d552c5da86
 https://bugs.r-project.org/show_bug.cgi?id=18326

We found this while building Linux arm64 binary packages for V8 for PPM. Instead of patching it in PPM only, I think it makes sense to essentially backport the R 4.3 patch to older versions so more users get the patch, like the GH actions for R, rig, Posit docker images, etc. There doesn't seem to be a ton of packages affected by this, but it's also fairly simple and harmless to backport.

cc @jeroen

Before, on R 4.2, Linux arm64:

Note the `warning: too many GOT entries for -fpic, please recompile with -fPIC` message at the end.
```sh
install.packages("V8", repos = "https://cloud.r-project.org")

* installing *source* package 'V8' ...
** package 'V8' successfully unpacked and MD5 sums checked
** using staged installation
Found C++20 compiler: g++
Target architecture: arm64 
Getting bundle: v8-debian-11-arm64.tar.gz
Using CXXCPP=g++ -std=gnu++20 -E
Using PKG_CFLAGS=-I/tmp/RtmpMBBLzJ/R.INSTALL9feb1e5ac/V8/.deps/include 
Using PKG_LIBS=-L/tmp/RtmpMBBLzJ/R.INSTALL9feb1e5ac/V8/.deps/lib -lv8_monolith
Running feature test for pointer compression...
Enabling pointer compression
Running feature test for sandbox...
Sandbox not enabled
** libs
g++ -std=gnu++20 -I"/opt/R/4.2.0/lib/R/include" -DNDEBUG -I/tmp/RtmpMBBLzJ/R.INSTALL9feb1e5ac/V8/.deps/include  -DV8_COMPRESS_POINTERS -I'/rspm_builder/tmp/tmp.0mEXTZsv3f/Rcpp/include' -I/usr/local/include  -fvisibility=hidden -fpic  -g -O2  -c RcppExports.cpp -o RcppExports.o
g++ -std=gnu++20 -I"/opt/R/4.2.0/lib/R/include" -DNDEBUG -I/tmp/RtmpMBBLzJ/R.INSTALL9feb1e5ac/V8/.deps/include  -DV8_COMPRESS_POINTERS -I'/rspm_builder/tmp/tmp.0mEXTZsv3f/Rcpp/include' -I/usr/local/include  -fvisibility=hidden -fpic  -g -O2  -c bindings.cpp -o bindings.o
g++ -std=gnu++20 -shared -L/opt/R/4.2.0/lib/R/lib -L/usr/local/lib -o V8.so RcppExports.o bindings.o -L/tmp/RtmpMBBLzJ/R.INSTALL9feb1e5ac/V8/.deps/lib -lv8_monolith -L/opt/R/4.2.0/lib/R/lib -lR
RcppExports.o: in function `Rcpp::PreserveStorage<Rcpp::RObject_Impl<Rcpp::PreserveStorage> >::PreserveStorage()':
/rspm_builder/tmp/tmp.0mEXTZsv3f/Rcpp/include/Rcpp/storage/PreserveStorage.h:31:(.text+0x1b0): relocation truncated to fit: R_AARCH64_LD64_GOTPAGE_LO15 against symbol `R_NilValue' defined in .bss section in /opt/R/4.2.0/lib/R/lib/libR.so
/usr/bin/ld: /rspm_builder/tmp/tmp.0mEXTZsv3f/Rcpp/include/Rcpp/storage/PreserveStorage.h:31: warning: too many GOT entries for -fpic, please recompile with -fPIC
collect2: error: ld returned 1 exit status
make: *** [/opt/R/4.2.0/lib/R/share/make/shlib.mk:10: V8.so] Error 1
ERROR: compilation failed for package 'V8'
```

After, just testing this same build on this branch with R 4.2, noble arm64:
```sh
...
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (V8)
```