### PR TITLE
feat: portable, relocatable macOS and Windows R builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,233 @@
+name: macOS R builds
+
+on:
+  workflow_call:
+    inputs:
+      r_versions:
+        description: |
+          Comma-separated R versions or specifiers (e.g. last-5,3.6.3,devel).
+          Defaults to "last-5,3.6.3,devel".
+        required: false
+        default: 'last-5,3.6.3,devel'
+        type: string
+      arch:
+        description: 'Architecture: arm64, x86_64, or both'
+        default: 'both'
+        type: string
+      publish:
+        description: |
+          Publish the builds to S3 staging or production? Allowed values are "staging", "production", or empty (default).
+        required: false
+        default: ''
+        type: string
+    secrets:
+      AWS_PUBLISH_ROLE:
+        required: true
+      AWS_REGION:
+        required: true
+      S3_BUCKET_STAGING:
+        required: true
+      S3_BUCKET_PRODUCTION:
+        required: true
+      MACOS_DEVELOPER_CERTIFICATE:
+        required: false
+      MACOS_DEVELOPER_CERTIFICATE_PASSWORD:
+        required: false
+      MACOS_NOTARIZATION_USER_NAME:
+        required: false
+      MACOS_NOTARIZATION_USER_PASSWORD:
+        required: false
+      APPLE_TEAM_ID:
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.matrix }}
+      r_versions: ${{ steps.setup-matrix.outputs.r_versions }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Set up matrix of R versions and architectures
+        id: setup-matrix
+        run: |
+          # Resolve version specifiers to concrete R versions
+          r_versions=$(python manage_r_versions.py get "${{ inputs.r_versions }}")
+          echo "Resolved R versions: $r_versions"
+
+          # Determine which architectures to build
+          input_arch="${{ inputs.arch }}"
+          if [ "${input_arch}" = "both" ]; then
+            archs="arm64 x86_64"
+          else
+            archs="${input_arch}"
+          fi
+
+          # Build matrix JSON, filtering out arm64 + R < 4.1 (no CRAN arm64 .pkg)
+          includes="[]"
+          for version in $(echo "$r_versions" | tr ',' ' '); do
+            for arch in $archs; do
+              if [ "${arch}" = "arm64" ]; then
+                # Skip arm64 for R < 4.1 — no CRAN arm64 .pkg exists for those versions
+                case "${version}" in
+                  devel|patched|next) ;;
+                  *)
+                    major=$(echo "${version}" | cut -d. -f1)
+                    minor=$(echo "${version}" | cut -d. -f2)
+                    if [ "${major}" -lt 4 ] || { [ "${major}" -eq 4 ] && [ "${minor}" -lt 1 ]; }; then
+                      echo "Skipping arm64 for R ${version} (no CRAN arm64 .pkg for R < 4.1)"
+                      continue
+                    fi
+                    ;;
+                esac
+                runner="macos-14"
+              else
+                runner="macos-13"
+              fi
+              includes=$(echo "$includes" | jq --arg v "$version" --arg a "$arch" --arg o "$runner" \
+                '. + [{"r_version": $v, "arch": $a, "os": $o}]')
+            done
+          done
+
+          matrix=$(echo "$includes" | jq -c '{"include": .}')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "Using matrix: $matrix"
+
+          r_versions_json=$(echo "$r_versions" | jq -Rc 'split(",") | map(select(length > 0))')
+          echo "r_versions=$r_versions_json" >> $GITHUB_OUTPUT
+
+  build:
+    needs: setup-matrix
+    if: ${{ fromJson(needs.setup-matrix.outputs.matrix).include != null && toJson(fromJson(needs.setup-matrix.outputs.matrix).include) != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    name: macos-${{ matrix.arch }} (R ${{ matrix.r_version }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Import Developer Certificate into keychain
+        # An unset secret evaluates to empty string in GitHub Actions expressions,
+        # so this condition correctly skips signing when the certificate is not configured.
+        if: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE != '' }}
+        env:
+          MACOS_DEVELOPER_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE }}
+          MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
+        run: |
+          cert_file="${RUNNER_TEMP}/developer_certificate.p12"
+          keychain_file="${RUNNER_TEMP}/build.keychain"
+          keychain_password="$(openssl rand -hex 16)"
+
+          echo "${MACOS_DEVELOPER_CERTIFICATE}" | base64 --decode > "${cert_file}"
+
+          security create-keychain -p "${keychain_password}" "${keychain_file}"
+          security default-keychain -s "${keychain_file}"
+          security unlock-keychain -p "${keychain_password}" "${keychain_file}"
+          security import "${cert_file}" -k "${keychain_file}" \
+            -P "${MACOS_DEVELOPER_CERTIFICATE_PASSWORD}" \
+            -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "${keychain_password}" "${keychain_file}"
+
+          # Identify the Developer ID Application certificate CN for signing
+          identity=$(security find-identity -v -p codesigning "${keychain_file}" \
+            | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "CODESIGN_IDENTITY=${identity}" >> $GITHUB_ENV
+          echo "Using codesign identity: ${identity}"
+
+          # Store keychain path for cleanup step
+          echo "BUILD_KEYCHAIN=${keychain_file}" >> $GITHUB_ENV
+
+      - name: Build R ${{ matrix.r_version }} for macOS ${{ matrix.arch }}
+        id: build
+        run: |
+          output_dir="${RUNNER_TEMP}/r-builds-output"
+          mkdir -p "${output_dir}"
+          bash macos/build.sh "${{ matrix.r_version }}" "${{ matrix.arch }}" "${output_dir}"
+          tarball="${output_dir}/R-${{ matrix.r_version }}-macos-${{ matrix.arch }}.tar.gz"
+          echo "tarball=${tarball}" >> $GITHUB_OUTPUT
+          echo "output_dir=${output_dir}" >> $GITHUB_OUTPUT
+
+      - name: Extract R for testing
+        id: extract
+        run: |
+          extract_dir="${RUNNER_TEMP}/r-extracted"
+          mkdir -p "${extract_dir}"
+          tar xzf "${{ steps.build.outputs.tarball }}" -C "${extract_dir}"
+          r_home="${extract_dir}/R-${{ matrix.r_version }}"
+          echo "r_home=${r_home}" >> $GITHUB_OUTPUT
+
+      - name: Test R
+        run: bash macos/test.sh "${{ steps.extract.outputs.r_home }}"
+
+      - name: Notarize R (production only)
+        if: ${{ inputs.publish == 'production' && secrets.MACOS_NOTARIZATION_USER_NAME != '' && secrets.MACOS_NOTARIZATION_USER_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+        env:
+          APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_USER_NAME }}
+          APPLE_APP_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_USER_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bash macos/notarize.sh "${{ steps.extract.outputs.r_home }}"
+
+      - name: Clean up keychain
+        if: ${{ always() && env.BUILD_KEYCHAIN != '' }}
+        run: security delete-keychain "${BUILD_KEYCHAIN}"
+
+      - name: Configure AWS Credentials
+        if: ${{ inputs.publish != '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Publish R to S3
+        if: ${{ inputs.publish != '' }}
+        run: |
+          tarball="${{ steps.build.outputs.tarball }}"
+          s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
+          s3_key="r/macos-${{ matrix.arch }}/R-${{ matrix.r_version }}-macos-${{ matrix.arch }}.tar.gz"
+          echo "Publishing R ${{ matrix.r_version }} (macos-${{ matrix.arch }}) to s3://${s3_bucket}/${s3_key}"
+          aws s3 cp "${tarball}" "s3://${s3_bucket}/${s3_key}" --acl public-read
+
+  update-versions-json:
+    if: ${{ inputs.publish != '' && !cancelled() }}
+    needs: [build, setup-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Update versions.json
+        run: |
+          echo "Publishing versions.json for ${{ inputs.publish }}"
+          s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
+          versions=$(echo '${{ needs.setup-matrix.outputs.r_versions }}' | jq -r 'join(",")')
+          python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -100,11 +100,11 @@ jobs:
             esac
             built_versions="${built_versions:+${built_versions},}${version}"
             for arch in $archs; do
-              if [ "${arch}" = "arm64" ]; then
-                runner="macos-14"
-              else
-                runner="macos-13"
-              fi
+              # Both arches run on macos-14 (arm64). x86_64 R runs under
+              # Rosetta 2, which is pre-installed on GitHub's macos-14 images.
+              # This matches the r-build-standalone reference and avoids the
+              # GitHub-deprecated macos-13 runner.
+              runner="macos-14"
               includes=$(echo "$includes" | jq --arg v "$version" --arg a "$arch" --arg o "$runner" \
                 '. + [{"r_version": $v, "arch": $a, "os": $o}]')
             done

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -189,7 +189,9 @@ jobs:
         run: bash macos/test.sh "${{ steps.extract.outputs.r_home }}"
 
       - name: Notarize R (production only)
-        if: ${{ inputs.publish == 'production' && env.HAS_NOTARIZATION_CREDENTIALS == 'true' }}
+        # Requires Developer ID signed binaries — Apple rejects ad-hoc
+        # signatures — so gate on HAS_DEVELOPER_CERTIFICATE too.
+        if: ${{ inputs.publish == 'production' && env.HAS_DEVELOPER_CERTIFICATE == 'true' && env.HAS_NOTARIZATION_CREDENTIALS == 'true' }}
         env:
           APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_USER_NAME }}
           APPLE_APP_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_USER_PASSWORD }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -188,6 +188,17 @@ jobs:
       - name: Test R
         run: bash macos/test.sh "${{ steps.extract.outputs.r_home }}"
 
+      - name: Upload tarball as workflow artifact
+        # Always upload (regardless of publish state) so `gh run download`
+        # can pull builds for testing without needing S3 access. 7-day
+        # retention keeps storage cost negligible.
+        uses: actions/upload-artifact@v4
+        with:
+          name: R-${{ matrix.r_version }}-macos-${{ matrix.arch }}
+          path: ${{ steps.build.outputs.tarball }}
+          retention-days: 7
+          if-no-files-found: error
+
       - name: Notarize R (production only)
         # Requires Developer ID signed binaries — Apple rejects ad-hoc
         # signatures — so gate on HAS_DEVELOPER_CERTIFICATE too.

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -77,23 +77,30 @@ jobs:
             archs="${input_arch}"
           fi
 
-          # Build matrix JSON, filtering out arm64 + R < 4.1 (no CRAN arm64 .pkg)
+          # Build matrix JSON. Two skip rules:
+          #   1. R < 4.1 is skipped entirely — no CRAN/PPM macOS binary package
+          #      repo exists for those versions, and R 4.0.x has no .pkg
+          #      installer hosted anywhere, so a produced tarball is unusable.
+          #   2. arm64 is additionally unsupported on R < 4.1 (no arm64 .pkg),
+          #      but rule 1 already covers this — kept as a defensive comment.
           includes="[]"
+          built_versions=""
           for version in $(echo "$r_versions" | tr ',' ' '); do
+            case "${version}" in
+              devel|patched|next)
+                ;;
+              *)
+                major=$(echo "${version}" | cut -d. -f1)
+                minor=$(echo "${version}" | cut -d. -f2)
+                if [ "${major}" -lt 4 ] || { [ "${major}" -eq 4 ] && [ "${minor}" -lt 1 ]; }; then
+                  echo "Skipping macOS build for R ${version} — no binary package ecosystem for macOS R < 4.1"
+                  continue
+                fi
+                ;;
+            esac
+            built_versions="${built_versions:+${built_versions},}${version}"
             for arch in $archs; do
               if [ "${arch}" = "arm64" ]; then
-                # Skip arm64 for R < 4.1 — no CRAN arm64 .pkg exists for those versions
-                case "${version}" in
-                  devel|patched|next) ;;
-                  *)
-                    major=$(echo "${version}" | cut -d. -f1)
-                    minor=$(echo "${version}" | cut -d. -f2)
-                    if [ "${major}" -lt 4 ] || { [ "${major}" -eq 4 ] && [ "${minor}" -lt 1 ]; }; then
-                      echo "Skipping arm64 for R ${version} (no CRAN arm64 .pkg for R < 4.1)"
-                      continue
-                    fi
-                    ;;
-                esac
                 runner="macos-14"
               else
                 runner="macos-13"
@@ -107,7 +114,8 @@ jobs:
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
           echo "Using matrix: $matrix"
 
-          r_versions_json=$(echo "$r_versions" | jq -Rc 'split(",") | map(select(length > 0))')
+          # Only publish versions we actually built; filtering happens above.
+          r_versions_json=$(echo "$built_versions" | jq -Rc 'split(",") | map(select(length > 0))')
           echo "r_versions=$r_versions_json" >> $GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -118,13 +118,18 @@ jobs:
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: macos-${{ matrix.arch }} (R ${{ matrix.r_version }})
+    # The `secrets` context is not available in step-level `if:` conditions,
+    # so surface presence flags via job-level env and test `env.HAS_*` instead.
+    env:
+      HAS_DEVELOPER_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE != '' }}
+      HAS_NOTARIZATION_CREDENTIALS: ${{ secrets.MACOS_NOTARIZATION_USER_NAME != '' && secrets.MACOS_NOTARIZATION_USER_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Import Developer Certificate into keychain
         # An unset secret evaluates to empty string in GitHub Actions expressions,
         # so this condition correctly skips signing when the certificate is not configured.
-        if: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE != '' }}
+        if: ${{ env.HAS_DEVELOPER_CERTIFICATE == 'true' }}
         env:
           MACOS_DEVELOPER_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE }}
           MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
@@ -176,7 +181,7 @@ jobs:
         run: bash macos/test.sh "${{ steps.extract.outputs.r_home }}"
 
       - name: Notarize R (production only)
-        if: ${{ inputs.publish == 'production' && secrets.MACOS_NOTARIZATION_USER_NAME != '' && secrets.MACOS_NOTARIZATION_USER_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+        if: ${{ inputs.publish == 'production' && env.HAS_NOTARIZATION_CREDENTIALS == 'true' }}
         env:
           APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_USER_NAME }}
           APPLE_APP_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_USER_PASSWORD }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -105,6 +105,17 @@ jobs:
         shell: pwsh
         run: .\windows\test.ps1 -RHome "${{ steps.extract.outputs.r_home }}"
 
+      - name: Upload zip as workflow artifact
+        # Always upload (regardless of publish state) so `gh run download`
+        # can pull builds for testing without needing S3 access. 7-day
+        # retention keeps storage cost negligible.
+        uses: actions/upload-artifact@v4
+        with:
+          name: R-${{ matrix.r_version }}-windows
+          path: ${{ steps.build.outputs.zip }}
+          retention-days: 7
+          if-no-files-found: error
+
       - name: Configure AWS Credentials
         if: ${{ inputs.publish != '' }}
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,152 @@
+name: Windows R builds
+
+on:
+  workflow_call:
+    inputs:
+      r_versions:
+        description: |
+          Comma-separated R versions or specifiers (e.g. last-5,3.6.3,devel).
+          Defaults to "last-5,3.6.3,devel".
+        required: false
+        default: 'last-5,3.6.3,devel'
+        type: string
+      publish:
+        description: |
+          Publish the builds to S3 staging or production? Allowed values are "staging", "production", or empty (default).
+        required: false
+        default: ''
+        type: string
+    secrets:
+      AWS_PUBLISH_ROLE:
+        required: true
+      AWS_REGION:
+        required: true
+      S3_BUCKET_STAGING:
+        required: true
+      S3_BUCKET_PRODUCTION:
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.matrix }}
+      r_versions: ${{ steps.setup-matrix.outputs.r_versions }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Set up matrix of R versions
+        id: setup-matrix
+        run: |
+          # Resolve version specifiers to concrete R versions
+          r_versions=$(python manage_r_versions.py get "${{ inputs.r_versions }}")
+          echo "Resolved R versions: $r_versions"
+
+          # Build matrix JSON (Windows is x86_64 only — no arch filtering needed)
+          includes="[]"
+          for version in $(echo "$r_versions" | tr ',' ' '); do
+            includes=$(echo "$includes" | jq --arg v "$version" \
+              '. + [{"r_version": $v, "os": "windows-latest"}]')
+          done
+
+          matrix=$(echo "$includes" | jq -c '{"include": .}')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "Using matrix: $matrix"
+
+          r_versions_json=$(echo "$r_versions" | jq -Rc 'split(",") | map(select(length > 0))')
+          echo "r_versions=$r_versions_json" >> $GITHUB_OUTPUT
+
+  build:
+    needs: setup-matrix
+    if: ${{ fromJson(needs.setup-matrix.outputs.matrix).include != null && toJson(fromJson(needs.setup-matrix.outputs.matrix).include) != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    name: windows (R ${{ matrix.r_version }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build R ${{ matrix.r_version }} for Windows
+        id: build
+        shell: pwsh
+        run: |
+          $outputDir = "$env:RUNNER_TEMP\r-builds-output"
+          New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+          .\windows\build.ps1 -Version "${{ matrix.r_version }}" -OutputDir "$outputDir"
+          $zip = "$outputDir\R-${{ matrix.r_version }}-windows.zip"
+          echo "zip=$zip" >> $env:GITHUB_OUTPUT
+          echo "output_dir=$outputDir" >> $env:GITHUB_OUTPUT
+
+      - name: Extract R for testing
+        id: extract
+        shell: pwsh
+        run: |
+          $extractDir = "$env:RUNNER_TEMP\r-extracted"
+          New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+          Expand-Archive -Path "${{ steps.build.outputs.zip }}" -DestinationPath $extractDir -Force
+          $rHome = "$extractDir\R-${{ matrix.r_version }}"
+          echo "r_home=$rHome" >> $env:GITHUB_OUTPUT
+
+      - name: Test R
+        shell: pwsh
+        run: .\windows\test.ps1 -RHome "${{ steps.extract.outputs.r_home }}"
+
+      - name: Configure AWS Credentials
+        if: ${{ inputs.publish != '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Publish R to S3
+        if: ${{ inputs.publish != '' }}
+        shell: pwsh
+        run: |
+          $zip = "${{ steps.build.outputs.zip }}"
+          $s3Bucket = "${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
+          $s3Key = "r/windows/R-${{ matrix.r_version }}-windows.zip"
+          Write-Host "Publishing R ${{ matrix.r_version }} (windows) to s3://$s3Bucket/$s3Key"
+          aws s3 cp "$zip" "s3://$s3Bucket/$s3Key" --acl public-read
+
+  update-versions-json:
+    if: ${{ inputs.publish != '' && !cancelled() }}
+    needs: [build, setup-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Update versions.json
+        run: |
+          echo "Publishing versions.json for ${{ inputs.publish }}"
+          s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
+          versions=$(echo '${{ needs.setup-matrix.outputs.r_versions }}' | jq -r 'join(",")')
+          python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,16 @@ on:
         required: true
       S3_BUCKET_PRODUCTION:
         required: true
+      MACOS_DEVELOPER_CERTIFICATE:
+        required: false
+      MACOS_DEVELOPER_CERTIFICATE_PASSWORD:
+        required: false
+      MACOS_NOTARIZATION_USER_NAME:
+        required: false
+      MACOS_NOTARIZATION_USER_PASSWORD:
+        required: false
+      APPLE_TEAM_ID:
+        required: false
 
 permissions:
   id-token: write
@@ -276,3 +286,38 @@ jobs:
           s3_bucket=${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}
           versions=$(echo '${{ needs.setup-matrix.outputs.r_versions }}' | jq -r 'join(",")')
           python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"
+
+  build-macos:
+    if: ${{ contains(inputs.platforms, 'macos') }}
+    needs: [setup-matrix]
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      r_versions: ${{ inputs.r_versions }}
+      arch: >-
+        ${{ contains(inputs.platforms, 'macos-arm64') && !contains(inputs.platforms, 'macos-x86_64') && 'arm64'
+            || !contains(inputs.platforms, 'macos-arm64') && contains(inputs.platforms, 'macos-x86_64') && 'x86_64'
+            || 'both' }}
+      publish: ${{ inputs.publish }}
+    secrets:
+      AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      S3_BUCKET_STAGING: ${{ secrets.S3_BUCKET_STAGING }}
+      S3_BUCKET_PRODUCTION: ${{ secrets.S3_BUCKET_PRODUCTION }}
+      MACOS_DEVELOPER_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE }}
+      MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
+      MACOS_NOTARIZATION_USER_NAME: ${{ secrets.MACOS_NOTARIZATION_USER_NAME }}
+      MACOS_NOTARIZATION_USER_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_USER_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+  build-windows:
+    if: ${{ contains(inputs.platforms, 'windows') }}
+    needs: [setup-matrix]
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      r_versions: ${{ inputs.r_versions }}
+      publish: ${{ inputs.publish }}
+    secrets:
+      AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      S3_BUCKET_STAGING: ${{ secrets.S3_BUCKET_STAGING }}
+      S3_BUCKET_PRODUCTION: ${{ secrets.S3_BUCKET_PRODUCTION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,7 @@ jobs:
           python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"
 
   build-macos:
-    if: ${{ contains(inputs.platforms, 'macos') }}
+    if: ${{ inputs.platforms == 'all' || contains(inputs.platforms, 'macos') }}
     needs: [setup-matrix]
     uses: ./.github/workflows/build-macos.yml
     with:
@@ -310,7 +310,7 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
   build-windows:
-    if: ${{ contains(inputs.platforms, 'windows') }}
+    if: ${{ inputs.platforms == 'all' || contains(inputs.platforms, 'windows') }}
     needs: [setup-matrix]
     uses: ./.github/workflows/build-windows.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,9 @@ jobs:
           python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"
 
   build-macos:
-    if: ${{ inputs.platforms == 'all' || contains(inputs.platforms, 'macos') }}
+    # Empty inputs.platforms means a push event (workflow input defaults don't apply to push).
+    # Treat that as "all", matching get_matrix.py's behavior for the Linux jobs.
+    if: ${{ inputs.platforms == '' || inputs.platforms == 'all' || contains(inputs.platforms, 'macos') }}
     needs: [setup-matrix]
     uses: ./.github/workflows/build-macos.yml
     with:
@@ -320,7 +322,8 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
   build-windows:
-    if: ${{ inputs.platforms == 'all' || contains(inputs.platforms, 'windows') }}
+    # See note on build-macos above re: empty inputs.platforms on push events.
+    if: ${{ inputs.platforms == '' || inputs.platforms == 'all' || contains(inputs.platforms, 'windows') }}
     needs: [setup-matrix]
     uses: ./.github/workflows/build-windows.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,14 @@ jobs:
         run: make unit-test
 
   docker-images:
+    # Skip when no Linux platforms remain (e.g. workflow_dispatch with
+    # platforms=macos,windows). GHA expands an empty matrix to 0 jobs, but
+    # without this guard the workflow run conclusion is reported as failure
+    # even though every actual job succeeded — a known quirk of empty
+    # matrices in workflow_dispatch runs. The same guard exists on the
+    # build job below, and on the build/update jobs in build-macos.yml and
+    # build-windows.yml.
+    if: ${{ toJson(fromJson(needs.setup-matrix.outputs.platforms)) != '[]' && toJson(fromJson(needs.setup-matrix.outputs.arch)) != '[]' }}
     needs: setup-matrix
     strategy:
       matrix:
@@ -206,6 +214,8 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   build:
+    # See docker-images above for why this guard is needed.
+    if: ${{ fromJson(needs.setup-matrix.outputs.matrix).include != null && toJson(fromJson(needs.setup-matrix.outputs.matrix).include) != '[]' }}
     needs: [setup-matrix, docker-images]
     strategy:
       fail-fast: false

--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -70,9 +70,41 @@ jobs:
       publish: ${{ inputs.publish || 'production' }}
     secrets: inherit
 
+  build-new-r-versions-macos:
+    needs: check-r-versions
+    if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      r_versions: ${{ needs.check-r-versions.outputs.new_r_versions }}
+      arch: both
+      publish: ${{ inputs.publish || 'production' }}
+    secrets:
+      AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      S3_BUCKET_STAGING: ${{ secrets.S3_BUCKET_STAGING }}
+      S3_BUCKET_PRODUCTION: ${{ secrets.S3_BUCKET_PRODUCTION }}
+      MACOS_DEVELOPER_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE }}
+      MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
+      MACOS_NOTARIZATION_USER_NAME: ${{ secrets.MACOS_NOTARIZATION_USER_NAME }}
+      MACOS_NOTARIZATION_USER_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_USER_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+  build-new-r-versions-windows:
+    needs: check-r-versions
+    if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      r_versions: ${{ needs.check-r-versions.outputs.new_r_versions }}
+      publish: ${{ inputs.publish || 'production' }}
+    secrets:
+      AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      S3_BUCKET_STAGING: ${{ secrets.S3_BUCKET_STAGING }}
+      S3_BUCKET_PRODUCTION: ${{ secrets.S3_BUCKET_PRODUCTION }}
+
   # Notify Hosted about new R versions
   notify-slack-success:
-    needs: [build-new-r-versions, check-r-versions]
+    needs: [build-new-r-versions, build-new-r-versions-macos, build-new-r-versions-windows, check-r-versions]
     if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-r-versions.yml
+++ b/.github/workflows/check-r-versions.yml
@@ -70,41 +70,9 @@ jobs:
       publish: ${{ inputs.publish || 'production' }}
     secrets: inherit
 
-  build-new-r-versions-macos:
-    needs: check-r-versions
-    if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
-    uses: ./.github/workflows/build-macos.yml
-    with:
-      r_versions: ${{ needs.check-r-versions.outputs.new_r_versions }}
-      arch: both
-      publish: ${{ inputs.publish || 'production' }}
-    secrets:
-      AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      S3_BUCKET_STAGING: ${{ secrets.S3_BUCKET_STAGING }}
-      S3_BUCKET_PRODUCTION: ${{ secrets.S3_BUCKET_PRODUCTION }}
-      MACOS_DEVELOPER_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE }}
-      MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
-      MACOS_NOTARIZATION_USER_NAME: ${{ secrets.MACOS_NOTARIZATION_USER_NAME }}
-      MACOS_NOTARIZATION_USER_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_USER_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-  build-new-r-versions-windows:
-    needs: check-r-versions
-    if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
-    uses: ./.github/workflows/build-windows.yml
-    with:
-      r_versions: ${{ needs.check-r-versions.outputs.new_r_versions }}
-      publish: ${{ inputs.publish || 'production' }}
-    secrets:
-      AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      S3_BUCKET_STAGING: ${{ secrets.S3_BUCKET_STAGING }}
-      S3_BUCKET_PRODUCTION: ${{ secrets.S3_BUCKET_PRODUCTION }}
-
   # Notify Hosted about new R versions
   notify-slack-success:
-    needs: [build-new-r-versions, build-new-r-versions-macos, build-new-r-versions-windows, check-r-versions]
+    needs: [build-new-r-versions, check-r-versions]
     if: ${{ needs.check-r-versions.outputs.new_r_versions != '' }}
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,10 @@ See [builder/patches/README.md](builder/patches/README.md).
 
 - macOS build scripts live in `macos/`, Windows scripts in `windows/`
 - These use CRAN binaries + post-processing (not compiled from source like Linux builds)
+- See [`macos/README.md`](macos/README.md) and [`windows/README.md`](windows/README.md) for technical details (Mach-O patching pipeline, code signing, Inno Setup extraction, IDE compatibility, troubleshooting)
 - CI workflows are `.github/workflows/build-macos.yml` and `.github/workflows/build-windows.yml`
 - Makefile targets: `build-r-macos`, `test-r-macos`, `build-r-windows`, `test-r-windows`
+- Portable-R startup hooks live in the **base Rprofile** (`library/base/R/Rprofile`), not `etc/Rprofile.site`, so they survive `R --vanilla` and IDE-embedded R sessions. This matches the manylinux PR #280 pattern.
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,13 @@ See [builder/patches/README.md](builder/patches/README.md).
 - **OpenBLAS naming inconsistency**: OpenBLAS .so names differ across distros (`libopenblaso.so` on Rocky 9 vs `libopenblas.so` on Ubuntu/Alpine). This is why portable builds use a post-build BLAS swap (keeping Makeconf's `-lRblas`) rather than `--with-blas=<lib>` at configure time.
 - **PCRE2 hidden for R 3.x**: `build.sh` temporarily hides PCRE2 pkg-config during configure for R < 4.0 to prevent unwanted linkage.
 
+## macOS and Windows builds
+
+- macOS build scripts live in `macos/`, Windows scripts in `windows/`
+- These use CRAN binaries + post-processing (not compiled from source like Linux builds)
+- CI workflows are `.github/workflows/build-macos.yml` and `.github/workflows/build-windows.yml`
+- Makefile targets: `build-r-macos`, `test-r-macos`, `build-r-windows`, `test-r-windows`
+
 ## Code style
 
 - Shell scripts use `bash` (manylinux) or `sh` (musllinux/Alpine)

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,16 @@ bash:
 		-w /r-builds \
 		${TARGET_IMAGE} /bin/bash
 
-.PHONY: docker-build docker-down print-platforms
+build-r-macos:
+	bash macos/build.sh $(R_VERSION) $(ARCH) output
+
+test-r-macos:
+	bash macos/test.sh output/R-$(R_VERSION)
+
+build-r-windows:
+	powershell.exe -File windows/build.ps1 -Version $(R_VERSION) -OutputDir output
+
+test-r-windows:
+	powershell.exe -File windows/test.ps1 -RHome output/R-$(R_VERSION)-windows/R-$(R_VERSION)
+
+.PHONY: docker-build docker-down print-platforms build-r-macos test-r-macos build-r-windows test-r-windows

--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,24 @@ bash:
 		-w /r-builds \
 		${TARGET_IMAGE} /bin/bash
 
+# macOS/Windows targets build CRAN binaries rather than compiling from source,
+# so they don't use the Linux docker-compose pipeline. ARCH defaults to the host
+# architecture for local dev; CI always sets it explicitly.
+ARCH ?= $(shell uname -m)
+
 build-r-macos:
 	bash macos/build.sh $(R_VERSION) $(ARCH) output
 
 test-r-macos:
+	@rm -rf output/R-$(R_VERSION)
+	tar xzf output/R-$(R_VERSION)-macos-$(ARCH).tar.gz -C output/
 	bash macos/test.sh output/R-$(R_VERSION)
 
 build-r-windows:
 	powershell.exe -File windows/build.ps1 -Version $(R_VERSION) -OutputDir output
 
 test-r-windows:
+	powershell.exe -Command "Remove-Item -Recurse -Force -ErrorAction SilentlyContinue output/R-$(R_VERSION)-windows; Expand-Archive -Path output/R-$(R_VERSION)-windows.zip -DestinationPath output/R-$(R_VERSION)-windows -Force"
 	powershell.exe -File windows/test.ps1 -RHome output/R-$(R_VERSION)-windows/R-$(R_VERSION)
 
 .PHONY: docker-build docker-down print-platforms build-r-macos test-r-macos build-r-windows test-r-windows

--- a/README.md
+++ b/README.md
@@ -431,8 +431,15 @@ sudo ln -s ~/R/R-${R_VERSION} \
 
 Don't run this on a host that already has a real R install at that
 version-arch — it'll shadow the framework `Resources` for that version.
-RStudio and command-line use don't need this step. See
-[`macos/README.md`](macos/README.md) for the technical reasoning.
+RStudio and command-line use don't need this step.
+
+The architectures of Positron and the R install must match: Positron's R
+kernel loads `libR.dylib` in-process, and macOS dyld cannot `dlopen` a
+dylib of a different architecture. On Apple Silicon, install x86_64
+Positron alongside arm64 if you need to use the x86_64 portable R build,
+or stick with the arm64 build. RStudio does not have this constraint
+because it launches R as a subprocess. See [`macos/README.md`](macos/README.md)
+for the technical reasoning.
 
 #### Portable Windows (experimental)
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,18 @@ will be discontinued, but existing binaries will continue to be available.
 
 ### Portable builds (experimental)
 
-Portable R builds are also available that work across Linux distributions
-without distro-specific packages. These builds bundle most library dependencies
-and are relocatable to any install path.
+Portable R builds are also available that bundle most library dependencies
+and are relocatable to any install path. The Linux variants work across
+distributions without distro-specific packages; the macOS and Windows
+variants post-process the official CRAN binaries so they can be extracted
+anywhere instead of installed system-wide.
 
 - **manylinux** - any Linux distro with glibc >= 2.34 (RHEL 9+, Ubuntu 22.04+,
   Debian 12+, Amazon Linux 2023+, Arch Linux, etc.)
 - **musllinux** - Alpine Linux 3.20+ and other musl-based distros
+- **macOS** - arm64 (Apple Silicon) and x86_64 (Intel; also runs under
+  Rosetta 2), R 4.1.0+
+- **Windows** - x86_64, R 3.6.3+
 
 ## Supported R Versions
 
@@ -353,28 +358,91 @@ sudo apk add --no-cache \
 ```
 
 
-#### macOS
+#### Portable macOS (experimental)
+
+Portable, relocatable macOS R builds are available for arm64 (Apple Silicon)
+and x86_64 (Intel). These are post-processed CRAN binaries: the official
+`.pkg` installer is downloaded, extracted without installing, and patched so
+all hardcoded `/Library/Frameworks/R.framework/...` paths in Mach-O load
+commands and config files are rewritten to `@rpath`/`@loader_path`
+references. The result is a tarball that can be extracted to any directory
+and run from there — no admin rights, no Gatekeeper installer prompts, no
+side effects on the system R installation.
+
+These macOS builds are available for R 4.1.0 and later. R 4.0.x and R 3.x
+are not supported because CRAN does not host a macOS `.pkg` installer for
+those versions on either the main mirror or the CRAN archive. Use the
+official CRAN installer for those versions instead.
+
+Bundled libraries (Tcl/Tk, gfortran runtime, etc.) come from the CRAN `.pkg`,
+so behavior matches CRAN's official binary R for macOS. Each `.so` and
+`.dylib` is signed (ad-hoc on staging, Developer ID + notarized on
+production); when the production secrets are configured, downloaded tarballs
+pass Gatekeeper without quarantine. See [`macos/README.md`](macos/README.md)
+for the full technical breakdown.
+
+##### Install via tarball
 
 ```bash
-# arm64 (Apple Silicon)
-curl -LO https://cdn.posit.co/r/macos-arm64/R-4.4.1-macos-arm64.tar.gz
-tar xzf R-4.4.1-macos-arm64.tar.gz
-./R-4.4.1/bin/R --version
+R_VERSION=4.4.3
 
-# x86_64 (Intel)
-curl -LO https://cdn.posit.co/r/macos-x86_64/R-4.4.1-macos-x86_64.tar.gz
-tar xzf R-4.4.1-macos-x86_64.tar.gz
-./R-4.4.1/bin/R --version
+# arm64 (Apple Silicon)
+curl -O https://cdn.posit.co/r/macos-arm64/R-${R_VERSION}-macos-arm64.tar.gz
+mkdir -p ~/R
+tar xzf R-${R_VERSION}-macos-arm64.tar.gz -C ~/R
+~/R/R-${R_VERSION}/bin/R --version
+
+# x86_64 (Intel; also runs under Rosetta 2 on Apple Silicon)
+curl -O https://cdn.posit.co/r/macos-x86_64/R-${R_VERSION}-macos-x86_64.tar.gz
+mkdir -p ~/R
+tar xzf R-${R_VERSION}-macos-x86_64.tar.gz -C ~/R
+~/R/R-${R_VERSION}/bin/R --version
 ```
 
-#### Windows
+If you downloaded an unsigned/un-notarized tarball with `curl`, macOS
+attaches a quarantine attribute on extracted files. Strip it once with:
+
+```bash
+xattr -dr com.apple.quarantine ~/R/R-${R_VERSION}
+```
+
+Optional — for installing R packages that require compilation from source,
+install the Xcode Command Line Tools:
+
+```bash
+xcode-select --install
+```
+
+#### Portable Windows (experimental)
+
+Portable, relocatable Windows R builds are available for x86_64. The
+official CRAN `.exe` installer is downloaded and extracted with
+[`innoextract`](https://github.com/dscharrer/innoextract) (with a
+`/VERYSILENT /CURRENTUSER` silent-install fallback if `innoextract` is
+unavailable), so no admin rights, no registry changes, and no side effects
+on the system R installation. Windows R is already largely self-contained
+(all DLLs bundled, paths largely relative), so unlike macOS no Mach-O
+patching pipeline is needed — extraction + a portable site-library and
+default repo configuration is all that's required.
+
+These Windows builds are available for R 3.6.3 and later, with R 3.6.3
+included as a long-term compatibility anchor (matching the existing Linux
+builds). See [`windows/README.md`](windows/README.md) for the full technical
+breakdown.
+
+##### Install via zip
 
 ```powershell
-# Download and extract
-Invoke-WebRequest -Uri https://cdn.posit.co/r/windows/R-4.4.1-windows.zip -OutFile R-4.4.1-windows.zip
-Expand-Archive R-4.4.1-windows.zip -DestinationPath .
-.\R-4.4.1\bin\R.exe --version
+$RVersion = "4.4.3"
+
+Invoke-WebRequest -Uri "https://cdn.posit.co/r/windows/R-$RVersion-windows.zip" -OutFile "R-$RVersion-windows.zip"
+Expand-Archive "R-$RVersion-windows.zip" -DestinationPath C:\
+& "C:\R-$RVersion\bin\R.exe" --version
 ```
+
+Optional — for installing R packages that require compilation from source,
+install [Rtools](https://cran.r-project.org/bin/windows/Rtools/) (the
+version that matches your R minor version, e.g. Rtools 4.4 for R 4.4.x).
 
 ### Verify R installation
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,27 @@ install the Xcode Command Line Tools:
 xcode-select --install
 ```
 
+**Using the portable R inside Positron** — Positron's R discovery requires
+each R installation to live at the canonical
+`/Library/Frameworks/R.framework/Versions/<ver>-<arch>/Resources` path on
+disk (or be reachable via that path through a symlink). For the portable R
+to appear in Positron's interpreter picker, either install the tarball
+directly at that path, or symlink it once after extraction:
+
+```bash
+ARCH=arm64       # or x86_64
+RVER_MM=4.4      # major.minor of the R you extracted
+
+sudo mkdir -p /Library/Frameworks/R.framework/Versions/${RVER_MM}-${ARCH}
+sudo ln -s ~/R/R-${R_VERSION} \
+  /Library/Frameworks/R.framework/Versions/${RVER_MM}-${ARCH}/Resources
+```
+
+Don't run this on a host that already has a real R install at that
+version-arch — it'll shadow the framework `Resources` for that version.
+RStudio and command-line use don't need this step. See
+[`macos/README.md`](macos/README.md) for the technical reasoning.
+
 #### Portable Windows (experimental)
 
 Portable, relocatable Windows R builds are available for x86_64. The

--- a/README.md
+++ b/README.md
@@ -353,6 +353,29 @@ sudo apk add --no-cache \
 ```
 
 
+#### macOS
+
+```bash
+# arm64 (Apple Silicon)
+curl -LO https://cdn.posit.co/r/macos-arm64/R-4.4.1-macos-arm64.tar.gz
+tar xzf R-4.4.1-macos-arm64.tar.gz
+./R-4.4.1/bin/R --version
+
+# x86_64 (Intel)
+curl -LO https://cdn.posit.co/r/macos-x86_64/R-4.4.1-macos-x86_64.tar.gz
+tar xzf R-4.4.1-macos-x86_64.tar.gz
+./R-4.4.1/bin/R --version
+```
+
+#### Windows
+
+```powershell
+# Download and extract
+Invoke-WebRequest -Uri https://cdn.posit.co/r/windows/R-4.4.1-windows.zip -OutFile R-4.4.1-windows.zip
+Expand-Archive R-4.4.1-windows.zip -DestinationPath .
+.\R-4.4.1\bin\R.exe --version
+```
+
 ### Verify R installation
 
 Test that R was successfully installed by running:

--- a/get_matrix.py
+++ b/get_matrix.py
@@ -9,6 +9,15 @@ import json
 import subprocess
 
 
+# Platforms whose builds are handled by dedicated reusable workflows
+# (build-macos.yml, build-windows.yml) rather than the Linux Docker pipeline.
+_NON_LINUX_PREFIXES = ('macos', 'windows')
+
+
+def _is_non_linux(platform):
+    return any(platform == p or platform.startswith(p + '-') for p in _NON_LINUX_PREFIXES)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Print R-builds platforms as JSON.")
     parser.add_argument(
@@ -46,6 +55,10 @@ def _get_matrix(platforms=['all'], versions=[], arch=['amd64', 'arm64']):
         supported_platforms = subprocess.check_output(['make', 'print-platforms'], text=True)
         supported_platforms = supported_platforms.split()
         platforms = supported_platforms
+
+    # Strip macOS/Windows selectors — they flow through build-macos.yml /
+    # build-windows.yml, not the Linux Docker matrix this script feeds.
+    platforms = [p for p in platforms if not _is_non_linux(p)]
 
     # Put all combinations in the "include" list, which allows complex matrix configurations
     include = []

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,235 @@
+# Portable macOS R builds
+
+This directory builds portable, relocatable macOS R distributions by post-processing the official CRAN `.pkg` installer. The output is a `.tar.gz` that can be extracted to any directory and run from there — no admin rights, no Gatekeeper installer prompt, and no side effects on the system R installation.
+
+## Overview
+
+Unlike the Linux portable builds (which compile R from source and bundle system libraries with `delocate_r.py` + patchelf), the macOS pipeline starts from the existing CRAN binary. CRAN ships high-quality macOS installers built with Apple's blessed toolchain (custom gfortran, correct configure flags, bundled Tcl/Tk and gfortran runtime). Replicating that toolchain from scratch would be complex and fragile, so we treat the CRAN `.pkg` as a known-good upstream and only apply the smallest set of changes needed for relocatability:
+
+1. Download the CRAN `.pkg` installer.
+2. Extract it with `pkgutil --expand-full` (no admin, no install).
+3. Rewrite hardcoded `/Library/Frameworks/R.framework/...` Mach-O load commands to `@rpath` / `@loader_path` references.
+4. Patch `bin/R`, `bin/Rscript`, `etc/Makeconf`, `etc/Renviron` to derive `R_HOME` at runtime.
+5. Append portable-R hooks (default CRAN repo, Tcl/Tk paths, CRAN binary package fix-up) to the base Rprofile.
+6. Codesign all Mach-O binaries (ad-hoc on staging, Developer ID + notarized on production).
+7. Package as `R-{version}-macos-{arch}.tar.gz`.
+
+Output: a self-contained tarball where `bin/R --version` works regardless of where the directory is extracted.
+
+## Files
+
+```
+macos/
+  build.sh                    # Orchestrator: download .pkg → extract → patch → tarball
+  patch-mach-o.sh             # Phase 1: rewrite Mach-O load commands to @rpath/@loader_path
+  make-relocatable.sh         # Phase 2: patch bin/R, Rscript, Makeconf for runtime R_HOME
+  install-rprofile-hook.sh    # Phase 3: append portable-R hooks to base Rprofile
+  notarize.sh                 # Submit signed build to Apple Notary Service
+  entitlements.plist          # Hardened-runtime entitlements (JIT, library validation, dyld env)
+  test.sh                     # Integration tests (relocatability, capabilities, package installs)
+```
+
+## Use cases
+
+Portable macOS builds are useful for:
+
+- **Version managers** (rig, custom scripts) that install multiple R versions side-by-side under user-chosen directories.
+- **CI / cloud runners** where you want a specific R version without an admin install.
+- **Air-gapped systems** — copy the tarball to a machine without internet access.
+- **Developer environments** where switching between R versions for a project shouldn't require touching `/Library/Frameworks/R.framework`.
+
+## Limitations
+
+- **No CRAN binaries before R 4.1.** CRAN does not host a macOS `.pkg` installer for R 4.0.x or earlier on either the main mirror (`cloud.r-project.org`) or `cran-archive.r-project.org` for arm64, and R 4.0.x has no usable `.pkg` at all. Building these would mean compiling from source — out of scope for this pipeline.
+- **CRAN-bundled libraries are pinned at build time.** Tcl/Tk, gfortran runtime, OpenBLAS — whatever CRAN ships in the `.pkg` is what you get. Updating these requires rebuilding from a newer CRAN release.
+- **Gatekeeper quarantine on tarballs.** macOS attaches `com.apple.quarantine` to anything downloaded via `curl`/browser. On unsigned/un-notarized builds this triggers Gatekeeper warnings on first run. On notarized production builds it does not. Either way, `xattr -dr com.apple.quarantine ~/R/R-{version}` strips it.
+
+## What gets built
+
+Both arm64 (Apple Silicon) and x86_64 (Intel; runs under Rosetta 2 on Apple Silicon hosts) for R 4.1.0 onwards. The build matrix in `build-macos.yml` defaults to the last 5 R minor versions plus `devel`, with R < 4.1 skipped.
+
+Output paths on the CDN follow the existing pattern:
+
+```
+cdn.posit.co/r/macos-arm64/R-{version}-macos-arm64.tar.gz
+cdn.posit.co/r/macos-x86_64/R-{version}-macos-x86_64.tar.gz
+```
+
+## How it works
+
+### Phase 1 — Download and extract (`build.sh`)
+
+CRAN's macOS URL layout has shifted multiple times. As of 2026-04, the candidate URLs probed in order are:
+
+| R version | arch | URL pattern |
+|---|---|---|
+| R >= 4.3 | arm64 | `cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg` |
+| R >= 4.3 | x86_64 | `cloud.r-project.org/bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg` |
+| R 4.1 - 4.2 | arm64 | same as R >= 4.3 |
+| R 4.1 - 4.2 | x86_64 | `cloud.r-project.org/bin/macosx/base/R-{ver}.pkg` |
+| R 3.6.x | x86_64 | `cran-archive.r-project.org/bin/macosx/base/R-{ver}.nn.pkg` (note: not built) |
+| devel | both | `mac.r-project.org/{sonoma,big-sur}-{arch}/R-{branch}-branch/...` |
+
+Devel builds at `mac.r-project.org` use a per-branch subdirectory. The branch number rolls forward (4.6 → 4.7 → ...), so `build.sh` iterates a list of plausible branches newest-first, picks the first that returns 200 OK, and uses that. Update the `branches` array in `resolve_pkg_url()` when R rolls a major branch.
+
+`pkgutil --expand-full` extracts the Xar archive. R lives at `R.framework/Versions/{ver}-{arch}/Resources/` (or `Versions/Current/Resources/`), which we flatten into `R-{version}/`. R 4.2 and earlier x86_64 also ship a separate `tcltk*.pkg` payload — we extract its `libtcl*.dylib` / `libtk*.dylib` into our `lib/` and the `tcl8.6/` / `tk8.6/` script directories into `lib/tcl8.6/` / `lib/tk8.6/`.
+
+### Phase 2 — Mach-O patching (`patch-mach-o.sh`)
+
+CRAN binaries embed absolute paths everywhere — every `LC_LOAD_DYLIB` load command, every `LC_RPATH`, the `LC_ID_DYLIB` of every `.dylib` — pointing into `/Library/Frameworks/R.framework/Versions/{ver}-{arch}/Resources/lib/`. `patch-mach-o.sh` walks every Mach-O file (`.dylib`, `.so`, `bin/exec/R`, `bin/Rscript.bin`) and:
+
+- Rewrites every load command containing `/Library/Frameworks/R.framework` to a relative reference. The exact replacement depends on context:
+  - `lib/*.dylib` peer references → `@loader_path/{libname}` (peer in same directory)
+  - `bin/exec/R` → `@executable_path/../../lib/{libname}` (R lives at `bin/exec/R`, so `../../lib` reaches `lib/`)
+  - `library/{pkg}/libs/*.so` → `@rpath/{libname}` + `LC_RPATH @loader_path/../../../lib`
+  - `modules/*.so` → `@rpath/{libname}` + `LC_RPATH @loader_path/../lib`
+- Sets `LC_ID_DYLIB` on every `lib/*.dylib` to `@rpath/{name}.dylib` so consumers don't pick up the framework path from the dylib's own ID.
+- Rewrites non-system absolute paths (`/opt/R/{arch}/lib/...` for R 4.3+ Tcl/Tk in some builds, `/usr/local/lib/...` for older Tcl/Tk) when the referenced library exists in our bundled `lib/`.
+
+After all rewrites, every Mach-O file is codesigned. See [Code signing and notarization](#code-signing-and-notarization) below.
+
+### Phase 3 — Runtime relocation (`make-relocatable.sh`)
+
+`bin/R` is a shell script CRAN sets up with a static `R_HOME_DIR=/Library/Frameworks/R.framework/Versions/{ver}-{arch}/Resources` line. Two changes are needed:
+
+- **Add a runtime override** that re-derives `R_HOME_DIR` from the script's own location:
+  ```sh
+  R_HOME_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")/.." && pwd)"
+  ```
+  This is **inserted before** `R_HOME="${R_HOME_DIR}"`, not in place of the static line. Keeping the original static `R_HOME_DIR=` line intact matters for IDE compatibility — see [IDE compatibility](#ide-compatibility-rstudio-positron) below.
+
+- **Replace the embedded framework prefix** in `R_SHARE_DIR`, `R_INCLUDE_DIR`, `R_DOC_DIR` with `${R_HOME_DIR}`-relative paths.
+
+`bin/Rscript` needs a version-aware fix because the Rscript binary's behavior changed in R 4.2:
+
+- **R < 4.2**: `Rscript` is a Mach-O binary that **ignores** the `R_HOME` env var and uses compiled-in paths. We replace it entirely with a shell wrapper that calls `bin/R --slave`. (Same pattern as the Linux portable build's `Rscript`.)
+- **R >= 4.2**: `Rscript` respects `R_HOME`. We rename the binary to `Rscript.bin` and replace `Rscript` with a shell wrapper that exports `R_HOME` and execs `Rscript.bin`. The wrapper is plain Bash so it remains relocatable.
+
+`etc/Makeconf` also needs patching for compiled R packages to link correctly:
+
+- Replace the embedded framework prefix with `$(R_HOME)`.
+- Replace `LIBR = -F.../Versions/.../Resources/lib -framework R` with `LIBR = -L"$(R_HOME)/lib" -lR` so packages link directly against `libR.dylib`. The framework reference would only resolve if R were actually installed at `/Library/Frameworks/R.framework/...`.
+- Strip remaining `-F/Library/Frameworks/...` flags.
+
+`etc/Renviron`, `etc/ldpaths`, and any other text scripts in `bin/` get a global `s|<framework-path>|${R_HOME}|g` replacement.
+
+### Phase 4 — Portable-R hooks (`install-rprofile-hook.sh`)
+
+The script appends three `local()` blocks to **`library/base/R/Rprofile`** (the base Rprofile, sourced by R itself during startup). It is **not** written to `etc/Rprofile.site` — that file is skipped under `R --vanilla` and bypassed by IDEs that load `libR.dylib` directly without going through `bin/R`. The base Rprofile is sourced in every launch context. This matches the manylinux PR #280 approach.
+
+The three hooks installed:
+
+1. **Default CRAN repo** → `https://p3m.dev/cran/latest` (Posit Public Package Manager). Provides binary R packages for macOS for the same R version × arch matrix this build targets.
+
+2. **Tcl/Tk library paths** — sets `TCL_LIBRARY` and `TK_LIBRARY` to `${R_HOME}/lib/tcl8.6` and `${R_HOME}/lib/tk8.6` if those directories exist (only true for R < 4.3 builds where build.sh extracted the Tcl/Tk sub-package). R >= 4.3 bundles Tcl/Tk inside R.framework and does not need these env vars.
+
+3. **`.portable` environment for CRAN binary package fix-up** (macOS-only; gated on `Sys.info()[["sysname"]] == "Darwin"`). CRAN binary `.tgz` packages embed absolute Mach-O paths from CRAN's build host (`/Library/Frameworks/R.framework/...`). When R is installed anywhere else, `library(pkg)` fails with "image not found." The wrapper:
+   - Defines `.portable$install.packages` that calls `utils::install.packages` and then runs `install_name_tool` on the freshly-installed `.so` files, rewriting each framework reference to `@rpath/{libname}`, adding an `LC_RPATH @loader_path/../../../lib`, and ad-hoc resigning.
+   - Attaches `.portable` at `pos = 2L` of the search path via a `setHook(packageEvent("stats", "attach"), ...)` hook so it masks the regular `install.packages`. `stats` is the last default package to attach during R startup, so this fires after all default packages but before user code runs.
+
+   **Known limitation:** RStudio and Positron install their own `install.packages` overrides at IDE startup. If those attach above `.portable` in the search path (typically as `tools:rstudio` at position 2), the `.portable` wrapper is shadowed and the fix-up does not run. As an escape hatch, `bin/fix-dylibs` is a standalone shell script that scans the library tree for unpatched `.so` files and runs the same `install_name_tool` rewrites manually. We will revisit this design after testing in real IDE sessions.
+
+## Code signing and notarization
+
+`patch-mach-o.sh` Phase 6 codesigns every Mach-O binary in the tree:
+
+- **Local / staging builds**: ad-hoc signed (`codesign -s -`). Required because `install_name_tool` invalidates any existing signature; without re-signing, macOS refuses to load the dylib. Ad-hoc signed binaries run on the build machine but are quarantined on download by Gatekeeper.
+
+- **Production builds**: signed with the Developer ID Application certificate when `CODESIGN_IDENTITY` is set, with the hardened runtime enabled and entitlements applied (see `entitlements.plist`). Required entitlements:
+  - `com.apple.security.cs.allow-jit` — R's byte-code compiler.
+  - `com.apple.security.cs.allow-unsigned-executable-memory` — Rcpp and other packages that generate code at runtime.
+  - `com.apple.security.cs.disable-library-validation` — needed because users install third-party packages with their own Mach-O `.so` files signed by other teams (or ad-hoc resigned by the `.portable` hook).
+  - `com.apple.security.cs.allow-dyld-environment-variables` — `DYLD_LIBRARY_PATH`, etc.
+
+After Developer ID signing, `notarize.sh` zips the build with `ditto -c -k --keepParent` and submits it to Apple's notary service via `xcrun notarytool submit --wait`. On acceptance, the build is whole-package notarized — but we don't currently staple individual files inside the tarball, so end users still get one quarantine warning per file on first run if they open in Finder. Running `xattr -dr com.apple.quarantine ~/R/R-{version}` after extraction clears it. (Not stapling each file is a deliberate choice — there are thousands of `.so` files in a typical R install and stapling each would dramatically inflate build time. Document the `xattr` command in the install instructions instead.)
+
+The notarization step is gated in CI on **both** the Developer ID secret and the notarization credentials being present. Apple rejects ad-hoc-signed binaries, so submitting without `MACOS_DEVELOPER_CERTIFICATE` configured produces a confusing signature error — the gate avoids that.
+
+Required CI secrets for production:
+
+| Secret | Content |
+| --- | --- |
+| `MACOS_DEVELOPER_CERTIFICATE` | Base64 of the `.p12` (Developer ID Application cert + private key) |
+| `MACOS_DEVELOPER_CERTIFICATE_PASSWORD` | The `.p12` export password |
+| `MACOS_NOTARIZATION_USER_NAME` | Apple ID email |
+| `MACOS_NOTARIZATION_USER_PASSWORD` | App-specific password from appleid.apple.com → Sign-In and Security |
+| `APPLE_TEAM_ID` | 10-char Team ID from developer.apple.com → Membership |
+
+## IDE compatibility (RStudio, Positron)
+
+Both RStudio and Positron discover R installations by parsing `bin/R` as a text file rather than executing it. Two things must be true for IDE discovery to succeed:
+
+- **`bin/R` must contain a parseable static `R_HOME_DIR=` line.** This is why `make-relocatable.sh` *inserts* a runtime override above the static line rather than replacing it. The IDE's parser finds the static line and is happy; the runtime override fires at exec time and pins `R_HOME_DIR` to the actual extracted path.
+- **Startup hooks must live in the base Rprofile** (`library/base/R/Rprofile`), not in `etc/Rprofile.site`. `etc/Rprofile.site` is skipped under `R --vanilla` and may be skipped or sourced at an unexpected time when the IDE embeds R via `libR.dylib`. The base Rprofile is sourced unconditionally during R's own startup sequence.
+
+For RStudio specifically, the IDE wraps `install.packages()` with its own override at startup. This currently shadows the `.portable` hook described above. The interaction has not been tested end-to-end; if it turns out RStudio's wrapper bypasses our fix-up, the path forward is either (a) wrapping `dyn.load` instead of `install.packages` so we run when the package's `.so` actually loads, or (b) directing users to `bin/fix-dylibs` as the explicit recovery step. Update this section once IDE testing establishes the actual behavior.
+
+## Adding support for a new R minor version
+
+Most new R minor versions need no code changes. The build matrix in `build-macos.yml` resolves `last-5,3.6.3,devel` via `manage_r_versions.py`, so a new release version is automatically picked up.
+
+Two cases require maintenance:
+
+- **R rolls to a new major branch** (e.g. 4.6 → 4.7). `build.sh`'s `resolve_pkg_url()` iterates a fixed `branches=("4.8" "4.7" "4.6" "4.5" "4.4")` list newest-first when resolving devel URLs. When a new branch opens, prepend the new branch number; when the oldest branch closes, drop it.
+- **CRAN changes its directory layout** (has happened multiple times — `big-sur-arm64`, `big-sur-x86_64`, the unified `macosx/base`, and `cran-archive.r-project.org` are all current as of 2026-04). When this happens, add the new candidate to `resolve_pkg_url()` and probe newest-first.
+
+Beyond URL resolution, the patching pipeline is structurally version-agnostic. The two version-aware code paths are:
+
+- The Rscript wrapper in `make-relocatable.sh` (R < 4.2 vs R >= 4.2 — see Phase 3 above).
+- The Tcl/Tk sub-package extraction in `build.sh` (R < 4.3 ships it as a separate `tcltk*.pkg`; R >= 4.3 bundles it in R.framework).
+
+If a new R version breaks something, start by checking whether either of those branches needs updating.
+
+## Build and test commands
+
+```bash
+# Build R for macOS (defaults to host architecture)
+R_VERSION=4.4.3 make build-r-macos
+
+# Build a specific architecture
+R_VERSION=4.4.3 ARCH=arm64 make build-r-macos
+R_VERSION=4.4.3 ARCH=x86_64 make build-r-macos    # runs under Rosetta 2
+
+# Run integration tests against a built tarball
+R_VERSION=4.4.3 make test-r-macos
+R_VERSION=4.4.3 ARCH=x86_64 make test-r-macos
+
+# Direct invocation (no Make)
+bash macos/build.sh 4.4.3 arm64 output
+tar xzf output/R-4.4.3-macos-arm64.tar.gz -C output/
+bash macos/test.sh output/R-4.4.3
+```
+
+The Makefile's `build-r-macos` target also extracts the tarball before running tests so `make build-r-macos && make test-r-macos` works locally.
+
+## What the tests verify
+
+`test.sh` covers:
+
+- R starts and reports its version.
+- `R.home()` matches the extracted directory (proves runtime `R_HOME` derivation).
+- `Rscript` works and produces correct stdout.
+- `capabilities("cairo")`, `capabilities("png")`, `capabilities("tcltk")` all return `TRUE`.
+- `solve(matrix(1:4, 2, 2))` works (proves BLAS/LAPACK link-loads).
+- No Mach-O file in the tree references `/Library/Frameworks/R.framework`, `/tmp/r-build|install`, `/opt/homebrew`, `/opt/R`, or `/usr/local/(Cellar|opt|lib)` — proves Phase 1 covered everything.
+- `etc/Makeconf` LIBR uses `-lR` (not `-framework R`) — proves Phase 3.
+- R works without `DYLD_LIBRARY_PATH` / `DYLD_FALLBACK_LIBRARY_PATH` — proves rpath rewriting is sufficient on its own.
+- Relocatability — copy R to `/tmp/r-relocated-{pid}`, verify `R.home()` reports the new path and Rscript runs there.
+- Source package compilation (`install.packages("jsonlite", type="source")`) — exercises Makeconf, headers, linker flags. Requires Xcode CLT.
+- Base Rprofile hooks survive `R --vanilla` — proves the move from `etc/Rprofile.site` to the base Rprofile worked, and `.portable` is attached.
+- Binary package install via `install.packages("jsonlite", type="binary")` — exercises the `.portable` hook's `install_name_tool` fix-up. Both CRAN and PPM are passed as repos so the call resolves on whichever serves the binary for this R version × arch combo.
+
+## Troubleshooting
+
+**"image not found" loading a package after `install.packages()`** — the package's `.so` files still reference `/Library/Frameworks/R.framework/...`. The `.portable` hook didn't run (likely shadowed by an IDE) or was disabled. Run `~/R/R-{version}/bin/fix-dylibs` manually.
+
+**`Rscript` complains about `R_HOME`** — for R < 4.2 the Rscript binary ignores `R_HOME` and uses compiled-in paths. The shell wrapper installed by `make-relocatable.sh` should sidestep this; if it didn't (e.g. someone re-extracted the tarball over an existing install), re-run `make-relocatable.sh`.
+
+**Gatekeeper blocks bin/R on first run** — if you downloaded the tarball with `curl` and the build was not notarized, run `xattr -dr com.apple.quarantine ~/R/R-{version}` once. Notarized production builds should not need this.
+
+**`bin/R` works but the IDE can't find R** — verify `bin/R` still contains a static `R_HOME_DIR=...` line. If it was overwritten (e.g. by an extra sed pass), the IDE's text parser can't extract a path. The runtime override should be *inserted before* the static line, not replace it.
+
+## Related projects
+
+- **[portable-r/portable-r-macos](https://github.com/portable-r/portable-r-macos)** — independent prototype of the same approach. Used as a reference; this pipeline shares its core idea (CRAN .pkg + post-process) but adds CI integration, Developer ID signing, the version-aware Rscript wrapper, and the base-Rprofile hook design.
+- **[builder/portable-r/](../builder/portable-r/README.md)** — the Linux portable builds. Different mechanism (compile from source + bundle libs via `delocate_r.py`) but the same goal of relocatable, distribution-independent R.

--- a/macos/README.md
+++ b/macos/README.md
@@ -163,10 +163,32 @@ Required CI secrets for production:
 
 Both RStudio and Positron discover R installations by parsing `bin/R` as a text file rather than executing it. Two things must be true for IDE discovery to succeed:
 
-- **`bin/R` must contain a parseable static `R_HOME_DIR=` line.** This is why `make-relocatable.sh` *inserts* a runtime override above the static line rather than replacing it. The IDE's parser finds the static line and is happy; the runtime override fires at exec time and pins `R_HOME_DIR` to the actual extracted path.
+- **`bin/R` must contain a parseable static `R_HOME_DIR=` line.** This is why `make-relocatable.sh` *inserts* a runtime override above the static line rather than replacing it. The IDE's parser finds the static line and is happy; the runtime override fires at exec time and pins `R_HOME_DIR` to the actual extracted path. The catch-all `sed` that converts other framework references to `${R_HOME}` excludes any line starting with `R_HOME_DIR=` so this static value survives intact — without that exclusion the static line gets rewritten to `R_HOME_DIR=${R_HOME}` and Positron rejects the install with `Can't find DESCRIPTION for the utils package at ${R_HOME}/library/utils/DESCRIPTION`.
 - **Startup hooks must live in the base Rprofile** (`library/base/R/Rprofile`), not in `etc/Rprofile.site`. `etc/Rprofile.site` is skipped under `R --vanilla` and may be skipped or sourced at an unexpected time when the IDE embeds R via `libR.dylib`. The base Rprofile is sourced unconditionally during R's own startup sequence.
 
-For RStudio specifically, the IDE wraps `install.packages()` with its own override at startup. This currently shadows the `.portable` hook described above. The interaction has not been tested end-to-end; if it turns out RStudio's wrapper bypasses our fix-up, the path forward is either (a) wrapping `dyn.load` instead of `install.packages` so we run when the package's `.so` actually loads, or (b) directing users to `bin/fix-dylibs` as the explicit recovery step. Update this section once IDE testing establishes the actual behavior.
+### Positron's "orthogonal install" check requires the framework path to exist
+
+Positron (`getRHomePathDarwin` in `extensions/positron-r/src/r-installation.ts`) extracts the value of the first `R_HOME_DIR=` line and then validates that path on disk by looking for `library/utils/DESCRIPTION` inside it. Our portable R's static line points at the canonical framework path (e.g. `/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources`), which only resolves on a host that has a real R 4.4 install at that location. On a host that has, say, only R 4.5 installed, Positron rejects our portable R as an "invalid installation" even though it works fine from the command line, RStudio, and any embedded R consumer that doesn't go through Positron's discovery path.
+
+Workarounds for end users who need Positron compatibility:
+
+- **Symlink the canonical path** to the portable install:
+  ```bash
+  sudo mkdir -p /Library/Frameworks/R.framework/Versions/<ver>-<arch>
+  sudo ln -s /path/to/extracted/R-<ver> \
+    /Library/Frameworks/R.framework/Versions/<ver>-<arch>/Resources
+  ```
+  Test-only, requires sudo. Don't do this on a system with a real R install at the same version.
+- **Install the portable R *at* the canonical path** in the first place. Defeats the "extract anywhere" design but does work transparently with Positron.
+- **Use a different IDE** (RStudio, Positron-Pro Server, plain console) that doesn't have the same discovery requirement.
+
+A cleaner long-term fix would be to either upstream a relaxation of Positron's path check (allow `bin/R`-relative discovery as a fallback when the parsed `R_HOME_DIR` doesn't resolve) or to ship the build's static `R_HOME_DIR=` line as a placeholder Positron is willing to accept. Both are deferred until the design is past the experimental phase.
+
+### RStudio's `install.packages` wrapper
+
+RStudio attaches a `tools:rstudio` environment at search position 2 during session init. `tools:rstudio` does **not** include an `install.packages` override (verified by `find('install.packages')` returning `.portable package:utils` from inside an RStudio session, with the `.portable` wrapper's `fix_pkgs` body present). So our `setHook(packageEvent("stats", "attach"), ...)` mechanism that re-attaches `.portable` at search position 2 ends up at position 3 after RStudio's own attach, but still wins for `install.packages()` resolution — search-path lookup walks the path top-down and `tools:rstudio` is transparent for that name.
+
+Validated end-to-end on RStudio macOS arm64 with R 4.4.3: `install.packages("jsonlite")` from the RStudio console correctly downloaded the CRAN binary `.tgz`, the `.portable` wrapper's `install_name_tool` patch ran, and `library(jsonlite)` loaded cleanly with zero remaining `/Library/Frameworks/R.framework` references in the installed `.so`.
 
 ## Adding support for a new R minor version
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -63,12 +63,16 @@ CRAN's macOS URL layout has shifted multiple times. As of 2026-04, the candidate
 
 | R version | arch | URL pattern |
 |---|---|---|
-| R >= 4.3 | arm64 | `cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg` |
-| R >= 4.3 | x86_64 | `cloud.r-project.org/bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg` |
-| R 4.1 - 4.2 | arm64 | same as R >= 4.3 |
+| R 4.6+ | arm64 | `cloud.r-project.org/bin/macosx/sonoma-arm64/base/R-{ver}-arm64.pkg` |
+| R 4.3 - 4.5 | arm64 | `cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg` |
+| R 4.6+ | x86_64 | `cloud.r-project.org/bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg` |
+| R 4.3 - 4.5 | x86_64 | same as R 4.6+ |
+| R 4.1 - 4.2 | arm64 | `cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg` |
 | R 4.1 - 4.2 | x86_64 | `cloud.r-project.org/bin/macosx/base/R-{ver}.pkg` |
 | R 3.6.x | x86_64 | `cran-archive.r-project.org/bin/macosx/base/R-{ver}.nn.pkg` (note: not built) |
 | devel | both | `mac.r-project.org/{sonoma,big-sur}-{arch}/R-{branch}-branch/...` |
+
+For arm64, sonoma-arm64 is probed first; if it 404s (R ≤ 4.5), the script falls through to big-sur-arm64. CRAN does not ship a sonoma-x86_64 prefix — x86_64 stays on big-sur-x86_64 across the matrix.
 
 Devel builds at `mac.r-project.org` use a per-branch subdirectory. The branch number rolls forward (4.6 → 4.7 → ...), so `build.sh` iterates a list of plausible branches newest-first, picks the first that returns 200 OK, and uses that. Update the `branches` array in `resolve_pkg_url()` when R rolls a major branch.
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -161,34 +161,40 @@ Required CI secrets for production:
 
 ## IDE compatibility (RStudio, Positron)
 
-Both RStudio and Positron discover R installations by parsing `bin/R` as a text file rather than executing it. Two things must be true for IDE discovery to succeed:
+Both RStudio and Positron discover R installations by parsing `bin/R` as a text file rather than executing it. Three things must be true for IDE discovery to succeed end-to-end:
 
-- **`bin/R` must contain a parseable static `R_HOME_DIR=` line.** This is why `make-relocatable.sh` *inserts* a runtime override above the static line rather than replacing it. The IDE's parser finds the static line and is happy; the runtime override fires at exec time and pins `R_HOME_DIR` to the actual extracted path. The catch-all `sed` that converts other framework references to `${R_HOME}` excludes any line starting with `R_HOME_DIR=` so this static value survives intact — without that exclusion the static line gets rewritten to `R_HOME_DIR=${R_HOME}` and Positron rejects the install with `Can't find DESCRIPTION for the utils package at ${R_HOME}/library/utils/DESCRIPTION`.
+- **`bin/R` must contain a parseable static `R_HOME_DIR=` line.** `make-relocatable.sh` inserts a runtime override *immediately after* the static line rather than replacing it: the IDE's text parser finds the static line, the runtime override fires next at exec time and pins `R_HOME_DIR` to the actual extracted path. The catch-all `sed` that converts other framework references to `${R_HOME}` excludes any line starting with `R_HOME_DIR=` so this static value survives intact — without that exclusion the static line gets rewritten to `R_HOME_DIR=${R_HOME}` and Positron rejects the install with `Can't find DESCRIPTION for the utils package at ${R_HOME}/library/utils/DESCRIPTION`.
+- **The static line must be in *orthogonal* form.** Positron's `RInstallation` constructor (`extensions/positron-r/src/r-installation.ts`) classifies an install as orthogonal iff its parsed `R_HOME_DIR` does NOT match the regex `R\.framework\/Resources`; a non-orthogonal install is only usable when it's the system's "current" R. CRAN's R 4.4.3 macOS arm64 `.pkg` ships the non-orthogonal form `R_HOME_DIR=/Library/Frameworks/R.framework/Resources`, which would make every portable install fail Positron's `orthogonal || current` usability check on a host that has any other R as the system default. `make-relocatable.sh` therefore force-rewrites the static line to `Versions/<ver>-<arch>/Resources` regardless of what CRAN shipped, which sets `orthogonal = true` and makes the install usable.
 - **Startup hooks must live in the base Rprofile** (`library/base/R/Rprofile`), not in `etc/Rprofile.site`. `etc/Rprofile.site` is skipped under `R --vanilla` and may be skipped or sourced at an unexpected time when the IDE embeds R via `libR.dylib`. The base Rprofile is sourced unconditionally during R's own startup sequence.
 
-### Positron's "orthogonal install" check requires the framework path to exist
+### Required end-user step on macOS to use in Positron
 
-Positron (`getRHomePathDarwin` in `extensions/positron-r/src/r-installation.ts`) extracts the value of the first `R_HOME_DIR=` line and then validates that path on disk by looking for `library/utils/DESCRIPTION` inside it. Our portable R's static line points at the canonical framework path (e.g. `/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources`), which only resolves on a host that has a real R 4.4 install at that location. On a host that has, say, only R 4.5 installed, Positron rejects our portable R as an "invalid installation" even though it works fine from the command line, RStudio, and any embedded R consumer that doesn't go through Positron's discovery path.
+Positron (`getRHomePathDarwin`) extracts the parsed `R_HOME_DIR` and additionally requires that `library/utils/DESCRIPTION` actually exist at that path on disk. Our portable R's static line is now an orthogonal `Versions/<ver>-<arch>/Resources` path, so the on-disk requirement is "the canonical CRAN-style version-arch directory must resolve to *some* valid R installation tree." For an end user who extracts the portable tarball outside the canonical path, that requirement is satisfied by a one-time symlink:
 
-Workarounds for end users who need Positron compatibility:
+```bash
+sudo mkdir -p /Library/Frameworks/R.framework/Versions/<ver>-<arch>
+sudo ln -s /path/to/extracted/R-<ver> \
+  /Library/Frameworks/R.framework/Versions/<ver>-<arch>/Resources
+```
 
-- **Symlink the canonical path** to the portable install:
-  ```bash
-  sudo mkdir -p /Library/Frameworks/R.framework/Versions/<ver>-<arch>
-  sudo ln -s /path/to/extracted/R-<ver> \
-    /Library/Frameworks/R.framework/Versions/<ver>-<arch>/Resources
-  ```
-  Test-only, requires sudo. Don't do this on a system with a real R install at the same version.
-- **Install the portable R *at* the canonical path** in the first place. Defeats the "extract anywhere" design but does work transparently with Positron.
-- **Use a different IDE** (RStudio, Positron-Pro Server, plain console) that doesn't have the same discovery requirement.
+After this, Positron's discovery walks `Versions/`, parses the orthogonal static line, validates `library/utils/DESCRIPTION` through the symlink (which now resolves to the portable R's actual `library/utils/DESCRIPTION`), reads the correct R version from the `Built:` field, and accepts the install.
 
-A cleaner long-term fix would be to either upstream a relaxation of Positron's path check (allow `bin/R`-relative discovery as a fallback when the parsed `R_HOME_DIR` doesn't resolve) or to ship the build's static `R_HOME_DIR=` line as a placeholder Positron is willing to accept. Both are deferred until the design is past the experimental phase.
+Caveats and alternatives:
 
-### RStudio's `install.packages` wrapper
+- Don't run the symlink command on a host that already has a real R install at the same version-arch — it'll shadow the framework's `Resources` for that version.
+- **Or install the portable R *at* the canonical path** in the first place (`tar xzf … -C /Library/Frameworks/R.framework/Versions/<ver>-<arch>/Resources`). Same end result, no symlink needed.
+- **Or skip Positron** and use the install from a terminal or RStudio (which doesn't need the symlink — see below).
+- **Or use a manager like ro** that owns the install path and rewrites `bin/R`'s static `R_HOME_DIR=` to its own managed location during install. The manager's path then exists with a real `library/utils/DESCRIPTION` inside, and Positron accepts the install via `customBinaries` with no symlink needed.
 
-RStudio attaches a `tools:rstudio` environment at search position 2 during session init. `tools:rstudio` does **not** include an `install.packages` override (verified by `find('install.packages')` returning `.portable package:utils` from inside an RStudio session, with the `.portable` wrapper's `fix_pkgs` body present). So our `setHook(packageEvent("stats", "attach"), ...)` mechanism that re-attaches `.portable` at search position 2 ends up at position 3 after RStudio's own attach, but still wins for `install.packages()` resolution — search-path lookup walks the path top-down and `tools:rstudio` is transparent for that name.
+A cleaner long-term fix would be an upstream change in Positron to fall back to `dirname(dirname(binpath))`-style R_HOME derivation when the parsed `R_HOME_DIR` doesn't validate (the Windows path already does this). Worth filing as a follow-up issue once this design moves past the experimental phase.
 
-Validated end-to-end on RStudio macOS arm64 with R 4.4.3: `install.packages("jsonlite")` from the RStudio console correctly downloaded the CRAN binary `.tgz`, the `.portable` wrapper's `install_name_tool` patch ran, and `library(jsonlite)` loaded cleanly with zero remaining `/Library/Frameworks/R.framework` references in the installed `.so`.
+### IDE-specific notes from end-to-end testing
+
+Validated end-to-end on macOS arm64 with R 4.4.3 in both RStudio and Positron:
+
+- **RStudio** attaches `tools:rstudio` at search position 2 during session init. It does *not* include an `install.packages` override.
+- **Positron** attaches both `tools:rstudio` (compatibility shim) and `tools:positron` above us; neither defines `install.packages`.
+- In both IDEs, our `setHook(packageEvent("stats", "attach"), ...)` mechanism re-attaches `.portable` at search position 2, which gets pushed down by the IDE's later attaches but still wins for `install.packages()` resolution because the IDE envs are transparent for that name. Result: `find('install.packages')` returns `.portable package:utils` from both IDE consoles, the `.portable` wrapper's `install_name_tool` patch runs after `install.packages("jsonlite")`, and `library(jsonlite)` loads cleanly with zero remaining `/Library/Frameworks/R.framework` references in the installed `.so`.
 
 ## Adding support for a new R minor version
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -169,13 +169,15 @@ Both RStudio and Positron discover R installations by parsing `bin/R` as a text 
 
 ### Required end-user step on macOS to use in Positron
 
-Positron (`getRHomePathDarwin`) extracts the parsed `R_HOME_DIR` and additionally requires that `library/utils/DESCRIPTION` actually exist at that path on disk. Our portable R's static line is now an orthogonal `Versions/<ver>-<arch>/Resources` path, so the on-disk requirement is "the canonical CRAN-style version-arch directory must resolve to *some* valid R installation tree." For an end user who extracts the portable tarball outside the canonical path, that requirement is satisfied by a one-time symlink:
+Positron (`getRHomePathDarwin`) extracts the parsed `R_HOME_DIR` and additionally requires that `library/utils/DESCRIPTION` actually exist at that path on disk. Our portable R's static line is now an orthogonal `Versions/<slot>-<arch>/Resources` path, so the on-disk requirement is "the canonical CRAN-style version-arch directory must resolve to *some* valid R installation tree." For an end user who extracts the portable tarball outside the canonical path, that requirement is satisfied by a one-time symlink:
 
 ```bash
-sudo mkdir -p /Library/Frameworks/R.framework/Versions/<ver>-<arch>
+sudo mkdir -p /Library/Frameworks/R.framework/Versions/<slot>-<arch>
 sudo ln -s /path/to/extracted/R-<ver> \
-  /Library/Frameworks/R.framework/Versions/<ver>-<arch>/Resources
+  /Library/Frameworks/R.framework/Versions/<slot>-<arch>/Resources
 ```
+
+`<slot>` is the major.minor for numeric builds (e.g. `4.4` for R 4.4.3) and the literal alias for `devel` / `patched` / `next` builds (e.g. `Versions/devel-arm64/Resources`). The alias slot keeps devel installs from colliding with the same-numbered release build (a `devel` snapshot whose `Built:` field happens to read `R 4.6.0 Patched` would otherwise contend with the real R 4.6.0 install for `Versions/4.6-arm64/`).
 
 After this, Positron's discovery walks `Versions/`, parses the orthogonal static line, validates `library/utils/DESCRIPTION` through the symlink (which now resolves to the portable R's actual `library/utils/DESCRIPTION`), reads the correct R version from the `Built:` field, and accepts the install.
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -190,11 +190,17 @@ A cleaner long-term fix would be an upstream change in Positron to fall back to 
 
 ### IDE-specific notes from end-to-end testing
 
-Validated end-to-end on macOS arm64 with R 4.4.3 in both RStudio and Positron:
+Validated end-to-end on macOS arm64 with R 4.4.3 in both RStudio and Positron, and on macOS x86_64 (under Rosetta 2 on Apple Silicon) with R 4.4.3 in RStudio:
 
-- **RStudio** attaches `tools:rstudio` at search position 2 during session init. It does *not* include an `install.packages` override.
+- **RStudio** attaches `tools:rstudio` at search position 2 during session init. It does *not* include an `install.packages` override. Works equally on arm64-native R and x86_64-under-Rosetta R because RStudio launches R as a subprocess (`rsession` execs `bin/R`), so macOS handles the architecture transition transparently.
 - **Positron** attaches both `tools:rstudio` (compatibility shim) and `tools:positron` above us; neither defines `install.packages`.
 - In both IDEs, our `setHook(packageEvent("stats", "attach"), ...)` mechanism re-attaches `.portable` at search position 2, which gets pushed down by the IDE's later attaches but still wins for `install.packages()` resolution because the IDE envs are transparent for that name. Result: `find('install.packages')` returns `.portable package:utils` from both IDE consoles, the `.portable` wrapper's `install_name_tool` patch runs after `install.packages("jsonlite")`, and `library(jsonlite)` loads cleanly with zero remaining `/Library/Frameworks/R.framework` references in the installed `.so`.
+
+### Architecture matching for Positron
+
+Positron's R kernel (`ark`) loads `libR.dylib` *in-process* rather than spawning R as a subprocess. macOS's dynamic linker can't `dlopen` a Mach-O dylib of a different architecture into the calling process, so the architectures of Positron and the R install must match. On Apple Silicon, an arm64-native Positron loading an x86_64 R dies during startup with `SIGABRT` (`exit code -1`, signal 6) — discovery succeeds and the install passes every validation check, but the kernel can't load.
+
+The fix is to match architectures: install the x86_64 build of Positron alongside arm64 if you need to use x86_64 R, or use the arm64 build of R when running arm64 Positron. This is not specific to our portable R — CRAN's stock x86_64 R installed at the canonical framework path has the same limitation. RStudio doesn't hit this because it launches R as a subprocess, where macOS handles the arch transition through Rosetta 2.
 
 ## Adding support for a new R minor version
 

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -264,9 +264,11 @@ fi
 # The CRAN .pkg hardcodes /Library/Frameworks/R.framework/... throughout
 # its Mach-O binaries and config files. Our existing pipeline handles
 # all of this:
-#   patch-mach-o.sh      - rewrites dylib load commands to @rpath / @loader_path
-#   make-relocatable.sh  - patches bin/R, bin/Rscript, etc/Makeconf, etc/Renviron
-#   install-rprofile-hook.sh - installs Rprofile.site with .portable env
+#   patch-mach-o.sh         - rewrites dylib load commands to @rpath / @loader_path
+#   make-relocatable.sh     - patches bin/R, bin/Rscript, etc/Makeconf, etc/Renviron
+#   install-rprofile-hook.sh - appends portable-R hooks to library/base/R/Rprofile
+#                              (PPM repo, Tcl/Tk paths, .portable env for binary
+#                              package fix-up; see macos/README.md for details)
 echo "--- Running post-build patching pipeline ---"
 
 bash "${SCRIPT_DIR}/patch-mach-o.sh"          "${WORK_OUTPUT_DIR}"

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -275,7 +275,5 @@ tar czf "${TARBALL}" -C "${WORK_OUTPUT_PARENT}" "R-${R_VERSION}"
 echo "=== Tarball created: ${TARBALL} ==="
 
 # ── Cleanup ──────────────────────────────────────────────────────────
-# The EXIT trap also handles cleanup on error; this explicit call covers
-# the success path and runs before the trap fires.
-rm -rf "${WORK_DIR}" "${WORK_OUTPUT_PARENT}"
+# Cleanup is handled by the EXIT trap set at the top of the script.
 echo "=== Build complete ==="

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -63,53 +63,55 @@ echo "=== Building portable R ${R_VERSION} for macOS ${ARCH} ==="
 echo "Output dir: ${OUTPUT_DIR_BASE}"
 
 # ── 1. Resolve the CRAN .pkg download URL ────────────────────────────
-# CRAN has changed its URL layout across R versions, and nightly builds
-# (devel, patched, next) are hosted on mac.r-project.org, not CRAN mirrors.
+# CRAN's URL layout has shifted multiple times. Summary of what actually
+# exists as of 2026-04, probed and recorded:
 #
-# Release versions:
-#   R >= 4.2    arm64  : bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg
-#   R >= 4.2    x86_64 : bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg
-#   R 4.1.x    arm64  : bin/macosx/big-sur-arm64/base/R-{ver}.pkg
-#   R <= 4.1   x86_64 : bin/macosx/base/R-{ver}.pkg
+# Release versions (on cloud.r-project.org):
+#   R >= 4.3   arm64  : bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg
+#   R >= 4.3   x86_64 : bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg
+#   R 4.1-4.2  arm64  : bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg
+#   R 4.1-4.2  x86_64 : bin/macosx/base/R-{ver}.pkg
+#   R < 4.0    arm64  : not available
+#   R 3.6.x    x86_64 : cran-archive.r-project.org/bin/macosx/base/R-{ver}.nn.pkg
+#   R <= 3.5   x86_64 : cran-archive.r-project.org/bin/macosx/base/R-{ver}.pkg
 #
-# Nightly builds (mac.r-project.org):
-#   devel/patched/next : .pkg and .tar.xz for arm64 and x86_64
-#
-# Strategy: try the most specific URL first, then fall back.
+# Nightly "devel" builds (on mac.r-project.org):
+#   The old /last-success/ scheme is gone. Current layout is:
+#     sonoma-arm64/R-{branch}-branch/R-{branch}-branch-arm64.pkg  (R 4.6+ arm64)
+#     big-sur-arm64/R-{branch}-branch/R-{branch}-branch-arm64.pkg (R 4.5 arm64)
+#     big-sur-x86_64/R-{branch}-branch/R-{branch}-branch-x86_64.pkg
+#   "devel" maps to whichever branch is currently open — iterate from newest
+#   plausible branch downward so this keeps working across branch rollovers.
 
 resolve_pkg_url() {
   local ver="$1" arch="$2" mirror="$3"
   local candidates=()
 
-  # Nightly/development builds live on mac.r-project.org
   case "${ver}" in
     devel|patched|next)
+      # Nightly builds at mac.r-project.org. "devel" resolves to the current
+      # open branch (e.g., 4.6-branch in 2026-04); iterate newest-first.
       local mac_base="https://mac.r-project.org"
+      local branches=("4.8" "4.7" "4.6" "4.5" "4.4")
       if [[ "${arch}" == "arm64" ]]; then
-        candidates+=(
-          "${mac_base}/big-sur-arm64/last-success/R-devel-arm64.pkg"
-          "${mac_base}/big-sur-arm64/last-success/R-devel.pkg"
-        )
-        # Also try versioned branch patterns
-        for branch in "4.7" "4.6" "4.5"; do
+        # arm64 R 4.6+ targets sonoma; R 4.5 stays on big-sur.
+        for branch in "${branches[@]}"; do
           candidates+=(
-            "${mac_base}/big-sur-arm64/last-success/R-${branch}-branch-arm64.pkg"
+            "${mac_base}/sonoma-arm64/R-${branch}-branch/R-${branch}-branch-arm64.pkg"
+            "${mac_base}/big-sur-arm64/R-${branch}-branch/R-${branch}-branch-arm64.pkg"
           )
         done
       else
-        candidates+=(
-          "${mac_base}/big-sur-x86_64/last-success/R-devel-x86_64.pkg"
-          "${mac_base}/big-sur-x86_64/last-success/R-devel.pkg"
-        )
-        for branch in "4.7" "4.6" "4.5"; do
+        for branch in "${branches[@]}"; do
           candidates+=(
-            "${mac_base}/big-sur-x86_64/last-success/R-${branch}-branch-x86_64.pkg"
+            "${mac_base}/big-sur-x86_64/R-${branch}-branch/R-${branch}-branch-x86_64.pkg"
           )
         done
       fi
       ;;
     *)
-      # Release versions on CRAN mirrors
+      # Release versions.
+      local archive="https://cran-archive.r-project.org"
       local major minor
       major="${ver%%.*}"
       minor="${ver#*.}"; minor="${minor%%.*}"
@@ -128,6 +130,10 @@ resolve_pkg_url() {
           "${mirror}/bin/macosx/big-sur-x86_64/base/R-${ver}-x86_64.pkg"
           "${mirror}/bin/macosx/big-sur-x86_64/base/R-${ver}.pkg"
           "${mirror}/bin/macosx/base/R-${ver}.pkg"
+          # Versions retired from the main CDN live on cran-archive. The
+          # ".nn" suffix is CRAN's notarized variant shipped for R 3.6.x.
+          "${archive}/bin/macosx/base/R-${ver}.nn.pkg"
+          "${archive}/bin/macosx/base/R-${ver}.pkg"
         )
       fi
       ;;

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -67,13 +67,21 @@ echo "Output dir: ${OUTPUT_DIR_BASE}"
 # exists as of 2026-04, probed and recorded:
 #
 # Release versions (on cloud.r-project.org):
-#   R >= 4.3   arm64  : bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg
-#   R >= 4.3   x86_64 : bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg
+#   R 4.6+     arm64  : bin/macosx/sonoma-arm64/base/R-{ver}-arm64.pkg
+#   R 4.3-4.5  arm64  : bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg
+#   R 4.6+     x86_64 : bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg
+#   R 4.3-4.5  x86_64 : bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg
 #   R 4.1-4.2  arm64  : bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg
 #   R 4.1-4.2  x86_64 : bin/macosx/base/R-{ver}.pkg
 #   R < 4.0    arm64  : not available
 #   R 3.6.x    x86_64 : cran-archive.r-project.org/bin/macosx/base/R-{ver}.nn.pkg
 #   R <= 3.5   x86_64 : cran-archive.r-project.org/bin/macosx/base/R-{ver}.pkg
+#
+# arm64 migrated from big-sur-arm64 → sonoma-arm64 for R 4.6+, matching
+# the same migration the devel branch made earlier. x86_64 stayed on
+# big-sur-x86_64 (CRAN doesn't ship sonoma-x86_64). We probe sonoma-arm64
+# first for arm64 so new releases land there without code changes; the
+# big-sur-arm64 fallback covers R 4.1-4.5.
 #
 # Nightly "devel" builds (on mac.r-project.org):
 #   The old /last-success/ scheme is gone. Current layout is:
@@ -122,6 +130,10 @@ resolve_pkg_url() {
           return 1
         fi
         candidates+=(
+          # sonoma-arm64 first — R 4.6+ live here. R 4.5 and earlier 404
+          # on this prefix, then fall through to big-sur-arm64.
+          "${mirror}/bin/macosx/sonoma-arm64/base/R-${ver}-arm64.pkg"
+          "${mirror}/bin/macosx/sonoma-arm64/base/R-${ver}.pkg"
           "${mirror}/bin/macosx/big-sur-arm64/base/R-${ver}-arm64.pkg"
           "${mirror}/bin/macosx/big-sur-arm64/base/R-${ver}.pkg"
         )

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build.sh -- Build a portable, relocatable R for macOS from CRAN .pkg
+#
+# Extracts the official CRAN R .pkg installer and runs the post-build
+# patching pipeline to produce a fully relocatable distribution. No
+# Homebrew deps, no configure/make, no gfortran bundling -- the CRAN
+# .pkg already includes the gfortran runtime and Tcl/Tk frameworks.
+
+# ── Usage / help ─────────────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+Usage: build.sh <r_version> <arch> [<output_dir>]
+
+Arguments:
+  r_version   Required. e.g. 4.5.0, 4.4.1
+  arch        arm64 | x86_64
+  output_dir  Directory for output tarball (default: current dir)
+
+Environment:
+  CRAN_MIRROR   Base mirror URL (default: https://cloud.r-project.org)
+
+Examples:
+  ./build.sh 4.5.0 arm64
+  ./build.sh 4.4.1 x86_64 /tmp/out
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+# ── Arguments ────────────────────────────────────────────────────────
+R_VERSION="${1:?Usage: build.sh <r_version> <arch> [<output_dir>]}"
+ARCH="${2:?Usage: build.sh <r_version> <arch> [<output_dir>]}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR_BASE="${3:-$(pwd)}"
+CRAN_MIRROR="${CRAN_MIRROR:-https://cloud.r-project.org}"
+
+# Normalise architecture labels
+case "${ARCH}" in
+  arm64|aarch64) ARCH="arm64"  ;;
+  x86_64)        ARCH="x86_64" ;;
+  *) echo "ERROR: unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+
+# Validate R_VERSION before constructing any paths that embed it
+if [[ ! "${R_VERSION}" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$|^(devel|patched|next)$ ]]; then
+  echo "ERROR: invalid R_VERSION '${R_VERSION}'" >&2
+  exit 1
+fi
+
+# Construct work paths after validation so R_VERSION is known-safe
+WORK_DIR="/tmp/r-build-$$"
+WORK_OUTPUT_PARENT="/tmp/r-build-out-$$"
+WORK_OUTPUT_DIR="${WORK_OUTPUT_PARENT}/R-${R_VERSION}"
+trap 'rm -rf "${WORK_DIR}" "${WORK_OUTPUT_PARENT}"' EXIT
+
+echo "=== Building portable R ${R_VERSION} for macOS ${ARCH} ==="
+echo "Output dir: ${OUTPUT_DIR_BASE}"
+
+# ── 1. Resolve the CRAN .pkg download URL ────────────────────────────
+# CRAN has changed its URL layout across R versions, and nightly builds
+# (devel, patched, next) are hosted on mac.r-project.org, not CRAN mirrors.
+#
+# Release versions:
+#   R >= 4.2    arm64  : bin/macosx/big-sur-arm64/base/R-{ver}-arm64.pkg
+#   R >= 4.2    x86_64 : bin/macosx/big-sur-x86_64/base/R-{ver}-x86_64.pkg
+#   R 4.1.x    arm64  : bin/macosx/big-sur-arm64/base/R-{ver}.pkg
+#   R <= 4.1   x86_64 : bin/macosx/base/R-{ver}.pkg
+#
+# Nightly builds (mac.r-project.org):
+#   devel/patched/next : .pkg and .tar.xz for arm64 and x86_64
+#
+# Strategy: try the most specific URL first, then fall back.
+
+resolve_pkg_url() {
+  local ver="$1" arch="$2" mirror="$3"
+  local candidates=()
+
+  # Nightly/development builds live on mac.r-project.org
+  case "${ver}" in
+    devel|patched|next)
+      local mac_base="https://mac.r-project.org"
+      if [[ "${arch}" == "arm64" ]]; then
+        candidates+=(
+          "${mac_base}/big-sur-arm64/last-success/R-devel-arm64.pkg"
+          "${mac_base}/big-sur-arm64/last-success/R-devel.pkg"
+        )
+        # Also try versioned branch patterns
+        for branch in "4.7" "4.6" "4.5"; do
+          candidates+=(
+            "${mac_base}/big-sur-arm64/last-success/R-${branch}-branch-arm64.pkg"
+          )
+        done
+      else
+        candidates+=(
+          "${mac_base}/big-sur-x86_64/last-success/R-devel-x86_64.pkg"
+          "${mac_base}/big-sur-x86_64/last-success/R-devel.pkg"
+        )
+        for branch in "4.7" "4.6" "4.5"; do
+          candidates+=(
+            "${mac_base}/big-sur-x86_64/last-success/R-${branch}-branch-x86_64.pkg"
+          )
+        done
+      fi
+      ;;
+    *)
+      # Release versions on CRAN mirrors
+      local major minor
+      major="${ver%%.*}"
+      minor="${ver#*.}"; minor="${minor%%.*}"
+
+      if [[ "${arch}" == "arm64" ]]; then
+        if (( major < 4 || (major == 4 && minor < 1) )); then
+          echo "ERROR: no arm64 CRAN .pkg available for R ${ver}" >&2
+          return 1
+        fi
+        candidates+=(
+          "${mirror}/bin/macosx/big-sur-arm64/base/R-${ver}-arm64.pkg"
+          "${mirror}/bin/macosx/big-sur-arm64/base/R-${ver}.pkg"
+        )
+      else
+        candidates+=(
+          "${mirror}/bin/macosx/big-sur-x86_64/base/R-${ver}-x86_64.pkg"
+          "${mirror}/bin/macosx/big-sur-x86_64/base/R-${ver}.pkg"
+          "${mirror}/bin/macosx/base/R-${ver}.pkg"
+        )
+      fi
+      ;;
+  esac
+
+  for url in "${candidates[@]}"; do
+    if curl -sfI --retry 2 --connect-timeout 10 "${url}" >/dev/null 2>&1; then
+      echo "${url}"
+      return 0
+    fi
+  done
+
+  echo "ERROR: could not resolve .pkg URL for R ${ver} (${arch})" >&2
+  echo "Tried:" >&2
+  printf '  %s\n' "${candidates[@]}" >&2
+  return 1
+}
+
+echo "--- Resolving CRAN download URL ---"
+DOWNLOAD_URL="$(resolve_pkg_url "${R_VERSION}" "${ARCH}" "${CRAN_MIRROR}")"
+PKG_FILE="$(basename "${DOWNLOAD_URL}")"
+echo "URL: ${DOWNLOAD_URL}"
+
+# ── 2. Download the .pkg ─────────────────────────────────────────────
+echo "--- Downloading R ${R_VERSION} .pkg ---"
+mkdir -p "${WORK_DIR}"
+
+curl -fSL --retry 3 -o "${WORK_DIR}/${PKG_FILE}" "${DOWNLOAD_URL}"
+echo "  Downloaded ${PKG_FILE}"
+
+# ── 3. Extract .pkg without installing ───────────────────────────────
+echo "--- Extracting .pkg with pkgutil --expand-full ---"
+EXPAND_DIR="${WORK_DIR}/expanded"
+rm -rf "${EXPAND_DIR}"
+pkgutil --expand-full "${WORK_DIR}/${PKG_FILE}" "${EXPAND_DIR}"
+
+# Locate R.framework inside the expanded payload; assert exactly one match.
+R_FRAMEWORK_CANDIDATES="$(find "${EXPAND_DIR}" -type d -name "R.framework" 2>/dev/null)"
+R_FRAMEWORK_COUNT="$(echo "${R_FRAMEWORK_CANDIDATES}" | grep -c . 2>/dev/null || echo 0)"
+if [[ "${R_FRAMEWORK_COUNT}" -ne 1 ]]; then
+  echo "ERROR: expected exactly 1 R.framework directory, found ${R_FRAMEWORK_COUNT}" >&2
+  find "${EXPAND_DIR}" -maxdepth 4 -type d >&2
+  exit 1
+fi
+R_FRAMEWORK="${R_FRAMEWORK_CANDIDATES}"
+echo "  Found: ${R_FRAMEWORK}"
+
+# ── 4. Flatten R.framework into output directory ─────────────────────
+# R.framework/Versions/{ver}-{arch}/Resources holds the actual R tree.
+# The version directory name varies (e.g. "4.4-arm64", "4.3-x86_64",
+# "4.4", or accessed via the "Current" symlink).
+echo "--- Flattening R.framework layout ---"
+
+R_MAJOR="${R_VERSION%%.*}"
+R_MINOR="${R_VERSION#*.}"; R_MINOR="${R_MINOR%%.*}"
+
+mkdir -p "${WORK_OUTPUT_PARENT}"
+
+R_RESOURCES=""
+for candidate in \
+  "${R_FRAMEWORK}/Versions/Current/Resources" \
+  "${R_FRAMEWORK}/Versions/${R_MAJOR}.${R_MINOR}-${ARCH}/Resources" \
+  "${R_FRAMEWORK}/Versions/${R_MAJOR}.${R_MINOR}/Resources" \
+; do
+  if [[ -d "${candidate}" ]]; then
+    R_RESOURCES="${candidate}"
+    break
+  fi
+done
+
+# Last resort: search
+if [[ -z "${R_RESOURCES}" ]]; then
+  R_RESOURCES="$(find "${R_FRAMEWORK}/Versions" -maxdepth 2 -type d -name Resources | head -1)"
+fi
+
+if [[ -z "${R_RESOURCES}" || ! -d "${R_RESOURCES}" ]]; then
+  echo "ERROR: could not locate Resources inside R.framework" >&2
+  find "${R_FRAMEWORK}" -maxdepth 4 -type d >&2
+  exit 1
+fi
+echo "  Resources: ${R_RESOURCES}"
+
+rm -rf "${WORK_OUTPUT_DIR}"
+cp -R "${R_RESOURCES}" "${WORK_OUTPUT_DIR}"
+echo "  Copied to ${WORK_OUTPUT_DIR}"
+
+# ── 4b. Extract Tcl/Tk from sub-package (older .pkg bundles it separately) ──
+# R >= 4.3 bundles Tcl/Tk inside R.framework. Older .pkg files ship it as a
+# separate tcltk*.pkg that installs to /usr/local/lib or /opt/R/{arch}/lib.
+# We extract it and bundle into our lib/ and share/ directories.
+TCLTK_PKG="$(find "${EXPAND_DIR}" -maxdepth 1 -type d -name "tcltk*" | head -1)"
+if [[ -n "${TCLTK_PKG}" && -d "${TCLTK_PKG}/Payload" ]]; then
+  echo "--- Extracting Tcl/Tk from sub-package ---"
+  TCLTK_PAYLOAD="${TCLTK_PKG}/Payload"
+
+  # Find the lib directory containing libtcl*.dylib. head -1 is intentional:
+  # multiple versioned libtcl*.dylib variants can coexist and we only need
+  # any one of them to locate the containing lib directory.
+  TCLTK_LIB="$(find "${TCLTK_PAYLOAD}" -name "libtcl*.dylib" -type f -print -quit 2>/dev/null)"
+  if [[ -n "${TCLTK_LIB}" ]]; then
+    TCLTK_LIB_DIR="$(dirname "${TCLTK_LIB}")"
+    echo "  Found Tcl/Tk libs in: ${TCLTK_LIB_DIR}"
+
+    # Copy dylibs to our lib/ directory
+    for dylib in "${TCLTK_LIB_DIR}"/libtcl*.dylib "${TCLTK_LIB_DIR}"/libtk*.dylib; do
+      if [[ -f "${dylib}" ]]; then
+        cp -v "${dylib}" "${WORK_OUTPUT_DIR}/lib/"
+      fi
+    done
+
+    # Copy Tcl/Tk script directories (tcl8.6/, tk8.6/) for init.tcl etc.
+    for tcldir in "tcl8.6" "tk8.6" "tcl8" "tcl8.5" "tk8.5"; do
+      if [[ -d "${TCLTK_LIB_DIR}/${tcldir}" ]]; then
+        mkdir -p "${WORK_OUTPUT_DIR}/lib/${tcldir}"
+        cp -R "${TCLTK_LIB_DIR}/${tcldir}/" "${WORK_OUTPUT_DIR}/lib/${tcldir}/"
+        echo "  Copied ${tcldir} scripts to lib/${tcldir}"
+      fi
+    done
+    echo "  Tcl/Tk libraries bundled"
+  else
+    echo "  tcltk sub-package found but no libtcl dylib inside (may be framework-bundled)"
+  fi
+else
+  echo "--- No tcltk sub-package found (Tcl/Tk likely bundled in R.framework) ---"
+fi
+
+# ── 5. Run post-build patching pipeline ──────────────────────────────
+# The CRAN .pkg hardcodes /Library/Frameworks/R.framework/... throughout
+# its Mach-O binaries and config files. Our existing pipeline handles
+# all of this:
+#   patch-mach-o.sh      - rewrites dylib load commands to @rpath / @loader_path
+#   make-relocatable.sh  - patches bin/R, bin/Rscript, etc/Makeconf, etc/Renviron
+#   install-rprofile-hook.sh - installs Rprofile.site with .portable env
+echo "--- Running post-build patching pipeline ---"
+
+bash "${SCRIPT_DIR}/patch-mach-o.sh"          "${WORK_OUTPUT_DIR}"
+bash "${SCRIPT_DIR}/make-relocatable.sh"       "${WORK_OUTPUT_DIR}" "${R_VERSION}"
+bash "${SCRIPT_DIR}/install-rprofile-hook.sh"  "${WORK_OUTPUT_DIR}"
+
+# ── 6. Package tarball ───────────────────────────────────────────────
+echo "--- Packaging tarball ---"
+mkdir -p "${OUTPUT_DIR_BASE}"
+TARBALL="${OUTPUT_DIR_BASE}/R-${R_VERSION}-macos-${ARCH}.tar.gz"
+tar czf "${TARBALL}" -C "${WORK_OUTPUT_PARENT}" "R-${R_VERSION}"
+echo "=== Tarball created: ${TARBALL} ==="
+
+# ── Cleanup ──────────────────────────────────────────────────────────
+# The EXIT trap also handles cleanup on error; this explicit call covers
+# the success path and runs before the trap fires.
+rm -rf "${WORK_DIR}" "${WORK_OUTPUT_PARENT}"
+echo "=== Build complete ==="

--- a/macos/entitlements.plist
+++ b/macos/entitlements.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Allow R to JIT-compile code (e.g., the byte-code compiler) -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <!-- Allow R to allocate writable+executable memory (required by some
+         packages that generate machine code at runtime, e.g. Rcpp) -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Allow loading CRAN binary packages (.so) signed by other teams
+         or ad-hoc signed after install_name_tool patching -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- Allow DYLD_LIBRARY_PATH / DYLD_INSERT_LIBRARIES so users and
+         R itself can override library load paths at runtime -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/macos/install-rprofile-hook.sh
+++ b/macos/install-rprofile-hook.sh
@@ -1,29 +1,56 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# install-rprofile-hook.sh -- Install portable-R startup hooks into the base
+# Rprofile so they apply in every R launch context.
+#
+# Why the base Rprofile and not etc/Rprofile.site?
+#   etc/Rprofile.site is skipped under `R --vanilla` and is also bypassed
+#   when an embedding host (RStudio's rsession, Positron's R kernel) loads
+#   libR.so directly without going through bin/R. The base Rprofile at
+#   library/base/R/Rprofile is sourced by R itself during startup, so it
+#   runs in every launch context.
+#
+# This file appends three local() blocks to the base Rprofile:
+#   1. Default CRAN repo -> p3m.dev (Posit Public Package Manager)
+#   2. TCL_LIBRARY / TK_LIBRARY env vars pointing at our bundled lib/tcl8.6
+#      and lib/tk8.6 directories (R < 4.3 needs these; R >= 4.3 ignores them
+#      because Tcl/Tk is bundled inside R.framework)
+#   3. A .portable environment that wraps install.packages() to rewrite
+#      hardcoded /Library/Frameworks/R.framework/... load commands in
+#      newly-installed CRAN binary packages. This is macOS-specific and
+#      gated on Sys.info()[["sysname"]] == "Darwin".
+#
+# The existing Rprofile content from CRAN is preserved (we append, not
+# overwrite). bin/fix-dylibs is also installed as a manual escape hatch
+# in case the install.packages wrapper is shadowed by an IDE.
+
 R_HOME="${1:?Usage: install-rprofile-hook.sh <r-home>}"
 R_HOME="$(cd "${R_HOME}" && pwd)"
 
-echo "=== Installing Rprofile.site hook in ${R_HOME} ==="
+BASE_RPROFILE="${R_HOME}/library/base/R/Rprofile"
+if [[ ! -f "${BASE_RPROFILE}" ]]; then
+  echo "ERROR: base Rprofile not found at ${BASE_RPROFILE}" >&2
+  exit 1
+fi
 
-cat > "${R_HOME}/etc/Rprofile.site" << 'RPROFILE'
-# Rprofile.site — rstudio/r-builds portable R distribution
-# This file is sourced at R startup. It provides:
-# 1. Automatic patching of CRAN binary packages for macOS portability
-# 2. Posit Package Manager as default repository
+echo "=== Appending portable-R hooks to ${BASE_RPROFILE} ==="
 
-# ── Default repository: Posit Package Manager ──────────────────────
+cat >> "${BASE_RPROFILE}" <<'RPROFILE'
+
+## ── rstudio/r-builds portable R hooks ─────────────────────────────────
+## Appended by install-rprofile-hook.sh. Lives in the base Rprofile so it
+## runs in every launch context, including R --vanilla and IDE-embedded R.
+
+## Default CRAN mirror: Posit Public Package Manager
 local({
   r <- getOption("repos")
-  r["CRAN"] <- "https://packagemanager.posit.co/cran/latest"
+  r["CRAN"] <- "https://p3m.dev/cran/latest"
   options(repos = r)
 })
 
-# ── Tcl/Tk library paths (for bundled Tcl/Tk) ────────────────────
-# CRAN binary packages and older .pkg installers expect Tcl/Tk at a
-# system path. When we bundle Tcl/Tk in our lib/ directory, we need
-# to tell R where to find the script files (init.tcl, etc.).
-# Following r-builds PR #280 pattern.
+## Tcl/Tk library paths for bundled scripts (R < 4.3; R >= 4.3 bundles
+## these inside R.framework and ignores the env vars).
 local({
   r_home <- Sys.getenv("R_HOME", R.home())
   tcl_dir <- file.path(r_home, "lib", "tcl8.6")
@@ -34,11 +61,19 @@ local({
     Sys.setenv(TK_LIBRARY = tk_dir)
 })
 
-# ── .portable environment: CRAN binary package compatibility ───────
-# CRAN binary packages (.tgz) embed absolute Mach-O paths from the
-# CRAN build machine (/Library/Frameworks/R.framework/...). This hook
-# transparently rewrites them after install.packages() completes.
-
+## .portable environment: macOS CRAN binary package fix-up.
+##
+## CRAN binary .tgz packages embed absolute Mach-O paths from the CRAN
+## build host (/Library/Frameworks/R.framework/...). When R is installed
+## anywhere else, those paths don't resolve and `library(pkg)` fails with
+## "image not found." This wrapper runs install_name_tool on each .so
+## immediately after install.packages() returns, rewriting the framework
+## paths to @rpath references that resolve via R's lib/ directory.
+##
+## Known limitation: IDEs (RStudio, Positron) install their own
+## install.packages() override that may shadow this wrapper. If you hit
+## "image not found" errors after installing a package via an IDE, run
+## `R_HOME/bin/fix-dylibs` manually to patch the installed package.
 if (Sys.info()[["sysname"]] == "Darwin") local({
   .portable <- new.env(parent = baseenv())
 
@@ -92,8 +127,9 @@ if (Sys.info()[["sysname"]] == "Darwin") local({
   }
 
   # Attach .portable above package:utils so it masks install.packages.
-  # Default packages load after Rprofile.site (pushing any early attach down),
-  # so we hook into the last default package (stats) to re-attach at position 2.
+  # Default packages load after the base Rprofile runs (pushing any early
+  # attach down), so we hook into the last default package (stats) to
+  # re-attach at position 2.
   setHook(packageEvent("stats", "attach"), function(...) {
     if (".portable" %in% search()) try(detach(".portable"), silent = TRUE)
     attach(.portable, name = ".portable", pos = 2L, warn.conflicts = FALSE)
@@ -101,7 +137,12 @@ if (Sys.info()[["sysname"]] == "Darwin") local({
 })
 RPROFILE
 
-# ── Also create bin/fix-dylibs for manual use ──────────────────────
+echo "  Appended portable-R hooks to base Rprofile"
+
+# ── Manual escape hatch: bin/fix-dylibs ────────────────────────────
+# If the .portable install.packages wrapper is shadowed by an IDE, the
+# user can run this script to fix any unpatched .so files in their
+# library tree.
 echo "--- Creating bin/fix-dylibs ---"
 cat > "${R_HOME}/bin/fix-dylibs" << 'FIXDYLIBS'
 #!/usr/bin/env bash
@@ -130,4 +171,4 @@ echo "Done. Patched ${count} files."
 FIXDYLIBS
 chmod +x "${R_HOME}/bin/fix-dylibs"
 
-echo "=== Rprofile.site hook installed ==="
+echo "=== Portable-R hooks installed ==="

--- a/macos/install-rprofile-hook.sh
+++ b/macos/install-rprofile-hook.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+R_HOME="${1:?Usage: install-rprofile-hook.sh <r-home>}"
+R_HOME="$(cd "${R_HOME}" && pwd)"
+
+echo "=== Installing Rprofile.site hook in ${R_HOME} ==="
+
+cat > "${R_HOME}/etc/Rprofile.site" << 'RPROFILE'
+# Rprofile.site — rstudio/r-builds portable R distribution
+# This file is sourced at R startup. It provides:
+# 1. Automatic patching of CRAN binary packages for macOS portability
+# 2. Posit Package Manager as default repository
+
+# ── Default repository: Posit Package Manager ──────────────────────
+local({
+  r <- getOption("repos")
+  r["CRAN"] <- "https://packagemanager.posit.co/cran/latest"
+  options(repos = r)
+})
+
+# ── Tcl/Tk library paths (for bundled Tcl/Tk) ────────────────────
+# CRAN binary packages and older .pkg installers expect Tcl/Tk at a
+# system path. When we bundle Tcl/Tk in our lib/ directory, we need
+# to tell R where to find the script files (init.tcl, etc.).
+# Following r-builds PR #280 pattern.
+local({
+  r_home <- Sys.getenv("R_HOME", R.home())
+  tcl_dir <- file.path(r_home, "lib", "tcl8.6")
+  tk_dir <- file.path(r_home, "lib", "tk8.6")
+  if (Sys.getenv("TCL_LIBRARY") == "" && file.exists(tcl_dir))
+    Sys.setenv(TCL_LIBRARY = tcl_dir)
+  if (Sys.getenv("TK_LIBRARY") == "" && file.exists(tk_dir))
+    Sys.setenv(TK_LIBRARY = tk_dir)
+})
+
+# ── .portable environment: CRAN binary package compatibility ───────
+# CRAN binary packages (.tgz) embed absolute Mach-O paths from the
+# CRAN build machine (/Library/Frameworks/R.framework/...). This hook
+# transparently rewrites them after install.packages() completes.
+
+if (Sys.info()[["sysname"]] == "Darwin") local({
+  .portable <- new.env(parent = baseenv())
+
+  # Patch a single .so file: rewrite R.framework references to @rpath
+  .portable$fix_so <- function(so) {
+    refs <- system2("otool", c("-L", shQuote(so)), stdout = TRUE, stderr = FALSE)
+    fw <- grep("/Library/Frameworks/R.framework", refs, value = TRUE)
+    if (length(fw) == 0L) return(invisible(FALSE))
+    for (line in fw) {
+      old <- trimws(sub("\\s+\\(.*", "", line))
+      system2("install_name_tool",
+              c("-change", shQuote(old),
+                shQuote(paste0("@rpath/", basename(old))),
+                shQuote(so)),
+              stdout = FALSE, stderr = FALSE)
+    }
+    system2("install_name_tool",
+            c("-add_rpath", "@loader_path/../../../lib", shQuote(so)),
+            stdout = FALSE, stderr = FALSE)
+    system2("codesign", c("-f", "-s", "-", shQuote(so)),
+            stdout = FALSE, stderr = FALSE)
+    invisible(TRUE)
+  }
+
+  # Scan ALL packages in a library directory and patch any unfixed .so files
+  .portable$fix_pkgs <- function(pkgs = NULL, lib = .libPaths()[1L]) {
+    all_pkgs <- list.dirs(lib, full.names = FALSE, recursive = FALSE)
+    fixed <- 0L
+    for (pkg in all_pkgs) {
+      so_files <- list.files(file.path(lib, pkg, "libs"),
+                             pattern = "\\.so$", full.names = TRUE)
+      for (so in so_files) {
+        if (isTRUE(tryCatch(.portable$fix_so(so), error = function(e) NULL)))
+          fixed <- fixed + 1L
+      }
+    }
+    if (fixed > 0L)
+      message(sprintf("Portable R: patched %d shared librar%s",
+                      fixed, if (fixed == 1L) "y" else "ies"))
+    invisible(fixed)
+  }
+
+  # Wrapper around utils::install.packages that patches .so files after install
+  .portable$install.packages <- function(pkgs, ...) {
+    utils <- asNamespace("utils")
+    result <- utils$install.packages(pkgs, ...)
+    mc <- match.call()
+    lib_dir <- if ("lib" %in% names(mc)) eval(mc$lib) else .libPaths()[1L]
+    try(.portable$fix_pkgs(pkgs, lib = lib_dir), silent = TRUE)
+    invisible(result)
+  }
+
+  # Attach .portable above package:utils so it masks install.packages.
+  # Default packages load after Rprofile.site (pushing any early attach down),
+  # so we hook into the last default package (stats) to re-attach at position 2.
+  setHook(packageEvent("stats", "attach"), function(...) {
+    if (".portable" %in% search()) try(detach(".portable"), silent = TRUE)
+    attach(.portable, name = ".portable", pos = 2L, warn.conflicts = FALSE)
+  })
+})
+RPROFILE
+
+# ── Also create bin/fix-dylibs for manual use ──────────────────────
+echo "--- Creating bin/fix-dylibs ---"
+cat > "${R_HOME}/bin/fix-dylibs" << 'FIXDYLIBS'
+#!/usr/bin/env bash
+set -euo pipefail
+R_HOME="$(cd "$(dirname "$0")/.." && pwd)"
+echo "Scanning for unpatched .so files in ${R_HOME}..."
+count=0
+for dir in "${R_HOME}/library" "${R_HOME}/modules"; do
+  [ -d "$dir" ] || continue
+  while IFS= read -r so; do
+    if otool -L "$so" 2>/dev/null | grep -q "/Library/Frameworks/R.framework"; then
+      otool -L "$so" | grep "/Library/Frameworks/R.framework" | awk '{print $1}' | while read -r old; do
+        install_name_tool -change "$old" "@rpath/$(basename "$old")" "$so" 2>/dev/null
+      done
+      case "$so" in
+        */modules/*)         install_name_tool -add_rpath "@loader_path/../lib" "$so" 2>/dev/null || true ;;
+        */library/*/libs/*)  install_name_tool -add_rpath "@loader_path/../../../lib" "$so" 2>/dev/null || true ;;
+      esac
+      codesign -f -s - "$so" 2>/dev/null || true
+      echo "  Patched: ${so#${R_HOME}/}"
+      count=$((count + 1))
+    fi
+  done < <(find "$dir" -name "*.so" -type f 2>/dev/null)
+done
+echo "Done. Patched ${count} files."
+FIXDYLIBS
+chmod +x "${R_HOME}/bin/fix-dylibs"
+
+echo "=== Rprofile.site hook installed ==="

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -5,17 +5,47 @@ R_HOME="${1:?Usage: make-relocatable.sh <r-home> [r-version]}"
 R_HOME="$(cd "${R_HOME}" && pwd)"
 R_VERSION="${2:-}"
 
-# Parse major.minor for version-specific handling. R_VERSION may be "devel",
-# "patched", or "next" — non-numeric — so fall back to introspecting the binary
-# in that case (and when R_VERSION is unset entirely).
-if [[ -n "${R_VERSION}" ]] && [[ "${R_VERSION}" =~ ^[0-9]+\.[0-9]+ ]]; then
-  R_MAJOR="${R_VERSION%%.*}"
-  R_MINOR="${R_VERSION#*.}"; R_MINOR="${R_MINOR%%.*}"
-else
-  R_VER_STRING=$("${R_HOME}/bin/exec/R" --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "")
-  R_MAJOR="${R_VER_STRING%%.*}"
-  R_MINOR="${R_VER_STRING#*.}"; R_MINOR="${R_MINOR%%.*}"
-fi
+# Determine the version slot used in the orthogonal R_HOME_DIR= rewrite
+# (`Versions/<slot>-<arch>/Resources`). Three tiers in priority order:
+#
+#   1. Aliases — devel/patched/next: use the alias literally. R_VERSION
+#      doesn't carry a numeric branch for these, and trying to derive one
+#      means the slot would change across R branch rollovers (4.6→4.7…)
+#      from identical input. The literal alias is also free of any
+#      collision with numeric `<minor>-<arch>` slots used by CRAN/rig.
+#   2. Numeric R_VERSION (4.4.3, 4.6.0, …) — parse major.minor.
+#   3. Fallback for direct invocation without R_VERSION — introspect via
+#      `bin/R --version`. Use the shell wrapper, NOT `bin/exec/R`: the
+#      raw Mach-O errors out with "Fatal error: R home directory is not
+#      defined" when called without R_HOME in the environment, leaving
+#      the regex with no digits to match. The wrapper sets R_HOME itself.
+#
+# R_MAJOR/R_MINOR remain set after this block for the Rscript R<4.2
+# branch below; for tier 1 they stay empty (devel/patched/next are
+# always modern R, and the regex guard there skips the <4.2 branch).
+R_MAJOR=""
+R_MINOR=""
+case "${R_VERSION}" in
+  devel|patched|next)
+    SLOT_VERSION="${R_VERSION}"
+    ;;
+  *)
+    if [[ "${R_VERSION}" =~ ^[0-9]+\.[0-9]+ ]]; then
+      R_MAJOR="${R_VERSION%%.*}"
+      R_MINOR="${R_VERSION#*.}"; R_MINOR="${R_MINOR%%.*}"
+    else
+      R_VER_STRING=$("${R_HOME}/bin/R" --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "")
+      if [ -z "${R_VER_STRING}" ]; then
+        echo "ERROR: Could not determine R version for slot computation" >&2
+        echo "       R_VERSION='${R_VERSION}', bin/R --version produced no version digits" >&2
+        exit 1
+      fi
+      R_MAJOR="${R_VER_STRING%%.*}"
+      R_MINOR="${R_VER_STRING#*.}"; R_MINOR="${R_MINOR%%.*}"
+    fi
+    SLOT_VERSION="${R_MAJOR}.${R_MINOR}"
+    ;;
+esac
 
 echo "=== Making R relocatable in ${R_HOME} ==="
 
@@ -30,7 +60,7 @@ if [ -z "${HARDCODED_PATH}" ]; then
 fi
 echo "Detected hardcoded path: ${HARDCODED_PATH}"
 
-# Force the static R_HOME_DIR= line to the orthogonal "Versions/<ver>-<arch>/
+# Force the static R_HOME_DIR= line to the orthogonal "Versions/<slot>-<arch>/
 # Resources" form regardless of what CRAN shipped. Positron's RInstallation
 # constructor classifies an install as orthogonal iff its homepath does NOT
 # match /R\.framework\/Resources/ (see extensions/positron-r/src/r-installation.ts),
@@ -46,7 +76,7 @@ if [ -z "${ARCH_DETECTED}" ]; then
   echo "ERROR: Could not detect arch from ${R_HOME}/bin/exec/R" >&2
   exit 1
 fi
-ORTHOGONAL_PATH="/Library/Frameworks/R.framework/Versions/${R_MAJOR}.${R_MINOR}-${ARCH_DETECTED}/Resources"
+ORTHOGONAL_PATH="/Library/Frameworks/R.framework/Versions/${SLOT_VERSION}-${ARCH_DETECTED}/Resources"
 echo "Rewriting static R_HOME_DIR to orthogonal path: ${ORTHOGONAL_PATH}"
 
 # Match the static assignment in either quote style. CRAN's R.sh.in

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -49,11 +49,16 @@ fi
 ORTHOGONAL_PATH="/Library/Frameworks/R.framework/Versions/${R_MAJOR}.${R_MINOR}-${ARCH_DETECTED}/Resources"
 echo "Rewriting static R_HOME_DIR to orthogonal path: ${ORTHOGONAL_PATH}"
 
-# Match only the static unquoted assignment (the lib/lib64 fallback lines
-# `R_HOME_DIR="/Library/${libnn}/R"` start with a double quote after the
-# `=` and so are skipped by the [^"] character class). The runtime override
-# we insert below also starts with a quote and is therefore skipped.
-sed -i '' "s|^R_HOME_DIR=/[^\"]*$|R_HOME_DIR=${ORTHOGONAL_PATH}|" "${R_HOME}/bin/R"
+# Match the static assignment in either quote style. CRAN's R.sh.in
+# template has historically written the value either unquoted (R 4.4
+# and earlier on macOS arm64: `R_HOME_DIR=/Library/...`) or quoted
+# (R 4.6+: `R_HOME_DIR="/Library/..."`). The lib/lib64 conditional
+# fallback lines `R_HOME_DIR="/Library/${libnn}/R"` are indented (so
+# the leading-anchor `^` excludes them) and also contain `${`, so the
+# `[^$"]*` body class would stop short of the closing quote. The
+# runtime override we insert below has the form `R_HOME_DIR="$(...)"`
+# — value starts with `$`, not `/`, so it doesn't match either.
+sed -i '' -E "s|^R_HOME_DIR=\"?/[^\$\"]*\"?\$|R_HOME_DIR=${ORTHOGONAL_PATH}|" "${R_HOME}/bin/R"
 
 # ── 1. Patch bin/R — dynamic R_HOME derivation ─────────────────────
 # Strategy (following r-builds PR #280): preserve the original static
@@ -78,11 +83,14 @@ echo "--- Patching bin/R ---"
 # the Rscript wrapper had set env R_HOME to the actual path. Inserting
 # the override earlier eliminates the mismatch.
 #
-# The address `^R_HOME_DIR=\/` matches only the static absolute-path
-# assignment (line 4 in CRAN's bin/R). The conditional fallback lines
-# `R_HOME_DIR="/Library/${libnn}/R"` start with a double quote after
-# `=`, so they do not match.
-sed -i '' '/^R_HOME_DIR=\//a\
+# The address `^R_HOME_DIR="?/` matches the static absolute-path
+# assignment in either quote style — `R_HOME_DIR=/Library/...`
+# (R 4.4 and earlier) or `R_HOME_DIR="/Library/..."` (R 4.6+). The
+# conditional libnn fallback lines `R_HOME_DIR="/Library/${libnn}/R"`
+# are indented so the leading-anchor `^` excludes them. Our runtime
+# override line has the form `R_HOME_DIR="$(...)"` — no `/` follows
+# the `="`, so the `?/` requirement excludes it.
+sed -i '' -E '/^R_HOME_DIR="?\//a\
 # Override R_HOME_DIR for relocatable installation\
 R_HOME_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")/.." \&\& pwd)"
 ' "${R_HOME}/bin/R"

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+R_HOME="${1:?Usage: make-relocatable.sh <r-home> [r-version]}"
+R_HOME="$(cd "${R_HOME}" && pwd)"
+R_VERSION="${2:-}"
+
+# Parse major.minor for version-specific handling
+if [[ -n "${R_VERSION}" ]]; then
+  R_MAJOR="${R_VERSION%%.*}"
+  R_MINOR="${R_VERSION#*.}"; R_MINOR="${R_MINOR%%.*}"
+else
+  # Fall back to detecting from the binary
+  R_VER_STRING=$("${R_HOME}/bin/exec/R" --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "")
+  R_MAJOR="${R_VER_STRING%%.*}"
+  R_MINOR="${R_VER_STRING#*.}"; R_MINOR="${R_MINOR%%.*}"
+fi
+
+echo "=== Making R relocatable in ${R_HOME} ==="
+
+# Detect the hardcoded framework path from bin/R (CRAN .pkg sets R_HOME_DIR
+# to e.g. /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources).
+HARDCODED_PATH="$(grep '^R_HOME_DIR=' "${R_HOME}/bin/R" | head -1 | sed 's/^R_HOME_DIR=//' | tr -d '"' | tr -d "'")"
+if [ -z "${HARDCODED_PATH}" ]; then
+  echo "ERROR: Could not detect hardcoded path from bin/R" >&2
+  exit 1
+fi
+echo "Detected hardcoded path: ${HARDCODED_PATH}"
+
+# ── 1. Patch bin/R — dynamic R_HOME derivation ─────────────────────
+# Strategy (following r-builds PR #280): preserve the original static
+# R_HOME_DIR= line for IDE compatibility (Positron, RStudio parse this
+# file as text), but insert a dynamic override before R_HOME assignment.
+echo "--- Patching bin/R ---"
+
+# Insert dynamic R_HOME_DIR override before the R_HOME assignment line.
+# This preserves the original static R_HOME_DIR= for IDE parsers while
+# ensuring runtime behavior derives the path dynamically.
+sed -i '' '/^R_HOME="${R_HOME_DIR}"$/i\
+# Override R_HOME_DIR for relocatable installation\
+R_HOME_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")/.." \&\& pwd)"
+' "${R_HOME}/bin/R"
+
+# Patch R_SHARE_DIR, R_INCLUDE_DIR, R_DOC_DIR to be relative
+sed -i '' 's|^R_SHARE_DIR=.*|R_SHARE_DIR="${R_HOME_DIR}/share"|' "${R_HOME}/bin/R"
+sed -i '' 's|^R_INCLUDE_DIR=.*|R_INCLUDE_DIR="${R_HOME_DIR}/include"|' "${R_HOME}/bin/R"
+sed -i '' 's|^R_DOC_DIR=.*|R_DOC_DIR="${R_HOME_DIR}/doc"|' "${R_HOME}/bin/R"
+# Replace any remaining references to the hardcoded path in bin/R
+sed -i '' "s|${HARDCODED_PATH}|\${R_HOME}|g" "${R_HOME}/bin/R"
+echo "  bin/R: R_HOME_DIR overridden at runtime (original preserved for IDE compat)"
+
+# ── 2. Set up Rscript — version-aware strategy ───────────────────
+echo "--- Setting up bin/Rscript ---"
+RSCRIPT_BIN="${R_HOME}/bin/Rscript"
+
+if [[ -n "${R_MAJOR}" ]] && (( R_MAJOR < 4 || (R_MAJOR == 4 && R_MINOR < 2) )); then
+  # R < 4.2: Rscript binary ignores R_HOME env var and uses compiled-in paths.
+  # Replace entirely with a shell script that calls bin/R (r-builds PR #280 approach).
+  if [ -f "${RSCRIPT_BIN}" ]; then
+    rm -f "${RSCRIPT_BIN}" "${RSCRIPT_BIN}.bin"
+  fi
+  cat > "${RSCRIPT_BIN}" << 'WRAPPER'
+#!/bin/sh
+R_HOME="$(cd "$(dirname "$0")/.." && pwd)"
+exec "${R_HOME}/bin/R" --slave "$@"
+WRAPPER
+  chmod +x "${RSCRIPT_BIN}"
+  echo "  bin/Rscript: replaced with R --no-echo wrapper (R < 4.2 compat)"
+else
+  # R >= 4.2: Rscript binary respects R_HOME. Preserve it and wrap.
+  if [ -f "${RSCRIPT_BIN}" ] && file "${RSCRIPT_BIN}" | grep -q "Mach-O"; then
+    mv "${RSCRIPT_BIN}" "${RSCRIPT_BIN}.bin"
+    chmod +x "${RSCRIPT_BIN}.bin"
+    echo "  bin/Rscript.bin: preserved original Mach-O binary"
+  fi
+  cat > "${RSCRIPT_BIN}" << 'WRAPPER'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export RHOME="$(cd "$SCRIPT_DIR/.." && pwd)"
+export R_HOME="$RHOME"
+exec "$SCRIPT_DIR/Rscript.bin" "$@"
+WRAPPER
+  chmod +x "${RSCRIPT_BIN}"
+  echo "  bin/Rscript: replaced with shell wrapper (sets RHOME before launch)"
+fi
+
+# ── 3. Patch etc/Makeconf ───────────────────────────────────────────
+echo "--- Patching etc/Makeconf ---"
+if [ -f "${R_HOME}/etc/Makeconf" ]; then
+  # Replace hardcoded framework path with $(R_HOME)
+  sed -i '' "s|${HARDCODED_PATH}|\$(R_HOME)|g" "${R_HOME}/etc/Makeconf"
+  # Replace -framework R linking with direct dylib linking
+  sed -i '' 's|^LIBR = -F.*-framework R|LIBR = -L"$(R_HOME)/lib" -lR|' "${R_HOME}/etc/Makeconf"
+  # Strip remaining -F framework flags
+  sed -i '' 's|-F/Library/Frameworks/R.framework/[^ ]*||g' "${R_HOME}/etc/Makeconf"
+  echo "  etc/Makeconf: patched (prefix -> \$(R_HOME), framework -> -lR, -F flags stripped)"
+fi
+
+# ── 4. Patch etc/Renviron ───────────────────────────────────────────
+echo "--- Patching etc/Renviron ---"
+if [ -f "${R_HOME}/etc/Renviron" ]; then
+  sed -i '' "s|${HARDCODED_PATH}|\${R_HOME}|g" "${R_HOME}/etc/Renviron"
+  echo "  etc/Renviron: hardcoded path -> \${R_HOME}"
+fi
+
+# ── 5. Patch etc/ldpaths ───────────────────────────────────────────
+echo "--- Checking etc/ldpaths ---"
+if [ -f "${R_HOME}/etc/ldpaths" ]; then
+  if grep -q "${HARDCODED_PATH}" "${R_HOME}/etc/ldpaths"; then
+    sed -i '' "s|${HARDCODED_PATH}|\${R_HOME}|g" "${R_HOME}/etc/ldpaths"
+    echo "  etc/ldpaths: hardcoded path -> \${R_HOME}"
+  else
+    echo "  etc/ldpaths: already uses relative paths"
+  fi
+fi
+
+# ── 6. Patch other shell scripts in bin/ ────────────────────────────
+echo "--- Patching other bin/ scripts ---"
+find "${R_HOME}/bin" -type f ! -name "*.bin" | while read -r f; do
+  if file "${f}" | grep -q "text" && grep -q "${HARDCODED_PATH}" "${f}" 2>/dev/null; then
+    sed -i '' "s|${HARDCODED_PATH}|\${R_HOME}|g" "${f}"
+    echo "  $(basename "${f}"): hardcoded paths replaced"
+  fi
+done
+
+echo "=== Relocatability patching complete ==="

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -34,10 +34,28 @@ echo "Detected hardcoded path: ${HARDCODED_PATH}"
 # file as text), but insert a dynamic override before R_HOME assignment.
 echo "--- Patching bin/R ---"
 
-# Insert dynamic R_HOME_DIR override before the R_HOME assignment line.
-# This preserves the original static R_HOME_DIR= for IDE parsers while
-# ensuring runtime behavior derives the path dynamically.
-sed -i '' '/^R_HOME="${R_HOME_DIR}"$/i\
+# Insert dynamic R_HOME_DIR override IMMEDIATELY AFTER the static
+# `R_HOME_DIR=/Library/Frameworks/...` assignment. The static line is
+# preserved (Positron's getRHomePathDarwin reads the FIRST line
+# containing R_HOME_DIR as text, and that's what we want it to find);
+# the runtime override fires next so every subsequent reference in the
+# script — including the `if test "${R_HOME}" != "${R_HOME_DIR}"`
+# warning check, the R_SHARE_DIR / R_INCLUDE_DIR / R_DOC_DIR
+# assignments, and the final exec — sees the actual extracted path.
+#
+# Inserting the override AFTER the warning check (the previous
+# approach) caused R to emit "WARNING: ignoring environment value of
+# R_HOME" to stdout when bin/R was invoked with R_HOME already exported
+# (e.g., by our bin/Rscript wrapper for R >= 4.2). The warning fired
+# because at that point R_HOME_DIR was still the framework path, while
+# the Rscript wrapper had set env R_HOME to the actual path. Inserting
+# the override earlier eliminates the mismatch.
+#
+# The address `^R_HOME_DIR=\/` matches only the static absolute-path
+# assignment (line 4 in CRAN's bin/R). The conditional fallback lines
+# `R_HOME_DIR="/Library/${libnn}/R"` start with a double quote after
+# `=`, so they do not match.
+sed -i '' '/^R_HOME_DIR=\//a\
 # Override R_HOME_DIR for relocatable installation\
 R_HOME_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")/.." \&\& pwd)"
 ' "${R_HOME}/bin/R"

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -125,8 +125,14 @@ if [ -f "${R_HOME}/etc/ldpaths" ]; then
 fi
 
 # ── 6. Patch other shell scripts in bin/ ────────────────────────────
+# Skip bin/R itself — Phase 1 already patched it with the correct
+# exclusion that preserves the static R_HOME_DIR= line for IDE parsers.
+# Without this skip, the unconditional global sed below would re-clobber
+# that static line back to `R_HOME_DIR=${R_HOME}` and break Positron's
+# discovery (the same DESCRIPTION-not-found rejection the Phase 1 fix
+# was meant to prevent).
 echo "--- Patching other bin/ scripts ---"
-find "${R_HOME}/bin" -type f ! -name "*.bin" | while read -r f; do
+find "${R_HOME}/bin" -type f ! -name "*.bin" ! -name "R" | while read -r f; do
   if file "${f}" | grep -q "text" && grep -q "${HARDCODED_PATH}" "${f}" 2>/dev/null; then
     sed -i '' "s|${HARDCODED_PATH}|\${R_HOME}|g" "${f}"
     echo "  $(basename "${f}"): hardcoded paths replaced"

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -46,8 +46,16 @@ R_HOME_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/
 sed -i '' 's|^R_SHARE_DIR=.*|R_SHARE_DIR="${R_HOME_DIR}/share"|' "${R_HOME}/bin/R"
 sed -i '' 's|^R_INCLUDE_DIR=.*|R_INCLUDE_DIR="${R_HOME_DIR}/include"|' "${R_HOME}/bin/R"
 sed -i '' 's|^R_DOC_DIR=.*|R_DOC_DIR="${R_HOME_DIR}/doc"|' "${R_HOME}/bin/R"
-# Replace any remaining references to the hardcoded path in bin/R
-sed -i '' "s|${HARDCODED_PATH}|\${R_HOME}|g" "${R_HOME}/bin/R"
+# Replace any remaining references to the hardcoded path in bin/R, but
+# skip lines that start with `R_HOME_DIR=`. Positron's getRHomePathDarwin
+# (and RStudio's analogous parser) reads the FIRST line containing
+# R_HOME_DIR and uses that string as the R home — so the static
+# `R_HOME_DIR=/Library/Frameworks/...` assignment must survive intact for
+# IDE discovery to work, even though our runtime override (inserted
+# above) is what actually executes. Without this exclusion the line gets
+# rewritten to `R_HOME_DIR=${R_HOME}` and Positron rejects the install
+# with "Can't find DESCRIPTION for the utils package at ${R_HOME}/...".
+sed -i '' "/^R_HOME_DIR=/!s|${HARDCODED_PATH}|\${R_HOME}|g" "${R_HOME}/bin/R"
 echo "  bin/R: R_HOME_DIR overridden at runtime (original preserved for IDE compat)"
 
 # ── 2. Set up Rscript — version-aware strategy ───────────────────

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -5,12 +5,13 @@ R_HOME="${1:?Usage: make-relocatable.sh <r-home> [r-version]}"
 R_HOME="$(cd "${R_HOME}" && pwd)"
 R_VERSION="${2:-}"
 
-# Parse major.minor for version-specific handling
-if [[ -n "${R_VERSION}" ]]; then
+# Parse major.minor for version-specific handling. R_VERSION may be "devel",
+# "patched", or "next" — non-numeric — so fall back to introspecting the binary
+# in that case (and when R_VERSION is unset entirely).
+if [[ -n "${R_VERSION}" ]] && [[ "${R_VERSION}" =~ ^[0-9]+\.[0-9]+ ]]; then
   R_MAJOR="${R_VERSION%%.*}"
   R_MINOR="${R_VERSION#*.}"; R_MINOR="${R_MINOR%%.*}"
 else
-  # Fall back to detecting from the binary
   R_VER_STRING=$("${R_HOME}/bin/exec/R" --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "")
   R_MAJOR="${R_VER_STRING%%.*}"
   R_MINOR="${R_VER_STRING#*.}"; R_MINOR="${R_MINOR%%.*}"
@@ -53,7 +54,8 @@ echo "  bin/R: R_HOME_DIR overridden at runtime (original preserved for IDE comp
 echo "--- Setting up bin/Rscript ---"
 RSCRIPT_BIN="${R_HOME}/bin/Rscript"
 
-if [[ -n "${R_MAJOR}" ]] && (( R_MAJOR < 4 || (R_MAJOR == 4 && R_MINOR < 2) )); then
+if [[ "${R_MAJOR}" =~ ^[0-9]+$ ]] && [[ "${R_MINOR}" =~ ^[0-9]+$ ]] \
+   && (( R_MAJOR < 4 || (R_MAJOR == 4 && R_MINOR < 2) )); then
   # R < 4.2: Rscript binary ignores R_HOME env var and uses compiled-in paths.
   # Replace entirely with a shell script that calls bin/R (r-builds PR #280 approach).
   if [ -f "${RSCRIPT_BIN}" ]; then

--- a/macos/make-relocatable.sh
+++ b/macos/make-relocatable.sh
@@ -20,13 +20,40 @@ fi
 echo "=== Making R relocatable in ${R_HOME} ==="
 
 # Detect the hardcoded framework path from bin/R (CRAN .pkg sets R_HOME_DIR
-# to e.g. /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources).
+# to e.g. /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources for
+# orthogonal installs, or /Library/Frameworks/R.framework/Resources for
+# non-orthogonal ones — observed on R 4.4.3 macOS arm64 .pkg).
 HARDCODED_PATH="$(grep '^R_HOME_DIR=' "${R_HOME}/bin/R" | head -1 | sed 's/^R_HOME_DIR=//' | tr -d '"' | tr -d "'")"
 if [ -z "${HARDCODED_PATH}" ]; then
   echo "ERROR: Could not detect hardcoded path from bin/R" >&2
   exit 1
 fi
 echo "Detected hardcoded path: ${HARDCODED_PATH}"
+
+# Force the static R_HOME_DIR= line to the orthogonal "Versions/<ver>-<arch>/
+# Resources" form regardless of what CRAN shipped. Positron's RInstallation
+# constructor classifies an install as orthogonal iff its homepath does NOT
+# match /R\.framework\/Resources/ (see extensions/positron-r/src/r-installation.ts),
+# and a non-orthogonal install is only usable when it's also the system's
+# "current" R — which our portable R isn't. Without this rewrite, Positron
+# rejects the install with "Non-orthogonal installation that is also not the
+# current version" even after symlinking the canonical path.
+#
+# Detect arch from the actual Mach-O binary; the build is single-arch so this
+# returns one definitive value.
+ARCH_DETECTED=$(file -b "${R_HOME}/bin/exec/R" 2>/dev/null | grep -oE 'arm64|x86_64' | head -1)
+if [ -z "${ARCH_DETECTED}" ]; then
+  echo "ERROR: Could not detect arch from ${R_HOME}/bin/exec/R" >&2
+  exit 1
+fi
+ORTHOGONAL_PATH="/Library/Frameworks/R.framework/Versions/${R_MAJOR}.${R_MINOR}-${ARCH_DETECTED}/Resources"
+echo "Rewriting static R_HOME_DIR to orthogonal path: ${ORTHOGONAL_PATH}"
+
+# Match only the static unquoted assignment (the lib/lib64 fallback lines
+# `R_HOME_DIR="/Library/${libnn}/R"` start with a double quote after the
+# `=` and so are skipped by the [^"] character class). The runtime override
+# we insert below also starts with a quote and is therefore skipped.
+sed -i '' "s|^R_HOME_DIR=/[^\"]*$|R_HOME_DIR=${ORTHOGONAL_PATH}|" "${R_HOME}/bin/R"
 
 # ── 1. Patch bin/R — dynamic R_HOME derivation ─────────────────────
 # Strategy (following r-builds PR #280): preserve the original static

--- a/macos/notarize.sh
+++ b/macos/notarize.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# notarize.sh — Submit a macOS R build to Apple's notary service.
+# Requires Developer ID signed binaries (CODESIGN_IDENTITY must have
+# been set during build) and Apple credentials.
+
+OUTPUT_DIR="${1:?Usage: notarize.sh <r-output-dir>}"
+OUTPUT_DIR="$(cd "${OUTPUT_DIR}" && pwd)"
+
+APPLE_ID="${APPLE_ID:?APPLE_ID is required}"
+APPLE_APP_PASSWORD="${APPLE_APP_PASSWORD:?APPLE_APP_PASSWORD is required}"
+APPLE_TEAM_ID="${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}"
+
+echo "=== Notarizing ${OUTPUT_DIR} ==="
+
+# xcrun notarytool requires zip, dmg, or pkg
+NOTARIZE_ZIP="${OUTPUT_DIR}-notarize.zip"
+ditto -c -k --keepParent "${OUTPUT_DIR}" "${NOTARIZE_ZIP}"
+echo "  Created notarization zip: ${NOTARIZE_ZIP}"
+
+echo "  Submitting to Apple notary service..."
+NOTARIZE_OUTPUT=$(xcrun notarytool submit "${NOTARIZE_ZIP}" \
+  --apple-id "${APPLE_ID}" \
+  --password "${APPLE_APP_PASSWORD}" \
+  --team-id "${APPLE_TEAM_ID}" \
+  --wait 2>&1) || true
+
+echo "${NOTARIZE_OUTPUT}"
+
+if echo "${NOTARIZE_OUTPUT}" | grep -q "status: Accepted"; then
+  echo "=== Notarization accepted by Apple ==="
+elif echo "${NOTARIZE_OUTPUT}" | grep -q "status: Invalid"; then
+  SUBMISSION_ID=$(echo "${NOTARIZE_OUTPUT}" | grep "  id:" | head -1 | awk '{print $2}')
+  if [ -n "${SUBMISSION_ID}" ]; then
+    echo "  Notarization rejected — fetching log:"
+    xcrun notarytool log "${SUBMISSION_ID}" \
+      --apple-id "${APPLE_ID}" \
+      --password "${APPLE_APP_PASSWORD}" \
+      --team-id "${APPLE_TEAM_ID}" 2>&1 || true
+  fi
+  echo "ERROR: Notarization failed" >&2
+  rm -f "${NOTARIZE_ZIP}"
+  exit 1
+else
+  echo "ERROR: Notarization status unknown" >&2
+  rm -f "${NOTARIZE_ZIP}"
+  exit 1
+fi
+
+rm -f "${NOTARIZE_ZIP}"

--- a/macos/patch-mach-o.sh
+++ b/macos/patch-mach-o.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+R_HOME="${1:?Usage: patch-mach-o.sh <r-home>}"
+R_HOME="$(cd "${R_HOME}" && pwd)"
+
+echo "=== Patching Mach-O binaries in ${R_HOME} ==="
+
+# Detect the hardcoded framework path from the CRAN .pkg extraction.
+# CRAN binaries embed paths like /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/...
+# We match any reference containing /Library/Frameworks/R.framework.
+FRAMEWORK_PATTERN="/Library/Frameworks/R.framework"
+
+echo "Patching references matching: ${FRAMEWORK_PATTERN}"
+
+# Non-system absolute paths that may appear in CRAN .pkg binaries.
+# /opt/R/{arch}/lib — R 4.3+ Tcl/Tk
+# /usr/local/lib — R <= 4.2 Tcl/Tk (x86_64)
+# We only rewrite these if the target library exists in our lib/ directory.
+NON_SYSTEM_PATTERNS="/opt/R/|/usr/local/(lib|opt|Cellar)/"
+
+patch_non_system_refs() {
+  local binary="$1"
+  local rpath_prefix="$2"
+  otool -L "${binary}" 2>/dev/null | awk 'NR>1{print $1}' | while read -r ref; do
+    if echo "${ref}" | grep -qE "${NON_SYSTEM_PATTERNS}"; then
+      local lib_name
+      lib_name="$(basename "${ref}")"
+      if [[ -f "${R_HOME}/lib/${lib_name}" ]]; then
+        patch_ref "${binary}" "${ref}" "${rpath_prefix}/${lib_name}"
+        echo "  $(basename "${binary}"): ${ref} -> ${rpath_prefix}/${lib_name}"
+      fi
+    fi
+  done
+}
+
+patch_id() {
+  local dylib="$1"
+  local new_id="$2"
+  install_name_tool -id "${new_id}" "${dylib}" \
+    || echo "  WARNING: failed to set ID on $(basename "${dylib}"): ${new_id}" >&2
+  echo "  ID: $(basename "${dylib}") -> ${new_id}"
+}
+
+patch_ref() {
+  local binary="$1"
+  local old_ref="$2"
+  local new_ref="$3"
+  install_name_tool -change "${old_ref}" "${new_ref}" "${binary}" \
+    || echo "  WARNING: failed to patch $(basename "${binary}"): ${old_ref}" >&2
+}
+
+add_rpath() {
+  local binary="$1"
+  local rpath="$2"
+  install_name_tool -add_rpath "${rpath}" "${binary}" 2>/dev/null || true
+}
+
+# ── 1. Patch lib/*.dylib — set @rpath IDs, @loader_path peer refs ──
+echo "--- Patching lib/*.dylib ---"
+find "${R_HOME}/lib" -maxdepth 1 -name "*.dylib" -type f 2>/dev/null | while read -r dylib; do
+  old_id=$(otool -D "${dylib}" 2>/dev/null | tail -1)
+  if echo "${old_id}" | grep -q "${FRAMEWORK_PATTERN}"; then
+    patch_id "${dylib}" "@rpath/$(basename "${old_id}")"
+  fi
+
+  otool -L "${dylib}" 2>/dev/null | awk 'NR>1{print $1}' | while read -r ref; do
+    if echo "${ref}" | grep -q "${FRAMEWORK_PATTERN}"; then
+      lib_name="$(basename "${ref}")"
+      patch_ref "${dylib}" "${ref}" "@loader_path/${lib_name}"
+      echo "  $(basename "${dylib}"): ${lib_name} -> @loader_path/${lib_name}"
+    fi
+  done
+done
+
+# Also patch non-system refs in dylibs (e.g. libtcl/libtk cross-references)
+find "${R_HOME}/lib" -maxdepth 1 -name "*.dylib" -type f 2>/dev/null | while read -r dylib; do
+  patch_non_system_refs "${dylib}" "@loader_path"
+done
+
+# Patch IDs and cross-refs of bundled Tcl/Tk dylibs (may reference /opt/R or /usr/local)
+find "${R_HOME}/lib" -maxdepth 1 -name "*.dylib" -type f 2>/dev/null | while read -r dylib; do
+  old_id=$(otool -D "${dylib}" 2>/dev/null | tail -1)
+  if echo "${old_id}" | grep -qE "${NON_SYSTEM_PATTERNS}"; then
+    patch_id "${dylib}" "@rpath/$(basename "${old_id}")"
+  fi
+done
+
+# ── 2. Patch bin/exec/R — the main executable ──────────────────────
+echo "--- Patching bin/exec/R ---"
+R_BIN="${R_HOME}/bin/exec/R"
+if [ -f "${R_BIN}" ]; then
+  otool -L "${R_BIN}" 2>/dev/null | awk 'NR>1{print $1}' | while read -r ref; do
+    if echo "${ref}" | grep -q "${FRAMEWORK_PATTERN}"; then
+      lib_name="$(basename "${ref}")"
+      patch_ref "${R_BIN}" "${ref}" "@executable_path/../../lib/${lib_name}"
+      echo "  bin/exec/R: ${lib_name} -> @executable_path/../../lib/${lib_name}"
+    fi
+  done
+  add_rpath "${R_BIN}" "@executable_path/../../lib"
+  echo "  Added LC_RPATH: @executable_path/../../lib"
+fi
+
+# ── 3. Patch bin/Rscript (if still a Mach-O binary) ────────────────
+echo "--- Patching bin/Rscript ---"
+RSCRIPT_BIN="${R_HOME}/bin/Rscript"
+# Also check for Rscript.bin (preserved original binary)
+for rscript in "${RSCRIPT_BIN}" "${RSCRIPT_BIN}.bin"; do
+  if [ -f "${rscript}" ] && file "${rscript}" | grep -q "Mach-O"; then
+    otool -L "${rscript}" 2>/dev/null | awk 'NR>1{print $1}' | while read -r ref; do
+      if echo "${ref}" | grep -q "${FRAMEWORK_PATTERN}"; then
+        lib_name="$(basename "${ref}")"
+        patch_ref "${rscript}" "${ref}" "@executable_path/../lib/${lib_name}"
+        echo "  $(basename "${rscript}"): ${lib_name} -> @executable_path/../lib/${lib_name}"
+      fi
+    done
+  fi
+done
+
+# ── 4. Patch library/*/libs/*.so — base R package extensions ───────
+echo "--- Patching library/*/libs/*.so ---"
+find "${R_HOME}/library" -name "*.so" -type f 2>/dev/null | while read -r so; do
+  otool -L "${so}" 2>/dev/null | awk 'NR>1{print $1}' | while read -r ref; do
+    if echo "${ref}" | grep -q "${FRAMEWORK_PATTERN}"; then
+      lib_name="$(basename "${ref}")"
+      patch_ref "${so}" "${ref}" "@rpath/${lib_name}"
+    fi
+  done
+  patch_non_system_refs "${so}" "@rpath"
+  add_rpath "${so}" "@loader_path/../../../lib"
+done
+echo "  Patched library .so files with @rpath refs + LC_RPATH @loader_path/../../../lib"
+
+# ── 5. Patch modules/*.so — R internal modules ─────────────────────
+echo "--- Patching modules/*.so ---"
+find "${R_HOME}/modules" -name "*.so" -type f 2>/dev/null | while read -r so; do
+  otool -L "${so}" 2>/dev/null | awk 'NR>1{print $1}' | while read -r ref; do
+    if echo "${ref}" | grep -q "${FRAMEWORK_PATTERN}"; then
+      lib_name="$(basename "${ref}")"
+      patch_ref "${so}" "${ref}" "@rpath/${lib_name}"
+    fi
+  done
+  patch_non_system_refs "${so}" "@rpath"
+  add_rpath "${so}" "@loader_path/../lib"
+done
+echo "  Patched module .so files with @rpath refs + LC_RPATH @loader_path/../lib"
+
+# ── 6. Codesign all Mach-O binaries ────────────────────────────────
+# If CODESIGN_IDENTITY is set, sign with Developer ID + hardened runtime
+# + entitlements (required for notarization). Otherwise, fall back to
+# ad-hoc signing for local development.
+
+SIGN_ID="${CODESIGN_IDENTITY:--}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTITLEMENTS="${SCRIPT_DIR}/entitlements.plist"
+
+if [ "${SIGN_ID}" != "-" ]; then
+  echo "--- Codesigning with Developer ID (hardened runtime) ---"
+  echo "  Identity: ${SIGN_ID}"
+
+  if [ ! -f "${ENTITLEMENTS}" ]; then
+    echo "ERROR: entitlements.plist not found at ${ENTITLEMENTS}" >&2
+    exit 1
+  fi
+
+  # Libraries first (innermost), then executables (outermost).
+  # Libraries are signed without entitlements; executables get entitlements.
+  CODESIGN_LIB=(codesign --force --sign "${SIGN_ID}" --timestamp --options runtime)
+  CODESIGN_EXE=(codesign --force --sign "${SIGN_ID}" --timestamp --options runtime --entitlements "${ENTITLEMENTS}")
+
+  # Sign dylibs (fail on error — broken signing means broken notarization)
+  find "${R_HOME}" -type f -name '*.dylib' -exec "${CODESIGN_LIB[@]}" {} \;
+
+  # Sign .so files (bundled packages + modules)
+  find "${R_HOME}" -type f -name '*.so' -exec "${CODESIGN_LIB[@]}" {} \;
+
+  # Sign executables with entitlements
+  [ -f "${R_BIN}" ] && "${CODESIGN_EXE[@]}" "${R_BIN}"
+  for rscript in "${RSCRIPT_BIN}" "${RSCRIPT_BIN}.bin"; do
+    if [ -f "${rscript}" ] && file "${rscript}" | grep -q "Mach-O"; then
+      "${CODESIGN_EXE[@]}" "${rscript}"
+    fi
+  done
+
+  # Catch-all: sign any remaining unsigned Mach-O files
+  find "${R_HOME}" -type f | while read -r f; do
+    if file "${f}" 2>/dev/null | grep -q "Mach-O"; then
+      codesign --verify "${f}" 2>/dev/null || "${CODESIGN_LIB[@]}" "${f}"
+    fi
+  done
+
+  echo "  Signed all binaries with hardened runtime"
+else
+  echo "--- Ad-hoc codesigning ---"
+  find "${R_HOME}" -type f \( -name '*.dylib' -o -name '*.so' \) -exec codesign -f -s - {} \; 2>/dev/null
+  [ -f "${R_BIN}" ] && codesign -f -s - "${R_BIN}" 2>/dev/null
+  for rscript in "${RSCRIPT_BIN}" "${RSCRIPT_BIN}.bin"; do
+    if [ -f "${rscript}" ] && file "${rscript}" | grep -q "Mach-O"; then
+      codesign -f -s - "${rscript}" 2>/dev/null
+    fi
+  done
+  echo "  Ad-hoc signed all Mach-O binaries"
+fi
+
+echo "=== Mach-O patching complete ==="

--- a/macos/test.sh
+++ b/macos/test.sh
@@ -131,8 +131,7 @@ fi
 
 # 11. Binary package install — exercises the .portable Rprofile hook's
 # post-install dylib fix-up (install_name_tool + codesign). Uses PPM because
-# it serves arm64 binaries for all R versions, including older ones CRAN
-# no longer hosts.
+# it serves arm64 binaries for all R versions the matrix targets (R >= 4.1).
 echo "--- Test: Binary package install ---"
 if "${R_HOME}/bin/R" --no-save --no-restore --no-init-file --no-echo -e '
   tmp <- tempdir()

--- a/macos/test.sh
+++ b/macos/test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+R_HOME="${1:?Usage: test.sh <r-home>}"
+R_HOME="$(cd "${R_HOME}" && pwd)"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+MOVED=""
+trap 'rm -rf "${MOVED}"' EXIT
+
+echo "=== Testing R installation at ${R_HOME} ==="
+
+# 1. R starts
+echo "--- Test: R starts ---"
+if "${R_HOME}/bin/R" --version 2>&1 | head -1 | grep -q "R version"; then
+  pass "R --version reports R version"
+else
+  fail "R --version did not report R version"
+fi
+
+# 2. R_HOME derivation
+echo "--- Test: R_HOME derivation ---"
+R_HOME_REPORTED=$("${R_HOME}/bin/R" --vanilla --no-echo -e 'cat(R.home())' 2>/dev/null)
+R_HOME_RESOLVED="$(cd "${R_HOME}" && pwd -P)"
+if [ "${R_HOME_REPORTED}" = "${R_HOME_RESOLVED}" ] || [ "${R_HOME_REPORTED}" = "${R_HOME}" ]; then
+  pass "R.home() matches expected R_HOME"
+else
+  fail "R.home() = '${R_HOME_REPORTED}', expected '${R_HOME}'"
+fi
+
+# 3. Rscript works
+echo "--- Test: Rscript ---"
+RSCRIPT_OUT=$("${R_HOME}/bin/Rscript" -e 'cat("hello")' 2>/dev/null)
+if [ "${RSCRIPT_OUT}" = "hello" ]; then
+  pass "Rscript executes correctly"
+else
+  fail "Rscript output: '${RSCRIPT_OUT}', expected 'hello'"
+fi
+
+# 4. Capabilities
+echo "--- Test: Capabilities ---"
+for cap in cairo png tcltk; do
+  if "${R_HOME}/bin/Rscript" -e "stopifnot(capabilities('${cap}'))" 2>/dev/null; then
+    pass "capability: ${cap}"
+  else
+    fail "capability: ${cap} not available"
+  fi
+done
+
+# 5. BLAS/LAPACK
+echo "--- Test: BLAS/LAPACK ---"
+if "${R_HOME}/bin/Rscript" -e 'stopifnot(is.numeric(solve(matrix(1:4,2,2))))' 2>/dev/null; then
+  pass "BLAS/LAPACK: matrix solve works"
+else
+  fail "BLAS/LAPACK: matrix solve failed"
+fi
+
+# 6. No hardcoded framework paths in Mach-O
+echo "--- Test: No hardcoded paths ---"
+HARDCODED_FOUND=0
+while IFS= read -r f; do
+  if file "${f}" 2>/dev/null | grep -q "Mach-O"; then
+    if otool -L "${f}" 2>/dev/null | grep -qE "/Library/Frameworks/R\.framework|/opt/(homebrew|R/)|/usr/local/(Cellar|opt|lib)"; then
+      fail "hardcoded path in ${f#${R_HOME}/}"
+      otool -L "${f}" | grep -E "/Library/Frameworks|/opt/(homebrew|R/)|/usr/local/(Cellar|opt|lib)" | head -3
+      HARDCODED_FOUND=1
+    fi
+  fi
+done < <(find "${R_HOME}" -type f \( -name '*.dylib' -o -name '*.so' -o -perm -111 \) 2>/dev/null)
+if [ "${HARDCODED_FOUND}" -eq 0 ]; then
+  pass "no hardcoded absolute paths in any Mach-O binary"
+fi
+
+# 7. Makeconf uses -lR not -framework R
+echo "--- Test: Makeconf ---"
+if [ -f "${R_HOME}/etc/Makeconf" ]; then
+  LIBR=$(grep "^LIBR " "${R_HOME}/etc/Makeconf" 2>/dev/null || true)
+  if echo "${LIBR}" | grep -q "\-lR"; then
+    pass "Makeconf LIBR uses -lR"
+  else
+    fail "Makeconf LIBR: ${LIBR}"
+  fi
+  if echo "${LIBR}" | grep -q "framework"; then
+    fail "Makeconf LIBR still references -framework"
+  fi
+fi
+
+# 8. Works without DYLD vars
+echo "--- Test: No DYLD vars needed ---"
+if env -u DYLD_LIBRARY_PATH -u DYLD_FALLBACK_LIBRARY_PATH \
+    "${R_HOME}/bin/Rscript" -e 'cat("no DYLD OK")' 2>/dev/null | grep -q "no DYLD OK"; then
+  pass "works without DYLD_* variables"
+else
+  fail "requires DYLD_* variables"
+fi
+
+# 9. Relocatability
+echo "--- Test: Relocatability ---"
+MOVED="/tmp/r-relocated-$$"
+cp -R "${R_HOME}" "${MOVED}"
+MOVED_HOME=$("${MOVED}/bin/Rscript" -e 'cat(R.home())' 2>/dev/null)
+MOVED_RESOLVED="$(cd "${MOVED}" && pwd -P)"
+if [ "${MOVED_HOME}" = "${MOVED_RESOLVED}" ] || [ "${MOVED_HOME}" = "${MOVED}" ]; then
+  pass "relocated R reports correct new R_HOME"
+else
+  fail "relocated R.home() = '${MOVED_HOME}', expected '${MOVED}'"
+fi
+rm -rf "${MOVED}"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if [ "${FAIL}" -gt 0 ]; then exit 1; fi

--- a/macos/test.sh
+++ b/macos/test.sh
@@ -130,7 +130,29 @@ else
   fail "source package compilation failed (may need Xcode CLT)"
 fi
 
-# 11. Binary package install — exercises the .portable Rprofile hook's
+# 11. Base Rprofile hooks survive --vanilla — the whole reason we install
+# them in library/base/R/Rprofile rather than etc/Rprofile.site (which
+# --vanilla skips) is so they work in every launch context including
+# IDE-embedded R sessions. This test asserts:
+#   - default CRAN repo is p3m.dev (PPM)
+#   - .portable environment is attached at position 2 above package:utils
+echo "--- Test: Base Rprofile hooks under --vanilla ---"
+HOOK_OUT=$("${R_HOME}/bin/R" --vanilla --no-echo -e '
+  cat("repo=", getOption("repos")["CRAN"], "\n", sep="")
+  cat("portable_attached=", ".portable" %in% search(), "\n", sep="")
+' 2>/dev/null)
+if echo "${HOOK_OUT}" | grep -q '^repo=https://p3m\.dev/'; then
+  pass "default CRAN repo set to p3m.dev under --vanilla"
+else
+  fail "default CRAN repo not p3m.dev under --vanilla: $(echo "${HOOK_OUT}" | grep '^repo=')"
+fi
+if echo "${HOOK_OUT}" | grep -q '^portable_attached=TRUE'; then
+  pass ".portable env attached under --vanilla"
+else
+  fail ".portable env not attached under --vanilla: $(echo "${HOOK_OUT}" | grep '^portable_attached=')"
+fi
+
+# 12. Binary package install — exercises the .portable Rprofile hook's
 # post-install dylib fix-up (install_name_tool + codesign).
 #
 # Use CRAN + PPM together so install.packages picks whichever has the

--- a/macos/test.sh
+++ b/macos/test.sh
@@ -14,9 +14,10 @@ trap 'rm -rf "${MOVED}"' EXIT
 
 echo "=== Testing R installation at ${R_HOME} ==="
 
-# 1. R starts
+# 1. R starts — released R prints "R version X.Y.Z", devel prints
+# "R Under development (unstable) ..."; match both.
 echo "--- Test: R starts ---"
-if "${R_HOME}/bin/R" --version 2>&1 | head -1 | grep -q "R version"; then
+if "${R_HOME}/bin/R" --version 2>&1 | head -1 | grep -qE "^R (version|Under development)"; then
   pass "R --version reports R version"
 else
   fail "R --version did not report R version"
@@ -130,12 +131,22 @@ else
 fi
 
 # 11. Binary package install — exercises the .portable Rprofile hook's
-# post-install dylib fix-up (install_name_tool + codesign). Uses PPM because
-# it serves arm64 binaries for all R versions the matrix targets (R >= 4.1).
+# post-install dylib fix-up (install_name_tool + codesign).
+#
+# Use CRAN + PPM together so install.packages picks whichever has the
+# binary for this R version × platform combo:
+#   - CRAN covers R 4.2+ big-sur-arm64, 4.3+ big-sur-x86_64, 4.6 sonoma-arm64,
+#     plus old unified macosx/contrib/4.1/ (but only for x86_64 pkgType).
+#   - PPM covers R 4.1-4.5 on both arches via legacy paths.
+#   - Neither has R 3.x (matrix skips those).
+# R resolves Contrib URLs via .Platform$pkgType, so passing both repos lets
+# install.packages find the package in whichever serves it.
 echo "--- Test: Binary package install ---"
 if "${R_HOME}/bin/R" --no-save --no-restore --no-init-file --no-echo -e '
   tmp <- tempdir()
-  install.packages("jsonlite", repos="https://packagemanager.posit.co/cran/latest", type="binary", lib=tmp, quiet=TRUE)
+  repos <- c(CRAN = "https://cloud.r-project.org",
+             PPM  = "https://packagemanager.posit.co/cran/latest")
+  install.packages("jsonlite", repos=repos, type="binary", lib=tmp, quiet=TRUE)
   stopifnot(requireNamespace("jsonlite", lib.loc=tmp))
   cat("binary install OK\n")
 ' 2>/dev/null | grep -q "binary install OK"; then

--- a/macos/test.sh
+++ b/macos/test.sh
@@ -64,9 +64,9 @@ echo "--- Test: No hardcoded paths ---"
 HARDCODED_FOUND=0
 while IFS= read -r f; do
   if file "${f}" 2>/dev/null | grep -q "Mach-O"; then
-    if otool -L "${f}" 2>/dev/null | grep -qE "/Library/Frameworks/R\.framework|/opt/(homebrew|R/)|/usr/local/(Cellar|opt|lib)"; then
+    if otool -L "${f}" 2>/dev/null | grep -qE "/tmp/r-(build|install)|/Library/Frameworks/R\.framework|/opt/(homebrew|R/)|/usr/local/(Cellar|opt|lib)"; then
       fail "hardcoded path in ${f#${R_HOME}/}"
-      otool -L "${f}" | grep -E "/Library/Frameworks|/opt/(homebrew|R/)|/usr/local/(Cellar|opt|lib)" | head -3
+      otool -L "${f}" | grep -E "/tmp/r-(build|install)|/Library/Frameworks|/opt/(homebrew|R/)|/usr/local/(Cellar|opt|lib)" | head -3
       HARDCODED_FOUND=1
     fi
   fi
@@ -98,18 +98,52 @@ else
   fail "requires DYLD_* variables"
 fi
 
-# 9. Relocatability
+# 9. Relocatability (R and Rscript both exercised at the new location)
 echo "--- Test: Relocatability ---"
 MOVED="/tmp/r-relocated-$$"
 cp -R "${R_HOME}" "${MOVED}"
-MOVED_HOME=$("${MOVED}/bin/Rscript" -e 'cat(R.home())' 2>/dev/null)
+MOVED_HOME=$("${MOVED}/bin/R" --vanilla --no-echo -e 'cat(R.home())' 2>/dev/null)
 MOVED_RESOLVED="$(cd "${MOVED}" && pwd -P)"
 if [ "${MOVED_HOME}" = "${MOVED_RESOLVED}" ] || [ "${MOVED_HOME}" = "${MOVED}" ]; then
   pass "relocated R reports correct new R_HOME"
+  if "${MOVED}/bin/Rscript" -e 'cat("relocated Rscript OK\n")' 2>/dev/null | grep -q "relocated Rscript OK"; then
+    pass "relocated Rscript works"
+  else
+    fail "relocated Rscript failed"
+  fi
 else
   fail "relocated R.home() = '${MOVED_HOME}', expected '${MOVED}'"
 fi
 rm -rf "${MOVED}"
+
+# 10. Source package compilation — exercises Makeconf, headers, linker flags
+echo "--- Test: Source package compilation ---"
+if "${R_HOME}/bin/R" --vanilla --no-echo -e '
+  tmp <- tempdir()
+  install.packages("jsonlite", repos="https://cloud.r-project.org", type="source", lib=tmp, quiet=TRUE)
+  stopifnot(requireNamespace("jsonlite", lib.loc=tmp))
+  cat("source install OK\n")
+' 2>/dev/null | grep -q "source install OK"; then
+  pass "source package compilation (jsonlite)"
+else
+  fail "source package compilation failed (may need Xcode CLT)"
+fi
+
+# 11. Binary package install — exercises the .portable Rprofile hook's
+# post-install dylib fix-up (install_name_tool + codesign). Uses PPM because
+# it serves arm64 binaries for all R versions, including older ones CRAN
+# no longer hosts.
+echo "--- Test: Binary package install ---"
+if "${R_HOME}/bin/R" --no-save --no-restore --no-init-file --no-echo -e '
+  tmp <- tempdir()
+  install.packages("jsonlite", repos="https://packagemanager.posit.co/cran/latest", type="binary", lib=tmp, quiet=TRUE)
+  stopifnot(requireNamespace("jsonlite", lib.loc=tmp))
+  cat("binary install OK\n")
+' 2>/dev/null | grep -q "binary install OK"; then
+  pass "binary package install (jsonlite)"
+else
+  fail "binary package install failed"
+fi
 
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="

--- a/macos/test.sh
+++ b/macos/test.sh
@@ -23,6 +23,20 @@ else
   fail "R --version did not report R version"
 fi
 
+# 1b. bin/R static R_HOME_DIR= line is well-formed for IDE discovery.
+# Positron's getRHomePathDarwin parses this line as text and validates the
+# resulting path on disk, so a malformed slot (e.g. ".-arm64" from a broken
+# version-introspection fallback) would silently break IDE discovery even
+# though CLI execution still works via the runtime override on the next line.
+echo "--- Test: static R_HOME_DIR= slot is well-formed ---"
+STATIC_LINE=$(grep '^R_HOME_DIR=' "${R_HOME}/bin/R" | head -1)
+SLOT_RE='^R_HOME_DIR=/Library/Frameworks/R\.framework/Versions/(devel|patched|next|[0-9]+\.[0-9]+)-(arm64|x86_64)/Resources$'
+if [[ "${STATIC_LINE}" =~ ${SLOT_RE} ]]; then
+  pass "static R_HOME_DIR= slot: ${STATIC_LINE#R_HOME_DIR=/Library/Frameworks/R.framework/Versions/}"
+else
+  fail "static R_HOME_DIR= is malformed: ${STATIC_LINE}"
+fi
+
 # 2. R_HOME derivation
 echo "--- Test: R_HOME derivation ---"
 R_HOME_REPORTED=$("${R_HOME}/bin/R" --vanilla --no-echo -e 'cat(R.home())' 2>/dev/null)

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,172 @@
+# Portable Windows R builds
+
+This directory builds portable, relocatable Windows R distributions by extracting the official CRAN `.exe` installer without running it. The output is a `.zip` that can be extracted to any directory and run from there — no admin rights, no Inno Setup installer dialog, no registry changes, and no side effects on the system R installation.
+
+## Overview
+
+Unlike macOS (which needs a Mach-O patching pipeline because CRAN binaries embed `/Library/Frameworks/R.framework/...` paths), Windows R from CRAN is already largely self-contained: all DLL dependencies are bundled inside `bin\x64\`, paths in `etc\` files use `${R_HOME}` substitution, and `R.exe` discovers its own home directory at runtime via `GetModuleFileName`. As a result, the only post-processing needed is:
+
+1. Download the CRAN `.exe` installer.
+2. Extract it with [`innoextract`](https://github.com/dscharrer/innoextract) (no admin, no install). Falls back to `/VERYSILENT /CURRENTUSER` silent install if `innoextract` is unavailable.
+3. Clean up `unins*` installer artifacts.
+4. Append portable-R hooks (default CRAN repo, portable site-library) to the base Rprofile.
+5. Package as `R-{version}-windows.zip`.
+
+No DLL rewriting, no rpath fix-up, no codesigning. Output: a self-contained zip where `bin\R.exe --version` works regardless of where it's extracted.
+
+## Files
+
+```
+windows/
+  build.ps1   # Orchestrator: download .exe → extract → configure → zip
+  test.ps1    # Integration tests (relocatability, Rprofile hooks, package install)
+```
+
+## Use cases
+
+Portable Windows builds are useful for:
+
+- **Version managers** (rig, custom scripts) that install multiple R versions side-by-side under user-chosen directories.
+- **CI / cloud runners** where you want a specific R version without an admin install.
+- **Air-gapped systems** — copy the zip to a machine without internet access.
+- **Developer environments** where switching between R versions for a project shouldn't require re-running the Inno Setup installer.
+
+## Limitations
+
+- **x86_64 only.** Windows arm64 R builds exist but the support is too new to base a portable distribution on. We can revisit when CRAN's Windows arm64 binaries are stable.
+- **No Rtools bundled.** Compiling R packages from source still requires installing Rtools separately (matched to the R minor version, e.g. Rtools 4.4 for R 4.4.x).
+- **CRAN-bundled libraries pin at build time.** Whatever DLLs ship in the `.exe` installer are what end users get; updating requires rebuilding from a newer CRAN release.
+
+## What gets built
+
+x86_64 only, R 3.6.3 onwards. The build matrix in `build-windows.yml` defaults to the last 5 R minor versions plus R 3.6.3 and `devel`. R 3.6.3 is included as a long-term compatibility anchor matching the existing Linux builds.
+
+Output paths on the CDN follow the existing pattern:
+
+```
+cdn.posit.co/r/windows/R-{version}-windows.zip
+```
+
+## How it works
+
+### Phase 1 — Download (`build.ps1`)
+
+CRAN's Windows installer URL has three tiers, probed newest-first:
+
+| Tier | URL pattern |
+|---|---|
+| Current release | `cloud.r-project.org/bin/windows/base/R-{ver}-win.exe` |
+| Old releases (still on main CDN) | `cloud.r-project.org/bin/windows/base/old/{ver}/R-{ver}-win.exe` |
+| Retired releases | `cran-archive.r-project.org/bin/windows/base/old/{ver}/R-{ver}-win.exe` |
+
+Devel uses its own stable URL: `cloud.r-project.org/bin/windows/base/R-devel-win.exe`. The download is cached at `$env:TEMP\R-{ver}-win.exe` and reused on re-runs of the same version (~80 MB per installer adds up otherwise).
+
+`$ProgressPreference = 'SilentlyContinue'` is set globally in the script. PowerShell 5.1's progress bar slows `Invoke-WebRequest` and `Expand-Archive` by 50–100x when running non-interactively (e.g. on GitHub Actions). Without this, a 30-second build takes 25 minutes.
+
+### Phase 2 — Extraction (`build.ps1`)
+
+The installer is an Inno Setup `.exe`. Two extraction methods, in order:
+
+1. **Primary: `innoextract`.** Unpacks the embedded payload directly without running the installer. No admin, no registry, no side effects. We try `Get-Command innoextract` first; if it's not on `PATH`, we install it via `choco install innoextract` if Chocolatey is available; otherwise we download the [official 1.9 Windows release](https://github.com/dscharrer/innoextract/releases/download/1.9/innoextract-1.9-windows.zip) directly. innoextract drops files into `{StagingDir}/app/` — we move that up to `{StagingDir}` and remove the empty `app/` directory.
+
+2. **Fallback: silent install.** If `innoextract` extraction returns non-zero (sometimes happens on very new R versions before innoextract has been updated), we fall back to running the Inno Setup installer with `/VERYSILENT /CURRENTUSER /DIR=<StagingDir>`. This is a real install — the installer process runs to completion — but `/CURRENTUSER` keeps it out of `Program Files` and `/DIR` overrides the default install location. The installer leaves `unins*.{exe,dat,msg}` files behind which we delete in Phase 3.
+
+The 10-minute timeout on the silent install is intentional — Inno Setup occasionally hangs on certain Windows 11 builds, and a stuck CI job is worse than a failed one.
+
+### Phase 3 — Cleanup (`build.ps1`)
+
+Remove `unins*.exe`, `unins*.dat`, `unins*.msg`, and any `*.iss` files. These are installer-only artifacts from the silent-install fallback and serve no purpose at runtime.
+
+### Phase 4 — Portable-R hooks (`build.ps1`)
+
+The script appends two `local()` blocks to **`library\base\R\Rprofile`** (the base Rprofile, sourced by R itself during startup). It is **not** written to `etc\Rprofile.site` — that file is skipped under `R --vanilla` and bypassed by IDEs that load `R.dll` directly without going through `R.exe`. The base Rprofile is sourced in every launch context. This matches the manylinux PR #280 and macOS approach.
+
+The two hooks installed:
+
+1. **Portable site-library** — adds `Sys.getenv("R_HOME")/site-library` to `.libPaths()` so user packages install into the R folder by default. Two consequences:
+   - When you copy or move the R-{version} folder, your installed packages travel with it.
+   - The default `R_LIBS_USER` location (`Documents\R\win-library\X.Y`) is OS-version-dependent; pinning to `R_HOME/site-library` is more predictable for portable use.
+   - If `R_HOME` is on a read-only filesystem (rare for portable use), `dir.create` silently fails and we leave `.libPaths()` unchanged. R falls back to the standard user library.
+
+2. **Default CRAN repo** → `https://p3m.dev/cran/latest` (Posit Public Package Manager). Provides binary R packages for Windows for the same R version matrix this build targets.
+
+The append is done with `[System.IO.File]::AppendAllText` rather than `Add-Content` because `Add-Content` adds CRLF line endings via `$OutputEncoding`, which would mix with the LF-only line endings in CRAN's base Rprofile. R reads either fine, but mixing is ugly.
+
+### Phase 5 — Packaging (`build.ps1`)
+
+`Compress-Archive` to a `.zip` named `R-{version}-windows.zip`. The staging tree is removed in a `finally` block, but the cached `.exe` installer at `$env:TEMP\R-{ver}-win.exe` is intentionally preserved so re-runs of the same version skip the download.
+
+`$OutputDir` handling: PowerShell's `Join-Path` naively concatenates even when the second argument is rooted, producing e.g. `D:\repo\D:\temp\out`. CI passes a rooted `$env:RUNNER_TEMP\r-builds-output`, so we test `[System.IO.Path]::IsPathRooted($OutputDir)` and use `$OutputDir` directly when it's already rooted; otherwise we resolve relative to the repo root.
+
+## IDE compatibility (RStudio, Positron)
+
+Both RStudio and Positron on Windows discover R installations by parsing files in the install tree (registry-based discovery is a fallback). Two requirements:
+
+- **`bin\R.exe` and `bin\x64\R.exe` must both exist.** Older RStudio versions look for `bin\x64\R.exe` specifically (R 4.1 and earlier had separate 32-bit and 64-bit builds in `bin\i386\` and `bin\x64\`); newer RStudio also accepts `bin\R.exe` in the unified layout used since R 4.2. The CRAN installer's payload covers both layouts depending on the R version, and our extraction preserves what CRAN ships.
+- **Startup hooks must live in the base Rprofile** (`library\base\R\Rprofile`), not in `etc\Rprofile.site`. `etc\Rprofile.site` is skipped under `R --vanilla` and may be skipped or sourced at an unexpected time when the IDE embeds R via `R.dll`. The base Rprofile is sourced unconditionally during R's own startup sequence.
+
+For RStudio specifically, the IDE wraps `install.packages()` with its own override at startup. Unlike macOS, no `.so` fix-up wrapper is needed on Windows — CRAN binary `.zip` packages are already self-contained — so the IDE wrapping is harmless here.
+
+## R < 4.2 caveat: Rfe.exe argv quoting bug
+
+On R < 4.2, `bin\R.exe` and `bin\Rscript.exe` are `Rfe.exe` launchers (`src/gnuwin32/front-ends/Rfe.c`) that re-assemble `argv` into a `cmd.exe` command string without escaping internal quotes. Result: `Rscript -e "cat('hello')"` silently truncates the expression at the first quote.
+
+The real binaries live at `bin\x64\R.exe` and `bin\x64\Rterm.exe` in those older versions. `test.ps1` works around this by:
+
+1. Preferring `bin\x64\R.exe` over `bin\R.exe` when both exist.
+2. Writing the R expression to a temp file and using `R.exe -f <file>` instead of `R.exe -e <string>`.
+
+R 4.2 and later put the real binaries in `bin\` directly and don't have this bug, but the temp-file approach works on all versions so the test code uses it unconditionally.
+
+## Adding support for a new R minor version
+
+Most new R minor versions need no code changes. The build matrix in `build-windows.yml` resolves `last-5,3.6.3,devel` via `manage_r_versions.py`, so a new release version is automatically picked up.
+
+Two cases require maintenance:
+
+- **CRAN moves an old release off the main mirror to `cran-archive.r-project.org`.** Already handled by the third candidate URL — no action needed unless CRAN changes the path layout.
+- **Inno Setup ships a format change innoextract doesn't yet support.** The silent-install fallback covers this. If innoextract starts failing on every new R release, watch for [innoextract releases](https://github.com/dscharrer/innoextract/releases) and update the pinned `1.9` reference to the newest version.
+
+## Build and test commands
+
+```powershell
+# Build R for Windows
+$env:R_VERSION = "4.4.3"; make build-r-windows
+
+# Run integration tests against a built zip (extracted automatically by Make)
+$env:R_VERSION = "4.4.3"; make test-r-windows
+
+# Direct invocation (no Make)
+.\windows\build.ps1 -Version 4.4.3 -OutputDir output
+Expand-Archive output\R-4.4.3-windows.zip -DestinationPath output\
+.\windows\test.ps1 -RHome output\R-4.4.3
+```
+
+The Makefile's `build-r-windows` target also extracts the zip before running tests so `make build-r-windows && make test-r-windows` works locally.
+
+## What the tests verify
+
+`test.ps1` covers:
+
+- R starts and reports its version.
+- `R.home()` matches the extracted directory (proves runtime path discovery survives extraction to an arbitrary location).
+- R evaluates expressions from a `-f <file>` invocation (sidesteps the R < 4.2 Rfe.exe argv-quoting bug).
+- Relocatability — copy R to `$env:TEMP\r-relocated-test`, verify R still starts and produces correct stdout there.
+- Base Rprofile hooks survive `R --vanilla`: default CRAN repo is `p3m.dev`, portable site-library is on `.libPaths()`.
+- Binary package install via `install.packages("jsonlite")` against PPM. CRAN's `bin/windows/contrib/3.6/` is empty (CRAN only retains the installer for old R, not the compiled packages); PPM serves Windows binaries for every R minor from 3.6 onward.
+
+## Troubleshooting
+
+**`Rscript -e "expr"` silently truncates the expression** — you're on R < 4.2 and hitting the Rfe.exe argv bug. Use `Rscript -f <file>` or upgrade to R 4.2+.
+
+**Extraction fails with `innoextract: not a supported Inno Setup version`** — innoextract is older than the Inno Setup version CRAN used. The silent-install fallback should kick in automatically; if not, force it by removing innoextract from `PATH` before running the build script.
+
+**R can't find packages after the install tree is moved** — verify the portable site-library hook ran. Check `tail -1 library\base\R\Rprofile` (or `Get-Content library\base\R\Rprofile -Tail 20`) and confirm the `local_lib <- file.path(Sys.getenv("R_HOME"), "site-library")` block is present.
+
+**Build is extremely slow on PowerShell 5.1** — `$ProgressPreference = 'SilentlyContinue'` is set in `build.ps1`, but if you're invoking the script with `-NoProfile` and overriding the variable, restore it. The PS 5.1 progress bar is a known bottleneck for `Invoke-WebRequest` and `Expand-Archive`.
+
+## Related projects
+
+- **[portable-r/portable-r-windows](https://github.com/portable-r/portable-r-windows)** — independent prototype of the same approach. Used as a reference; this pipeline shares its core idea (CRAN .exe extraction + minimal post-process) but adds CI integration, the innoextract+silent-install fallback chain, and the base-Rprofile hook design.
+- **[`macos/README.md`](../macos/README.md)** — companion macOS portable builds. Same goals, much heavier post-processing because CRAN macOS binaries embed framework paths.
+- **[`builder/portable-r/`](../builder/portable-r/README.md)** — the Linux portable builds. Different mechanism (compile from source + bundle libs via `delocate_r.py`) but the same goal of relocatable, distribution-independent R.

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -1,0 +1,158 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Version,
+
+    [string]$OutputDir = "output"
+)
+
+$ErrorActionPreference = "Stop"
+$StagingDir = "$env:TEMP\r-build\R-$Version"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent $ScriptDir
+
+try {
+
+Write-Host "=== Building R $Version for Windows ==="
+
+Write-Host "--- Downloading CRAN installer ---"
+$InstallerPath = "$env:TEMP\R-$Version-win.exe"
+if (Test-Path $InstallerPath) {
+    Write-Host "  Using cached installer: $InstallerPath"
+} else {
+    if ($Version -eq "devel") {
+        $InstallerUrl = "https://cloud.r-project.org/bin/windows/base/R-devel-win.exe"
+        Write-Host "  Downloading: $InstallerUrl"
+        Invoke-WebRequest -Uri $InstallerUrl -OutFile $InstallerPath -UseBasicParsing
+    } else {
+        $CurrentUrl = "https://cloud.r-project.org/bin/windows/base/R-$Version-win.exe"
+        $ArchiveUrl = "https://cloud.r-project.org/bin/windows/base/old/$Version/R-$Version-win.exe"
+        Write-Host "  Trying current URL: $CurrentUrl"
+        try {
+            Invoke-WebRequest -Uri $CurrentUrl -OutFile $InstallerPath -UseBasicParsing
+            $InstallerUrl = $CurrentUrl
+        } catch {
+            Write-Host "  Current URL failed, trying archive URL: $ArchiveUrl"
+            Invoke-WebRequest -Uri $ArchiveUrl -OutFile $InstallerPath -UseBasicParsing
+            $InstallerUrl = $ArchiveUrl
+        }
+    }
+    Write-Host "  Downloaded: $InstallerPath"
+}
+
+Write-Host "--- Extracting installer ---"
+if (Test-Path $StagingDir) { Remove-Item $StagingDir -Recurse -Force }
+New-Item -ItemType Directory -Path $StagingDir -Force | Out-Null
+
+$extracted = $false
+
+# Primary method: innoextract (fast, no side effects, no admin)
+$innoextract = Get-Command innoextract -ErrorAction SilentlyContinue
+if (-not $innoextract) {
+    # Try choco first
+    $choco = Get-Command choco -ErrorAction SilentlyContinue
+    if ($choco) {
+        Write-Host "  Installing innoextract via choco..."
+        choco install innoextract -y --no-progress 2>&1 | Out-Null
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+        $innoextract = Get-Command innoextract -ErrorAction SilentlyContinue
+    }
+    # Fallback: download innoextract from GitHub releases
+    if (-not $innoextract) {
+        Write-Host "  Downloading innoextract from GitHub..."
+        $innoDir = Join-Path $env:TEMP "innoextract"
+        New-Item -ItemType Directory -Path $innoDir -Force | Out-Null
+        $innoZip = Join-Path $env:TEMP "innoextract.zip"
+        Invoke-WebRequest -Uri "https://github.com/dscharrer/innoextract/releases/download/1.9/innoextract-1.9-windows.zip" -OutFile $innoZip -UseBasicParsing
+        Expand-Archive -Path $innoZip -DestinationPath $innoDir -Force
+        $innoExe = Get-ChildItem -Path $innoDir -Recurse -Filter "innoextract.exe" | Select-Object -First 1
+        if ($innoExe) {
+            $innoextract = $innoExe  # use the FileInfo object directly
+        }
+    }
+}
+
+if ($innoextract) {
+    Write-Host "  Extracting with innoextract..."
+    $innoPath = if ($innoextract -is [System.IO.FileInfo]) { $innoextract.FullName } else { $innoextract.Source }
+    $output = & $innoPath -d $StagingDir --extract $InstallerPath 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $AppDir = Join-Path $StagingDir "app"
+        if (Test-Path $AppDir) {
+            Get-ChildItem $AppDir | Move-Item -Destination $StagingDir -Force
+            Remove-Item $AppDir -Force -ErrorAction SilentlyContinue
+        }
+        $extracted = $true
+        Write-Host "  Extracted with innoextract to: $StagingDir"
+    } else {
+        Write-Host "  innoextract failed (exit $LASTEXITCODE), falling back to silent install..."
+        if (Test-Path $StagingDir) { Remove-Item $StagingDir -Recurse -Force }
+        New-Item -ItemType Directory -Path $StagingDir -Force | Out-Null
+    }
+}
+
+# Fallback: run the Inno Setup installer silently (aligns with portable-r-windows)
+if (-not $extracted) {
+    Write-Host "  Using silent install fallback (/VERYSILENT /DIR=...)..."
+    $proc = Start-Process -PassThru -FilePath $InstallerPath -ArgumentList @(
+        "/VERYSILENT",
+        "/SUPPRESSMSGBOXES",
+        "/CURRENTUSER",
+        "/NOICONS",
+        "/DIR=$StagingDir"
+    )
+    $finished = $proc.WaitForExit(600000)  # 10 minute timeout
+    if (-not $finished) {
+        $proc.Kill()
+        throw "Silent install timed out after 10 minutes"
+    }
+    if ($proc.ExitCode -ne 0) {
+        throw "Installer exited with code $($proc.ExitCode)"
+    }
+    # Clean up installer artifacts left by silent install
+    Remove-Item -Path (Join-Path $StagingDir "unins*.exe") -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path (Join-Path $StagingDir "unins*.dat") -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path (Join-Path $StagingDir "unins*.msg") -Force -ErrorAction SilentlyContinue
+    Write-Host "  Extracted via silent install to: $StagingDir"
+}
+
+Write-Host "--- Cleaning up installer artifacts ---"
+Get-ChildItem $StagingDir -Filter "unins*" | Remove-Item -Force -ErrorAction SilentlyContinue
+Get-ChildItem $StagingDir -Filter "*.iss" | Remove-Item -Force -ErrorAction SilentlyContinue
+Write-Host "  Removed installer artifacts"
+
+Write-Host "--- Configuring Rprofile.site ---"
+$RprofilePath = Join-Path $StagingDir "etc\Rprofile.site"
+
+$RprofileContent = @"
+# Rprofile.site -- rstudio/r-builds portable R distribution
+
+# Portable package library: install packages within this R directory
+local_lib <- file.path(Sys.getenv("R_HOME"), "site-library")
+if (!dir.exists(local_lib)) dir.create(local_lib, recursive = TRUE)
+.libPaths(c(local_lib, .libPaths()))
+
+# Default repository: Posit Package Manager
+local({
+  r <- getOption("repos")
+  r["CRAN"] <- "https://packagemanager.posit.co/cran/latest"
+  options(repos = r)
+})
+"@
+[System.IO.File]::WriteAllText($RprofilePath, $RprofileContent, (New-Object System.Text.UTF8Encoding $false))
+Write-Host "  Rprofile.site configured"
+
+Write-Host "--- Packaging ---"
+$OutputPath = Join-Path $RepoRoot $OutputDir
+if (-not (Test-Path $OutputPath)) { New-Item -ItemType Directory -Path $OutputPath | Out-Null }
+$ZipName = "R-$Version-windows.zip"
+$ZipPath = Join-Path $OutputPath $ZipName
+
+if (Test-Path $ZipPath) { Remove-Item $ZipPath }
+Compress-Archive -Path $StagingDir -DestinationPath $ZipPath
+Write-Host "=== Package created: $ZipPath ==="
+Get-Item $ZipPath | Select-Object Name, Length
+
+} finally {
+    Remove-Item $InstallerPath -Force -ErrorAction SilentlyContinue
+    Remove-Item $StagingDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -22,24 +22,36 @@ $InstallerPath = "$env:TEMP\R-$Version-win.exe"
 if (Test-Path $InstallerPath) {
     Write-Host "  Using cached installer: $InstallerPath"
 } else {
+    # URL locations, tried newest-first:
+    #   current       — cloud.r-project.org/bin/windows/base/R-$Version-win.exe
+    #   main archive  — cloud.r-project.org/bin/windows/base/old/$Version/...
+    #   cran-archive  — cran-archive.r-project.org/bin/windows/base/old/$Version/...
+    # devel uses its own stable URL; all other versions walk the list.
     if ($Version -eq "devel") {
-        $InstallerUrl = "https://cloud.r-project.org/bin/windows/base/R-devel-win.exe"
-        Write-Host "  Downloading: $InstallerUrl"
-        Invoke-WebRequest -Uri $InstallerUrl -OutFile $InstallerPath -UseBasicParsing
+        $candidates = @("https://cloud.r-project.org/bin/windows/base/R-devel-win.exe")
     } else {
-        $CurrentUrl = "https://cloud.r-project.org/bin/windows/base/R-$Version-win.exe"
-        $ArchiveUrl = "https://cloud.r-project.org/bin/windows/base/old/$Version/R-$Version-win.exe"
-        Write-Host "  Trying current URL: $CurrentUrl"
+        $candidates = @(
+            "https://cloud.r-project.org/bin/windows/base/R-$Version-win.exe",
+            "https://cloud.r-project.org/bin/windows/base/old/$Version/R-$Version-win.exe",
+            "https://cran-archive.r-project.org/bin/windows/base/old/$Version/R-$Version-win.exe"
+        )
+    }
+
+    $InstallerUrl = $null
+    foreach ($url in $candidates) {
+        Write-Host "  Trying: $url"
         try {
-            Invoke-WebRequest -Uri $CurrentUrl -OutFile $InstallerPath -UseBasicParsing
-            $InstallerUrl = $CurrentUrl
+            Invoke-WebRequest -Uri $url -OutFile $InstallerPath -UseBasicParsing
+            $InstallerUrl = $url
+            break
         } catch {
-            Write-Host "  Current URL failed, trying archive URL: $ArchiveUrl"
-            Invoke-WebRequest -Uri $ArchiveUrl -OutFile $InstallerPath -UseBasicParsing
-            $InstallerUrl = $ArchiveUrl
+            Write-Host "    -> $($_.Exception.Message)"
         }
     }
-    Write-Host "  Downloaded: $InstallerPath"
+    if (-not $InstallerUrl) {
+        throw "Could not download R $Version installer from any known URL"
+    }
+    Write-Host "  Downloaded: $InstallerUrl"
 }
 
 Write-Host "--- Extracting installer ---"

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -157,7 +157,15 @@ local({
 Write-Host "  Rprofile.site configured"
 
 Write-Host "--- Packaging ---"
-$OutputPath = Join-Path $RepoRoot $OutputDir
+# PowerShell's Join-Path naively concatenates even when the second arg is
+# absolute, producing e.g. 'D:\repo\D:\temp\out'. Handle both cases: use
+# $OutputDir directly when it's already rooted (CI passes $RUNNER_TEMP), and
+# resolve relative to the repo for local 'output/' usage.
+if ([System.IO.Path]::IsPathRooted($OutputDir)) {
+    $OutputPath = $OutputDir
+} else {
+    $OutputPath = Join-Path $RepoRoot $OutputDir
+}
 if (-not (Test-Path $OutputPath)) { New-Item -ItemType Directory -Path $OutputPath | Out-Null }
 $ZipName = "R-$Version-windows.zip"
 $ZipPath = Join-Path $OutputPath $ZipName

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -6,6 +6,9 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+# Suppress the PS 5.1 progress bar; it slows Invoke-WebRequest / Expand-Archive
+# by 50-100x when running non-interactively.
+$ProgressPreference = "SilentlyContinue"
 $StagingDir = "$env:TEMP\r-build\R-$Version"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $RepoRoot = Split-Path -Parent $ScriptDir
@@ -66,15 +69,15 @@ if (-not $innoextract) {
         Expand-Archive -Path $innoZip -DestinationPath $innoDir -Force
         $innoExe = Get-ChildItem -Path $innoDir -Recurse -Filter "innoextract.exe" | Select-Object -First 1
         if ($innoExe) {
-            $innoextract = $innoExe  # use the FileInfo object directly
+            $env:PATH = "$($innoExe.DirectoryName);$env:PATH"
         }
+        $innoextract = Get-Command innoextract -ErrorAction SilentlyContinue
     }
 }
 
 if ($innoextract) {
     Write-Host "  Extracting with innoextract..."
-    $innoPath = if ($innoextract -is [System.IO.FileInfo]) { $innoextract.FullName } else { $innoextract.Source }
-    $output = & $innoPath -d $StagingDir --extract $InstallerPath 2>&1
+    $output = & innoextract -d $StagingDir --extract $InstallerPath 2>&1
     if ($LASTEXITCODE -eq 0) {
         $AppDir = Join-Path $StagingDir "app"
         if (Test-Path $AppDir) {
@@ -153,6 +156,8 @@ Write-Host "=== Package created: $ZipPath ==="
 Get-Item $ZipPath | Select-Object Name, Length
 
 } finally {
-    Remove-Item $InstallerPath -Force -ErrorAction SilentlyContinue
+    # Keep the installer cached at $InstallerPath so re-runs of the same R
+    # version skip the ~80 MB download (see the "Using cached installer" branch
+    # above). Only the staging tree is removed.
     Remove-Item $StagingDir -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -135,26 +135,47 @@ Get-ChildItem $StagingDir -Filter "unins*" | Remove-Item -Force -ErrorAction Sil
 Get-ChildItem $StagingDir -Filter "*.iss" | Remove-Item -Force -ErrorAction SilentlyContinue
 Write-Host "  Removed installer artifacts"
 
-Write-Host "--- Configuring Rprofile.site ---"
-$RprofilePath = Join-Path $StagingDir "etc\Rprofile.site"
+Write-Host "--- Appending portable-R hooks to base Rprofile ---"
+# We append to library/base/R/Rprofile rather than writing etc/Rprofile.site
+# so the hooks run in every R launch context, including R --vanilla and
+# IDE-embedded R (RStudio's rsession, Positron's R kernel) which can bypass
+# Rprofile.site by loading R via libR directly.
+$BaseRprofilePath = Join-Path $StagingDir "library\base\R\Rprofile"
+if (-not (Test-Path $BaseRprofilePath)) {
+    throw "Base Rprofile not found at $BaseRprofilePath"
+}
 
-$RprofileContent = @"
-# Rprofile.site -- rstudio/r-builds portable R distribution
+$RprofileAppend = @"
 
-# Portable package library: install packages within this R directory
-local_lib <- file.path(Sys.getenv("R_HOME"), "site-library")
-if (!dir.exists(local_lib)) dir.create(local_lib, recursive = TRUE)
-.libPaths(c(local_lib, .libPaths()))
+## ── rstudio/r-builds portable R hooks ─────────────────────────────────
+## Appended by build.ps1. Lives in the base Rprofile so it runs in every
+## launch context, including R --vanilla and IDE-embedded R.
 
-# Default repository: Posit Package Manager
+## Portable package library: install user packages within the R install
+## tree so they travel with the R folder when copied/moved.
+local({
+  local_lib <- file.path(Sys.getenv("R_HOME"), "site-library")
+  if (!dir.exists(local_lib)) {
+    ok <- tryCatch(dir.create(local_lib, recursive = TRUE, showWarnings = FALSE),
+                   error = function(e) FALSE)
+    if (!isTRUE(ok)) return(invisible())
+  }
+  .libPaths(c(local_lib, .libPaths()))
+})
+
+## Default CRAN mirror: Posit Public Package Manager
 local({
   r <- getOption("repos")
-  r["CRAN"] <- "https://packagemanager.posit.co/cran/latest"
+  r["CRAN"] <- "https://p3m.dev/cran/latest"
   options(repos = r)
 })
 "@
-[System.IO.File]::WriteAllText($RprofilePath, $RprofileContent, (New-Object System.Text.UTF8Encoding $false))
-Write-Host "  Rprofile.site configured"
+
+# Append while preserving the existing file's line endings (CRAN's base
+# Rprofile is plain LF; AppendAllText writes our content as-is rather than
+# mixing in CRLF the way Add-Content would).
+[System.IO.File]::AppendAllText($BaseRprofilePath, $RprofileAppend, (New-Object System.Text.UTF8Encoding $false))
+Write-Host "  Hooks appended to: $BaseRprofilePath"
 
 Write-Host "--- Packaging ---"
 # PowerShell's Join-Path naively concatenates even when the second arg is

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -4,6 +4,9 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+# Suppress the PS 5.1 progress bar during package downloads.
+$ProgressPreference = "SilentlyContinue"
+
 $Pass = 0
 $Fail = 0
 
@@ -12,20 +15,49 @@ function Test-Fail($msg) { Write-Host "  FAIL: $msg"; $script:Fail++ }
 
 Write-Host "=== Testing Windows R at $RHome ==="
 
-# Set R_HOME so older R versions (< 4.2) can locate their installation.
-# R 4.2+ auto-detects from the executable path; older versions need this.
-$env:R_HOME = $RHome
+Write-Host "--- Layout ---"
+foreach ($p in @("bin\R.exe","bin\Rscript.exe","bin\x64\R.exe","bin\x64\Rscript.exe","bin\x64\Rterm.exe")) {
+    $full = Join-Path $RHome $p
+    if (Test-Path $full) { Write-Host "  present: $p" } else { Write-Host "  missing: $p" }
+}
 
-# R < 4.2 on Windows uses bin/x64/ for the real binaries; bin/R.exe is a
-# front-end launcher that depends on registry. R 4.2+ puts binaries in bin/.
-$x64Rscript = Join-Path $RHome "bin\x64\Rscript.exe"
+# R < 4.2 on Windows: bin\R.exe and bin\Rscript.exe are Rfe.exe launchers
+# that re-assemble argv into a cmd.exe string without escaping quotes
+# (src/gnuwin32/front-ends/Rfe.c), silently truncating -e expressions.
+# bin\x64\R.exe is the real binary. R 4.2+ puts real binaries in bin\.
 $x64RExe = Join-Path $RHome "bin\x64\R.exe"
-if (Test-Path $x64Rscript) {
-    $Rscript = $x64Rscript
+if (Test-Path $x64RExe) {
     $RExe = $x64RExe
 } else {
-    $Rscript = Join-Path $RHome "bin\Rscript.exe"
     $RExe = Join-Path $RHome "bin\R.exe"
+}
+Write-Host "  using: $RExe"
+
+# R.exe -f <path> avoids the Windows Rfe argv-quoting bug present in R < 4.2:
+# R reads the file directly instead of needing -e "..." reassembled by cmd.exe.
+function Invoke-RExpr {
+    param(
+        [string]$Binary,
+        [string]$Expression
+    )
+    $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ("rtest-" + [System.Guid]::NewGuid().ToString() + ".R")
+    [System.IO.File]::WriteAllText($tempFile, $Expression, (New-Object System.Text.UTF8Encoding $false))
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = & $Binary --vanilla --slave -f $tempFile 2>&1
+        $exit = $LASTEXITCODE
+        $ErrorActionPreference = "Stop"
+        return [pscustomobject]@{ Output = $output; ExitCode = $exit }
+    } finally {
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-StdoutLine {
+    param($Result)
+    $Result.Output | Where-Object {
+        $_ -is [string] -and $_ -notmatch "^(Error|Warning|trying URL|Content type|downloaded|installing|package |\s*$)"
+    } | Select-Object -First 1
 }
 
 # ── 1. R starts ─────────────────────────────────────────────────────
@@ -41,64 +73,61 @@ if ("$rVersion" -match "R version") {
 
 # ── 2. R_HOME ───────────────────────────────────────────────────────
 Write-Host "--- Test: R_HOME ---"
-$ErrorActionPreference = "Continue"
-$reported = & $Rscript -e "cat(normalizePath(R.home(), winslash='/'))" 2>&1 | Where-Object { $_ -is [string] -and $_ -notmatch "^Error" } | Select-Object -First 1
-$ErrorActionPreference = "Stop"
+$r = Invoke-RExpr -Binary $RExe -Expression "cat(normalizePath(R.home(), winslash='/'))"
+$reported = Get-StdoutLine -Result $r
 $expected = (Resolve-Path $RHome).Path -replace '\\', '/'
 if ("$reported" -eq $expected) {
     Test-Pass "R.home() matches expected"
 } else {
-    Test-Fail "R.home() = '$reported', expected '$expected'"
+    Test-Fail "R.home() = '$reported' (exit $($r.ExitCode)), expected '$expected'"
 }
 
-# ── 3. Rscript ──────────────────────────────────────────────────────
-Write-Host "--- Test: Rscript ---"
-$ErrorActionPreference = "Continue"
-$out = & $Rscript -e "cat('hello')" 2>&1 | Where-Object { $_ -is [string] -and $_ -notmatch "^Error" } | Select-Object -First 1
-$ErrorActionPreference = "Stop"
+# ── 3. Expression evaluation ────────────────────────────────────────
+Write-Host "--- Test: R -f expression ---"
+$r = Invoke-RExpr -Binary $RExe -Expression "cat('hello')"
+$out = Get-StdoutLine -Result $r
 if ("$out" -eq "hello") {
-    Test-Pass "Rscript works"
+    Test-Pass "R evaluates expressions"
 } else {
-    Test-Fail "Rscript output: '$out'"
+    Test-Fail "R -f output: '$out' (exit $($r.ExitCode))"
 }
 
 # ── 4. Relocatability ───────────────────────────────────────────────
 Write-Host "--- Test: Relocatability ---"
 $movedDir = "$env:TEMP\r-relocated-test"
 if (Test-Path $movedDir) { Remove-Item $movedDir -Recurse -Force }
-$oldRHome = $env:R_HOME
-try {
-    $env:R_HOME = $movedDir
-    Copy-Item $RHome -Destination $movedDir -Recurse
-    $movedX64 = Join-Path $movedDir "bin\x64\Rscript.exe"
-    if (Test-Path $movedX64) {
-        $movedRscript = $movedX64
-    } else {
-        $movedRscript = Join-Path $movedDir "bin\Rscript.exe"
-    }
-    $ErrorActionPreference = "Continue"
-    $movedOut = & $movedRscript -e "cat('relocated OK')" 2>&1 | Where-Object { $_ -is [string] -and $_ -notmatch "^Error" } | Select-Object -First 1
-    $ErrorActionPreference = "Stop"
-    if ("$movedOut" -eq "relocated OK") {
-        Test-Pass "relocated R works"
-    } else {
-        Test-Fail "relocated R failed: '$movedOut'"
-    }
-} finally {
-    $env:R_HOME = $oldRHome
-    Remove-Item $movedDir -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item $RHome -Destination $movedDir -Recurse
+$movedX64 = Join-Path $movedDir "bin\x64\R.exe"
+if (Test-Path $movedX64) {
+    $movedRExe = $movedX64
+} else {
+    $movedRExe = Join-Path $movedDir "bin\R.exe"
 }
+$r = Invoke-RExpr -Binary $movedRExe -Expression "cat('relocated OK')"
+$movedOut = Get-StdoutLine -Result $r
+if ("$movedOut" -eq "relocated OK") {
+    Test-Pass "relocated R works"
+} else {
+    Test-Fail "relocated R failed: '$movedOut' (exit $($r.ExitCode))"
+}
+Remove-Item $movedDir -Recurse -Force
 
 # ── 5. Binary package install ────────────────────────────────────────
 Write-Host "--- Test: Binary package install ---"
-$ErrorActionPreference = "Continue"
-$pkgResult = & $Rscript -e "tmp <- tempdir(); install.packages('jsonlite', repos='https://cloud.r-project.org', lib=tmp, quiet=TRUE); stopifnot(requireNamespace('jsonlite', lib.loc=tmp)); cat('pkg OK')" 2>&1
-$ErrorActionPreference = "Stop"
-$pkgStr = ($pkgResult | Out-String)
+$pkgExpr = @'
+tmp <- tempdir()
+install.packages("jsonlite", repos = "https://cloud.r-project.org", lib = tmp, quiet = TRUE)
+stopifnot(requireNamespace("jsonlite", lib.loc = tmp))
+cat("pkg OK")
+'@
+$r = Invoke-RExpr -Binary $RExe -Expression $pkgExpr
+$pkgStr = ($r.Output | Out-String)
 if ($pkgStr -match "pkg OK") {
     Test-Pass "binary package install (jsonlite)"
 } else {
-    Test-Fail "binary package install failed"
+    Test-Fail "binary package install failed (exit $($r.ExitCode))"
+    Write-Host "---- install output (first 20 lines) ----"
+    $r.Output | Select-Object -First 20 | ForEach-Object { Write-Host "    $_" }
 }
 
 # ── Summary ──────────────────────────────────────────────────────────

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -1,0 +1,107 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$RHome
+)
+
+$ErrorActionPreference = "Stop"
+$Pass = 0
+$Fail = 0
+
+function Test-Pass($msg) { Write-Host "  PASS: $msg"; $script:Pass++ }
+function Test-Fail($msg) { Write-Host "  FAIL: $msg"; $script:Fail++ }
+
+Write-Host "=== Testing Windows R at $RHome ==="
+
+# Set R_HOME so older R versions (< 4.2) can locate their installation.
+# R 4.2+ auto-detects from the executable path; older versions need this.
+$env:R_HOME = $RHome
+
+# R < 4.2 on Windows uses bin/x64/ for the real binaries; bin/R.exe is a
+# front-end launcher that depends on registry. R 4.2+ puts binaries in bin/.
+$x64Rscript = Join-Path $RHome "bin\x64\Rscript.exe"
+$x64RExe = Join-Path $RHome "bin\x64\R.exe"
+if (Test-Path $x64Rscript) {
+    $Rscript = $x64Rscript
+    $RExe = $x64RExe
+} else {
+    $Rscript = Join-Path $RHome "bin\Rscript.exe"
+    $RExe = Join-Path $RHome "bin\R.exe"
+}
+
+# ── 1. R starts ─────────────────────────────────────────────────────
+Write-Host "--- Test: R starts ---"
+$ErrorActionPreference = "Continue"
+$rVersion = & $RExe --version 2>&1 | Select-Object -First 1
+$ErrorActionPreference = "Stop"
+if ("$rVersion" -match "R version") {
+    Test-Pass "R --version reports R version"
+} else {
+    Test-Fail "R --version failed: $rVersion"
+}
+
+# ── 2. R_HOME ───────────────────────────────────────────────────────
+Write-Host "--- Test: R_HOME ---"
+$ErrorActionPreference = "Continue"
+$reported = & $Rscript -e "cat(normalizePath(R.home(), winslash='/'))" 2>&1 | Where-Object { $_ -is [string] -and $_ -notmatch "^Error" } | Select-Object -First 1
+$ErrorActionPreference = "Stop"
+$expected = (Resolve-Path $RHome).Path -replace '\\', '/'
+if ("$reported" -eq $expected) {
+    Test-Pass "R.home() matches expected"
+} else {
+    Test-Fail "R.home() = '$reported', expected '$expected'"
+}
+
+# ── 3. Rscript ──────────────────────────────────────────────────────
+Write-Host "--- Test: Rscript ---"
+$ErrorActionPreference = "Continue"
+$out = & $Rscript -e "cat('hello')" 2>&1 | Where-Object { $_ -is [string] -and $_ -notmatch "^Error" } | Select-Object -First 1
+$ErrorActionPreference = "Stop"
+if ("$out" -eq "hello") {
+    Test-Pass "Rscript works"
+} else {
+    Test-Fail "Rscript output: '$out'"
+}
+
+# ── 4. Relocatability ───────────────────────────────────────────────
+Write-Host "--- Test: Relocatability ---"
+$movedDir = "$env:TEMP\r-relocated-test"
+if (Test-Path $movedDir) { Remove-Item $movedDir -Recurse -Force }
+$oldRHome = $env:R_HOME
+try {
+    $env:R_HOME = $movedDir
+    Copy-Item $RHome -Destination $movedDir -Recurse
+    $movedX64 = Join-Path $movedDir "bin\x64\Rscript.exe"
+    if (Test-Path $movedX64) {
+        $movedRscript = $movedX64
+    } else {
+        $movedRscript = Join-Path $movedDir "bin\Rscript.exe"
+    }
+    $ErrorActionPreference = "Continue"
+    $movedOut = & $movedRscript -e "cat('relocated OK')" 2>&1 | Where-Object { $_ -is [string] -and $_ -notmatch "^Error" } | Select-Object -First 1
+    $ErrorActionPreference = "Stop"
+    if ("$movedOut" -eq "relocated OK") {
+        Test-Pass "relocated R works"
+    } else {
+        Test-Fail "relocated R failed: '$movedOut'"
+    }
+} finally {
+    $env:R_HOME = $oldRHome
+    Remove-Item $movedDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ── 5. Binary package install ────────────────────────────────────────
+Write-Host "--- Test: Binary package install ---"
+$ErrorActionPreference = "Continue"
+$pkgResult = & $Rscript -e "tmp <- tempdir(); install.packages('jsonlite', repos='https://cloud.r-project.org', lib=tmp, quiet=TRUE); stopifnot(requireNamespace('jsonlite', lib.loc=tmp)); cat('pkg OK')" 2>&1
+$ErrorActionPreference = "Stop"
+$pkgStr = ($pkgResult | Out-String)
+if ($pkgStr -match "pkg OK") {
+    Test-Pass "binary package install (jsonlite)"
+} else {
+    Test-Fail "binary package install failed"
+}
+
+# ── Summary ──────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "=== Results: $Pass passed, $Fail failed ==="
+if ($Fail -gt 0) { exit 1 }

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -61,11 +61,13 @@ function Get-StdoutLine {
 }
 
 # ── 1. R starts ─────────────────────────────────────────────────────
+# Released R reports "R version X.Y.Z (...)"; devel reports "R Under
+# development (unstable) (YYYY-MM-DD rXXXXX) ...". Match both.
 Write-Host "--- Test: R starts ---"
 $ErrorActionPreference = "Continue"
 $rVersion = & $RExe --version 2>&1 | Select-Object -First 1
 $ErrorActionPreference = "Stop"
-if ("$rVersion" -match "R version") {
+if ("$rVersion" -match "^R (version|Under development)") {
     Test-Pass "R --version reports R version"
 } else {
     Test-Fail "R --version failed: $rVersion"

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -113,10 +113,13 @@ if ("$movedOut" -eq "relocated OK") {
 Remove-Item $movedDir -Recurse -Force
 
 # ── 5. Binary package install ────────────────────────────────────────
+# Use Posit Package Manager because CRAN's Windows contrib/3.6/ is empty
+# (CRAN only keeps installers for old R, not compiled packages). PPM serves
+# Windows binaries for every R minor from 3.6 onward.
 Write-Host "--- Test: Binary package install ---"
 $pkgExpr = @'
 tmp <- tempdir()
-install.packages("jsonlite", repos = "https://cloud.r-project.org", lib = tmp, quiet = TRUE)
+install.packages("jsonlite", repos = "https://packagemanager.posit.co/cran/latest", lib = tmp, quiet = TRUE)
 stopifnot(requireNamespace("jsonlite", lib.loc = tmp))
 cat("pkg OK")
 '@

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -114,7 +114,34 @@ if ("$movedOut" -eq "relocated OK") {
 }
 Remove-Item $movedDir -Recurse -Force
 
-# ── 5. Binary package install ────────────────────────────────────────
+# ── 5. Base Rprofile hooks survive --vanilla ────────────────────────
+# Invoke-RExpr always passes --vanilla, so this run also proves the hooks
+# survive --vanilla (the whole reason we use the base Rprofile rather than
+# etc/Rprofile.site, which --vanilla skips). Asserts:
+#   - default CRAN repo is p3m.dev (PPM)
+#   - the portable site-library is on .libPaths() pointing into R_HOME
+Write-Host "--- Test: Base Rprofile hooks under --vanilla ---"
+$hookExpr = @'
+cat("repo=", getOption("repos")["CRAN"], "\n", sep="")
+site_lib <- file.path(Sys.getenv("R_HOME"), "site-library")
+cat("site_lib_on_path=", normalizePath(site_lib, mustWork=FALSE) %in% normalizePath(.libPaths(), mustWork=FALSE), "\n", sep="")
+'@
+$hookResult = Invoke-RExpr -Binary $RExe -Expression $hookExpr
+$hookOut = $hookResult.Output | Out-String
+if ($hookOut -match "repo=https://p3m\.dev/") {
+    Test-Pass "default CRAN repo set to p3m.dev under --vanilla"
+} else {
+    Test-Fail "default CRAN repo not p3m.dev under --vanilla"
+    $hookOut -split "`n" | Where-Object { $_ -match "^repo=" } | ForEach-Object { Write-Host "    $_" }
+}
+if ($hookOut -match "site_lib_on_path=TRUE") {
+    Test-Pass "portable site-library on .libPaths() under --vanilla"
+} else {
+    Test-Fail "portable site-library not on .libPaths() under --vanilla"
+    $hookOut -split "`n" | Where-Object { $_ -match "^site_lib_on_path=" } | ForEach-Object { Write-Host "    $_" }
+}
+
+# ── 6. Binary package install ────────────────────────────────────────
 # Use Posit Package Manager because CRAN's Windows contrib/3.6/ is empty
 # (CRAN only keeps installers for old R, not compiled packages). PPM serves
 # Windows binaries for every R minor from 3.6 onward.


### PR DESCRIPTION
## Overview

This PR is an **experimental**. It adds portable, relocatable macOS (arm64 + x86_64) and Windows (x86_64) R builds to r-builds, following the same goals as the Linux portable builds in #280 and #281, but using a fundamentally different approach: post-processing official CRAN binaries rather than compiling from source.

---

## Why not compile from source (like Linux)?

For Linux, we compile from source because CRAN doesn't ship Linux binaries. macOS and Windows are different: CRAN ships high-quality official binaries built with Apple's blessed toolchain (custom gfortran, correct configure flags, bundled Tcl/Tk and gfortran runtime). Replicating that toolchain from scratch would be complex and fragile. Instead, we download the CRAN binary, extract it without installing, and run a post-processing pipeline to strip hardcoded paths.

---

## How it works

### macOS

CRAN `.pkg` files are Xar archives containing an Inno-style payload. We extract them with `pkgutil --expand-full` (no admin rights, no system installation) and then run a three-stage pipeline:

1. **`patch-mach-o.sh`** — Uses `install_name_tool` to rewrite all hardcoded `/Library/Frameworks/R.framework/...` load commands in every `.dylib` and `.so` to `@rpath`/`@loader_path` references, the macOS equivalent of patchelf + `$ORIGIN`. Signs all Mach-O binaries (ad-hoc always; Developer ID + notarization on production).

2. **`make-relocatable.sh`** — Patches `bin/R` and `bin/Rscript` to derive `R_HOME` at runtime from the script's own location (BSD `sed -i ''` syntax). Patches `etc/Makeconf` to replace `-framework R` with `-lR` so package compilation works from any path. Patches `R_SHARE_DIR`, `R_INCLUDE_DIR`, `R_DOC_DIR` to be `${R_HOME}`-relative.

3. **`install-rprofile-hook.sh`** — Writes `Rprofile.site` to configure a portable `site-library` inside the R directory and set PPM as the default CRAN repository.

Output: `R-{version}-macos-{arch}.tar.gz` — extract anywhere, run `bin/R`.

### Windows

Windows CRAN R is already largely self-contained (all DLLs bundled, paths largely relative). No DLL patching or binary rewriting is needed.

1. Download the CRAN `.exe` installer
2. Extract with `innoextract` (no silent install, no admin rights, no registry changes); falls back to `/VERYSILENT /CURRENTUSER` if innoextract is unavailable
3. Clean up `unins*` artifacts
4. Write `Rprofile.site` with portable `site-library` and PPM default

Output: `R-{version}-windows.zip` — extract anywhere, run `bin\R.exe`.

---

## What gets built

| Platform | Arch | R versions | Notes |
|---|---|---|---|
| macOS | arm64 | R 4.1+, last-5 + devel | No CRAN arm64 `.pkg` before R 4.1 |
| macOS | x86_64 | R 4.1+, last-5 + devel | No binaries before R 4.1 |
| Windows | x86_64 | R 3.6.3+, last-5 + 3.6.3 + devel | |

R 3.6.3 is included as a long-term compatibility target (matching existing Linux builds). For macOS, 3.6.3 is x86_64 only.

---

## Published artifacts

Following the existing CDN pattern:

```
cdn.posit.co/r/macos-arm64/R-{version}-macos-arm64.tar.gz
cdn.posit.co/r/macos-x86_64/R-{version}-macos-x86_64.tar.gz
cdn.posit.co/r/windows/R-{version}-windows.zip
```

---

## CI integration

Two new reusable workflows (`build-macos.yml`, `build-windows.yml`) follow the same OIDC auth, `manage_r_versions.py`, and S3 publish patterns as the Linux workflows:

- **`build.yml`** — `build-macos` and `build-windows` call jobs are added, gated on `contains(inputs.platforms, 'macos')`/`'windows'`
- **`check-r-versions.yml`** — automatically triggers macOS and Windows builds alongside Linux when new R versions are detected; Slack notification waits for all three platform groups

macOS CI uses native runners (`macos-14` for arm64, `macos-13` for x86_64) — no Docker involved.

---

## Testing locally

Build:
```bash
# macOS arm64 (requires Xcode Command Line Tools)
bash macos/build.sh 4.4.1 arm64 output
tar xzf output/R-4.4.1-macos-arm64.tar.gz -C output/
bash macos/test.sh output/R-4.4.1

# or via Make
R_VERSION=4.4.1 ARCH=arm64 make build-r-macos
```

Test:
```
tar xzf output/R-4.4.1-macos-arm64.tar.gz -C output/
bash macos/test.sh output/R-4.4.1
# or via Make (after extracting):
R_VERSION=4.4.1 ARCH=arm64 make test-r-macos
```

Quick smoke test without full test suite:
```
tar xzf output/R-4.4.1-macos-arm64.tar.gz -C output/
output/R-4.4.1/bin/R --version
output/R-4.4.1/bin/Rscript -e "cat(R.home(), '\n')"
```

The test suite checks: R startup, `R.home()` accuracy, Rscript, `capabilities()` (cairo/png/tcltk), BLAS/LAPACK, absence of hardcoded `/Library/Frameworks` paths in all Mach-O binaries, and relocatability (copy to new path, verify R still works).

---

## Open questions / known gaps

- **Apple notarization secrets** — the workflow supports Developer ID signing + notarization but the repo doesn't yet have the required secrets (`MACOS_DEVELOPER_CERTIFICATE`, `APPLE_TEAM_ID`, etc.). Without them, builds use ad-hoc signing (functional locally, but Gatekeeper will quarantine on end-user systems without stapling).
- **`--acl public-read`** on S3 — carried from existing publish patterns; may need adjustment if the bucket has `BucketOwnerEnforced` ownership.
- **Windows arm64** — CRAN Windows arm64 support is too new and untested; not included.
- **R devel on macOS** — URL pattern for nightly builds on `mac.r-project.org` is in place but hasn't been tested against a live devel build.
- **No manylinux/musllinux-style library bundling on macOS** — CRAN bundles all required dylibs; we rely on that remaining stable.

---

## Files changed

| Path | Description |
|---|---|
| `macos/build.sh` | Main macOS build orchestrator |
| `macos/patch-mach-o.sh` | Mach-O load command rewriting + codesigning |
| `macos/make-relocatable.sh` | bin/R, Rscript, Makeconf patching (BSD sed) |
| `macos/install-rprofile-hook.sh` | Rprofile.site configuration |
| `macos/notarize.sh` | Apple Notary Service submission |
| `macos/entitlements.plist` | Hardened runtime entitlements |
| `macos/test.sh` | Integration test suite |
| `windows/build.ps1` | Windows build orchestrator |
| `windows/test.ps1` | Windows integration tests |
| `.github/workflows/build-macos.yml` | Reusable macOS CI workflow |
| `.github/workflows/build-windows.yml` | Reusable Windows CI workflow |
| `.github/workflows/build.yml` | Extended with macOS/Windows call jobs |
| `.github/workflows/check-r-versions.yml` | Extended with macOS/Windows auto-triggers |
| `Makefile` | Local build/test targets for macOS and Windows |
| `README.md` | Installation instructions for macOS and Windows |
| `CLAUDE.md` | Developer notes |


---

## Existing art for reference

https://github.com/portable-r/portable-r-macos
https://github.com/portable-r/portable-r-windows