### PR TITLE
Add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary                                                                                                                                                  
  - Adds Dependabot configuration to automatically check for GitHub Actions updates weekly                                                                    
  - Keeps CI workflows up to date with security patches and new features  