### PR TITLE
Fix opensuse-156 Docker build: add --allow-downgrade to handle libncurses6/ncurses-devel skew

### DIFF
--- a/builder/Dockerfile.opensuse-156
+++ b/builder/Dockerfile.opensuse-156
@@ -7,7 +7,16 @@ ENV OS_IDENTIFIER opensuse-156
 # https://download.opensuse.org/repositories/devel:/languages:/R:/released/openSUSE_Leap_42.3/src/R-base-3.5.3-103.1.src.rpm
 
 RUN zypper --non-interactive update
-RUN zypper --non-interactive --gpg-auto-import-keys -n install \
+# --allow-downgrade is needed because the opensuse/leap:15.6 base image
+# periodically gets libncurses6 maintenance updates from SUSE's SLE
+# channel before the matching ncurses-devel reaches the public Leap
+# repos, leaving the dev package one or two point releases behind the
+# installed runtime. readline-devel transitively requires ncurses-devel,
+# so without --allow-downgrade zypper presents an interactive solver
+# prompt and the build fails with exit code 4 (default answer cancel).
+# Letting zypper accept the suggested downgrade of libncurses6 to the
+# version that has a matching dev package resolves cleanly.
+RUN zypper --non-interactive --gpg-auto-import-keys --allow-downgrade -n install \
     bzip2 \
     cairo-devel \
     curl \

--- a/builder/Dockerfile.opensuse-156
+++ b/builder/Dockerfile.opensuse-156
@@ -15,9 +15,7 @@ RUN zypper --non-interactive update
 # so without --allow-downgrade zypper presents an interactive solver
 # prompt and the build fails with exit code 4 (default answer cancel).
 # Letting zypper accept the suggested downgrade of libncurses6 to the
-# version that has a matching dev package resolves cleanly. The flag
-# is a subcommand option of `install`, so it must appear after the
-# subcommand name (zypper rejects it as global with "flag is not known").
+# version that has a matching dev package resolves cleanly.
 RUN zypper --non-interactive --gpg-auto-import-keys -n install --allow-downgrade \
     bzip2 \
     cairo-devel \

--- a/builder/Dockerfile.opensuse-156
+++ b/builder/Dockerfile.opensuse-156
@@ -15,8 +15,10 @@ RUN zypper --non-interactive update
 # so without --allow-downgrade zypper presents an interactive solver
 # prompt and the build fails with exit code 4 (default answer cancel).
 # Letting zypper accept the suggested downgrade of libncurses6 to the
-# version that has a matching dev package resolves cleanly.
-RUN zypper --non-interactive --gpg-auto-import-keys --allow-downgrade -n install \
+# version that has a matching dev package resolves cleanly. The flag
+# is a subcommand option of `install`, so it must appear after the
+# subcommand name (zypper rejects it as global with "flag is not known").
+RUN zypper --non-interactive --gpg-auto-import-keys -n install --allow-downgrade \
     bzip2 \
     cairo-devel \
     curl \


### PR DESCRIPTION
## Summary

- The `opensuse/leap:15.6` Docker build has been failing deterministically since **2026-04-16** because of a versioning mismatch between `libncurses6` (in the base image) and `ncurses-devel` (in the public Leap update repos).
- Adding `--allow-downgrade` to the `zypper install` step lets zypper accept the solver's suggested downgrade of `libncurses6` automatically instead of cancelling.

## What's failing

```
Problem: 1: the to be installed readline-devel-7.0-150400.27.6.1.aarch64
  requires 'ncurses-devel', but this requirement cannot be provided
not installable providers: ncurses-devel-6.1-150000.5.24.1.aarch64 [repo-oss]
                           ncurses-devel-6.1-150000.5.27.1.aarch64 [repo-sle-update]
                           ncurses-devel-6.1-150000.5.30.1.aarch64 [repo-sle-update]

 Solution 1: downgrade of libncurses6-6.1-150000.5.33.1.aarch64 to
             libncurses6-6.1-150000.5.30.1.aarch64
 Solution 2: do not install readline-devel-7.0-150400.27.6.1.aarch64
 Solution 3: break readline-devel-7.0-150400.27.6.1.aarch64 by ignoring
             some of its dependencies

Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
```

zypper exits with code 4 because under `--non-interactive` the default answer is `cancel`.

## Root cause (not a flake)

I pulled the current `opensuse/leap:15.6` arm64 base image and confirmed:

```
Installed:                   libncurses6-6.1-150000.5.33.1   (built Thu Apr 16 13:36:36 2026)
Highest available in repo:   ncurses-devel-6.1-150000.5.30.1
```

`libncurses6-5.33.1` was published as part of SUSE's SLE 15 maintenance channel and got pulled into the base image. The matching `ncurses-devel-5.33.1` is part of the SLE Software Development Kit, which is licensed separately and doesn't get mirrored into public Leap repos. This kind of asymmetry between runtime and dev packages can persist indefinitely in Leap — SLE customers see both, Leap users see only the runtime side.

So "wait for retry" does not work here. The reason past PRs sometimes "passed on retry" is almost certainly Docker layer cache hits from earlier successful builds, not transient mirror flakiness.

## The fix

One-line change in `builder/Dockerfile.opensuse-156`: add `--allow-downgrade` to the `zypper install` invocation, with a comment explaining why so a future maintainer can find the context.

The downgrade is harmless — `5.30.1` is a couple of stable point releases behind `5.33.1`, R doesn't depend on any `5.33`-specific behavior, and once SUSE eventually does publish a matching `ncurses-devel-5.33.1` (if ever) the flag becomes a no-op.

## Why not also opensuse-160?

`opensuse-160` (Leap 16.0) has a similar `zypper install` step but uses different repos and hasn't hit this in practice. Keeping this PR scoped to the Dockerfile that's actually failing. Easy to add to 160 separately if it ever exhibits the same pattern.

## Test plan

- [ ] CI: `Docker image (opensuse-156-amd64)` and `Docker image (opensuse-156-arm64)` jobs pass on this PR
- [ ] Confirm via the build log that zypper reports the downgrade (e.g. `libncurses6 6.1-150000.5.33.1-150600.4.20.1 -> 6.1-150000.5.30.1`) and continues without prompting
- [ ] Spot-check that downstream R-build steps still produce a working RPM (i.e. the libncurses6 downgrade doesn't break anything later in the build)