### PR TITLE
Add support for Ubuntu 26.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS := ubuntu-2004 ubuntu-2204 ubuntu-2404 debian-12 debian-13 centos-7 centos-8 rhel-9 rhel-10 opensuse-156 opensuse-160 fedora-42 fedora-43
+PLATFORMS := ubuntu-2004 ubuntu-2204 ubuntu-2404 ubuntu-2604 debian-12 debian-13 centos-7 centos-8 rhel-9 rhel-10 opensuse-156 opensuse-160 fedora-42 fedora-43
 
 docker-build:
 	@cd builder && docker compose build --parallel

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bug, or ask questions on [Posit Community](https://forum.posit.co/).
 
 R binaries are built for the following Linux operating systems:
 
-- Ubuntu 20.04, 22.04, 24.04
+- Ubuntu 20.04, 22.04, 24.04, 26.04
 - Debian 12, 13
 - CentOS 7
 - Red Hat Enterprise Linux 7, 8, 9, 10
@@ -76,6 +76,9 @@ curl -O https://cdn.posit.co/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_$(dpkg --print-
 
 # Ubuntu 24.04
 curl -O https://cdn.posit.co/r/ubuntu-2404/pkgs/r-${R_VERSION}_1_$(dpkg --print-architecture).deb
+
+# Ubuntu 26.04
+curl -O https://cdn.posit.co/r/ubuntu-2604/pkgs/r-${R_VERSION}_1_$(dpkg --print-architecture).deb
 
 # Debian 12
 curl -O https://cdn.posit.co/r/debian-12/pkgs/r-${R_VERSION}_1_$(dpkg --print-architecture).deb

--- a/builder/Dockerfile.ubuntu-2604
+++ b/builder/Dockerfile.ubuntu-2604
@@ -1,0 +1,33 @@
+FROM ubuntu:resolute
+
+ENV OS_IDENTIFIER ubuntu-2604
+
+RUN set -x \
+  && sed -i "s|Types: deb|Types: deb deb-src|g" /etc/apt/sources.list.d/ubuntu.sources \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt update \
+  # For BLAS/LAPACK, select the library-only OpenBLAS package that gets included in the
+  # the libopenblas-dev package by default. Usually this is OpenBLAS with pthreads.
+  #
+  # Note that libopenblas-dev must NOT be installed to ensure that R links to BLAS in a
+  # portable way, via the generic libblas.so provided by the libblas-dev package.
+  # This gets installed through the r-base build dependencies. If both libblas-dev and
+  # libopenblas-dev are present, R will prefer linking to OpenBLAS.
+  && apt install -y curl libcurl4-openssl-dev libicu-dev libopenblas0-pthread libpcre2-dev unzip wget \
+  && apt build-dep -y r-base
+
+RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.46.1/nfpm_2.46.1_$(dpkg --print-architecture).deb" && \
+    apt install -y "./nfpm_2.46.1_$(dpkg --print-architecture).deb" && \
+    rm "nfpm_2.46.1_$(dpkg --print-architecture).deb"
+
+RUN chmod 0777 /opt
+
+# Override the default pager used by R
+ENV PAGER /usr/bin/pager
+
+# Note: Ubuntu 26 does not have PCRE1 (libpcre3), so R 3.x is not supported
+
+COPY package.ubuntu-2604 /package.sh
+COPY build.sh .
+COPY patches /patches
+ENTRYPOINT ./build.sh

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -38,6 +38,19 @@ services:
     volumes:
       - ./integration/tmp:/tmp/output
     platform: ${PLATFORM_ARCH}
+  ubuntu-2604:
+    command: ./build.sh
+    environment:
+      - R_VERSION=${R_VERSION}
+      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - LOCAL_STORE=/tmp/output
+    build:
+      context: .
+      dockerfile: Dockerfile.ubuntu-2604
+    image: r-builds:ubuntu-2604
+    volumes:
+      - ./integration/tmp:/tmp/output
+    platform: ${PLATFORM_ARCH}
   debian-12:
     command: ./build.sh
     environment:

--- a/builder/package.ubuntu-2604
+++ b/builder/package.ubuntu-2604
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if [[ ! -d /tmp/output/${OS_IDENTIFIER} ]]; then
+  mkdir -p "/tmp/output/${OS_IDENTIFIER}"
+fi
+
+# Note: Ubuntu 26 does not have PCRE1 (libpcre3), so R 3.x is not supported
+pcre_libs='- libpcre2-dev'
+
+deflate_libs='# - libdeflate-dev'
+if grep -q '^LIBS *=.*[-]ldeflate' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    deflate_libs='- libdeflate-dev'
+fi
+
+# R 4.5.0 and later require libzstd (with headers to link against libR)
+zstd_libs='# - libzstd-dev'
+if grep -q '^LIBS *=.*[-]lzstd' ${R_INSTALL_PATH}/lib/R/etc/Makeconf; then
+    zstd_libs='- libzstd-dev'
+fi
+
+cat <<EOF > /tmp/nfpm.yml
+name: r-${R_VERSION}
+version: 1
+version_schema: none
+section: universe/math
+priority: optional
+arch: $(dpkg --print-architecture)
+maintainer: Posit Software, PBC <https://github.com/rstudio/r-builds>
+description: |
+  GNU R statistical computation and graphics system
+vendor: Posit Software, PBC
+homepage: https://www.r-project.org
+license: GPL-2
+deb:
+  fields:
+    Bugs: https://github.com/rstudio/r-builds/issues
+depends:
+- g++
+- gcc
+- gfortran
+- libbz2-dev
+- libc6
+- libcairo2
+- libcurl4t64
+${deflate_libs}
+- libglib2.0-0t64
+- libgomp1
+- libicu-dev
+- libjpeg8
+- liblzma-dev
+- libopenblas-dev
+- libpango-1.0-0
+- libpangocairo-1.0-0
+- libpaper-utils
+${pcre_libs}
+- libpng16-16t64
+- libreadline8t64
+- libtcl8.6
+- libtiff6
+- libtirpc-dev
+- libtk8.6
+- libx11-6
+- libxt6t64
+${zstd_libs}
+- make
+- ucf
+- unzip
+- zip
+- zlib1g-dev
+contents:
+- src: ${R_INSTALL_PATH}
+  dst: ${R_INSTALL_PATH}
+EOF
+
+nfpm package \
+  -f /tmp/nfpm.yml \
+  -p deb \
+  -t "/tmp/output/${OS_IDENTIFIER}"
+
+export PKG_FILE=$(ls /tmp/output/${OS_IDENTIFIER}/r-${R_VERSION}*.deb | head -1)

--- a/get_matrix.py
+++ b/get_matrix.py
@@ -63,6 +63,9 @@ def _get_matrix(platforms=['all'], versions=[], arch=['amd64', 'arm64']):
             if platform == 'debian-13' and version <= '3.6.3':
                 # Debian 13 does not support R 3.x because it does not have PCRE1
                 continue
+            if platform == 'ubuntu-2604' and version <= '3.6.3':
+                # Ubuntu 26.04 does not support R 3.x because it does not have PCRE1
+                continue
             for a in arch:
                 include.append({
                     "platform": platform,

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -26,6 +26,15 @@ services:
     volumes:
       - ../:/r-builds
     platform: ${PLATFORM_ARCH}
+  ubuntu-2604:
+    image: ubuntu:resolute
+    command: /r-builds/test/test-apt.sh
+    environment:
+      - OS_IDENTIFIER=ubuntu-2604
+      - R_VERSION=${R_VERSION}
+    volumes:
+      - ../:/r-builds
+    platform: ${PLATFORM_ARCH}
   debian-12:
     image: debian:bookworm
     command: /r-builds/test/test-apt.sh


### PR DESCRIPTION
## Summary                                                                                                                                                          
                                                            
  - Add R build support for Ubuntu 26.04 (codename "Resolute Raccoon")
  - Ubuntu 26.04 does not include PCRE1 (libpcre3), so R 3.x versions are not supported on this platform (same as RHEL 10 and Debian 13)
  - Uses nfpm v2.46.1 for packaging (updated from v2.18.1 due to changed release asset naming)
