### PR TITLE
Unify macOS CDN path with Linux convention

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -172,7 +172,10 @@ jobs:
           output_dir="${RUNNER_TEMP}/r-builds-output"
           mkdir -p "${output_dir}"
           bash macos/build.sh "${{ matrix.r_version }}" "${{ matrix.arch }}" "${output_dir}"
-          tarball="${output_dir}/R-${{ matrix.r_version }}-macos-${{ matrix.arch }}.tar.gz"
+          # Filename matches Linux: x86_64 unsuffixed, arm64 carries -arm64.
+          arch_suffix=""
+          [[ "${{ matrix.arch }}" == "arm64" ]] && arch_suffix="-arm64"
+          tarball="${output_dir}/R-${{ matrix.r_version }}-macos${arch_suffix}.tar.gz"
           echo "tarball=${tarball}" >> $GITHUB_OUTPUT
           echo "output_dir=${output_dir}" >> $GITHUB_OUTPUT
 
@@ -225,7 +228,12 @@ jobs:
         run: |
           tarball="${{ steps.build.outputs.tarball }}"
           s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
-          s3_key="r/macos-${{ matrix.arch }}/R-${{ matrix.r_version }}-macos-${{ matrix.arch }}.tar.gz"
+          # Both arches share the /r/macos/ prefix, matching the Linux
+          # convention of one prefix per platform with arm64 distinguished
+          # only by an `-arm64` filename suffix.
+          arch_suffix=""
+          [[ "${{ matrix.arch }}" == "arm64" ]] && arch_suffix="-arm64"
+          s3_key="r/macos/R-${{ matrix.r_version }}-macos${arch_suffix}.tar.gz"
           echo "Publishing R ${{ matrix.r_version }} (macos-${{ matrix.arch }}) to s3://${s3_bucket}/${s3_key}"
           aws s3 cp "${tarball}" "s3://${s3_bucket}/${s3_key}" --acl public-read
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build-r-macos:
 
 test-r-macos:
 	@rm -rf output/R-$(R_VERSION)
-	tar xzf output/R-$(R_VERSION)-macos-$(ARCH).tar.gz -C output/
+	tar xzf output/R-$(R_VERSION)-macos$(if $(filter arm64,$(ARCH)),-arm64).tar.gz -C output/
 	bash macos/test.sh output/R-$(R_VERSION)
 
 build-r-windows:

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ anywhere instead of installed system-wide.
 - **manylinux** - any Linux distro with glibc >= 2.34 (RHEL 9+, Ubuntu 22.04+,
   Debian 12+, Amazon Linux 2023+, Arch Linux, etc.)
 - **musllinux** - Alpine Linux 3.20+ and other musl-based distros
-- **macOS** - arm64 (Apple Silicon) and x86_64 (Intel; also runs under
-  Rosetta 2), R 4.1.0+
+- **macOS** - arm64 (Apple Silicon) and x86_64 (Intel), R 4.1.0+
 - **Windows** - x86_64, R 3.6.3+
 
 ## Supported R Versions
@@ -392,7 +391,7 @@ mkdir -p ~/R
 tar xzf R-${R_VERSION}-macos-arm64.tar.gz -C ~/R
 ~/R/R-${R_VERSION}/bin/R --version
 
-# x86_64 (Intel; also runs under Rosetta 2 on Apple Silicon)
+# x86_64 (Intel)
 curl -O https://cdn.posit.co/r/macos/R-${R_VERSION}-macos.tar.gz
 mkdir -p ~/R
 tar xzf R-${R_VERSION}-macos.tar.gz -C ~/R

--- a/README.md
+++ b/README.md
@@ -387,15 +387,15 @@ for the full technical breakdown.
 R_VERSION=4.4.3
 
 # arm64 (Apple Silicon)
-curl -O https://cdn.posit.co/r/macos-arm64/R-${R_VERSION}-macos-arm64.tar.gz
+curl -O https://cdn.posit.co/r/macos/R-${R_VERSION}-macos-arm64.tar.gz
 mkdir -p ~/R
 tar xzf R-${R_VERSION}-macos-arm64.tar.gz -C ~/R
 ~/R/R-${R_VERSION}/bin/R --version
 
 # x86_64 (Intel; also runs under Rosetta 2 on Apple Silicon)
-curl -O https://cdn.posit.co/r/macos-x86_64/R-${R_VERSION}-macos-x86_64.tar.gz
+curl -O https://cdn.posit.co/r/macos/R-${R_VERSION}-macos.tar.gz
 mkdir -p ~/R
-tar xzf R-${R_VERSION}-macos-x86_64.tar.gz -C ~/R
+tar xzf R-${R_VERSION}-macos.tar.gz -C ~/R
 ~/R/R-${R_VERSION}/bin/R --version
 ```
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -12,7 +12,7 @@ Unlike the Linux portable builds (which compile R from source and bundle system 
 4. Patch `bin/R`, `bin/Rscript`, `etc/Makeconf`, `etc/Renviron` to derive `R_HOME` at runtime.
 5. Append portable-R hooks (default CRAN repo, Tcl/Tk paths, CRAN binary package fix-up) to the base Rprofile.
 6. Codesign all Mach-O binaries (ad-hoc on staging, Developer ID + notarized on production).
-7. Package as `R-{version}-macos-{arch}.tar.gz`.
+7. Package as `R-{version}-macos.tar.gz` (x86_64) or `R-{version}-macos-arm64.tar.gz` (arm64).
 
 Output: a self-contained tarball where `bin/R --version` works regardless of where the directory is extracted.
 
@@ -48,11 +48,12 @@ Portable macOS builds are useful for:
 
 Both arm64 (Apple Silicon) and x86_64 (Intel; runs under Rosetta 2 on Apple Silicon hosts) for R 4.1.0 onwards. The build matrix in `build-macos.yml` defaults to the last 5 R minor versions plus `devel`, with R < 4.1 skipped.
 
-Output paths on the CDN follow the existing pattern:
+Output paths on the CDN match the Linux convention — one prefix per
+platform with arm64 distinguished only by a filename suffix:
 
 ```
-cdn.posit.co/r/macos-arm64/R-{version}-macos-arm64.tar.gz
-cdn.posit.co/r/macos-x86_64/R-{version}-macos-x86_64.tar.gz
+cdn.posit.co/r/macos/R-{version}-macos.tar.gz          # x86_64
+cdn.posit.co/r/macos/R-{version}-macos-arm64.tar.gz    # arm64
 ```
 
 ## How it works

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -288,9 +288,14 @@ bash "${SCRIPT_DIR}/make-relocatable.sh"       "${WORK_OUTPUT_DIR}" "${R_VERSION
 bash "${SCRIPT_DIR}/install-rprofile-hook.sh"  "${WORK_OUTPUT_DIR}"
 
 # ── 6. Package tarball ───────────────────────────────────────────────
+# Filename convention matches Linux: x86_64 is the unsuffixed default,
+# arm64 carries an explicit `-arm64` suffix. CDN layout puts both arches
+# under a single /r/macos/ prefix, mirroring /r/<linux-platform>/.
 echo "--- Packaging tarball ---"
 mkdir -p "${OUTPUT_DIR_BASE}"
-TARBALL="${OUTPUT_DIR_BASE}/R-${R_VERSION}-macos-${ARCH}.tar.gz"
+ARCH_SUFFIX=""
+[[ "${ARCH}" == "arm64" ]] && ARCH_SUFFIX="-arm64"
+TARBALL="${OUTPUT_DIR_BASE}/R-${R_VERSION}-macos${ARCH_SUFFIX}.tar.gz"
 tar czf "${TARBALL}" -C "${WORK_OUTPUT_PARENT}" "R-${R_VERSION}"
 echo "=== Tarball created: ${TARBALL} ==="
 


### PR DESCRIPTION
## Summary

Move both macOS arches under a single `/r/macos/` prefix and adopt the same arch-suffix filename convention Linux already uses. macOS becomes structurally identical to Linux on the CDN.

**Before** (never published — landing change before the first publish):

```
/r/macos-arm64/R-{ver}-macos-arm64.tar.gz
/r/macos-x86_64/R-{ver}-macos-x86_64.tar.gz
```

**After**:

```
/r/macos/R-{ver}-macos.tar.gz          # x86_64
/r/macos/R-{ver}-macos-arm64.tar.gz    # arm64
```

The shape across all three OS families is now `/r/<platform>/R-<ver>-<platform>[-arm64].tar.gz`.

## Why this shape

The original PR #284 introduced macOS with a third pattern (one prefix per arch) that didn't match either Linux (one prefix per platform, arm64 suffix in filename) or any common precedent. While we're talking about whether to add arch to the Windows path for future-proofing, it became clearer that macOS was the thing actually out of step with the rest of the repo.

A few specific decisions that got made along the way:

- **One prefix instead of two.** Centralising under `/r/macos/` makes discovery (and any future mirror/listing tooling) cleaner — one prefix to enumerate, one place to look. This also aligns with the modern industry convention used by Go, Node.js, Rust, uv, and most GitHub Releases: all platform/arch variants in one directory, the filename does the disambiguating. Older ecosystems like apt/CRAN-macOS use arch-in-directory because their package metadata format requires it; we don't have that constraint.
- **`macos`, not `macosx`.** CRAN uses `bin/macosx/...`, but that's a legacy name from the OS X era (Apple dropped the X in 2012). Within this repo every other platform identifier is a current name (`ubuntu-2204`, `rhel-9`, `windows`), so `macosx` would be the odd one out. This isn't a CRAN mirror — within-repo consistency wins over CRAN parity.
- **Keep the platform in the filename.** `R-4.4.3-macos.tar.gz` rather than `R-4.4.3.tar.gz` — once a tarball is sitting in `~/Downloads/`, the filename alone should still tell you what it is. Linux already does this, and it disambiguates from the source tarball, the manylinux portable, etc.
- **x86_64 unsuffixed, arm64 suffixed.** Matching Linux. Both arches are first-class on macOS in 2026, but adopting the existing repo convention beats inventing a new one for this platform.

## Why this is the right time

Nothing has been published from PR #284 yet — the production CDN currently 404s on `/r/macos-arm64/...` and `/r/macos-x86_64/...`. Renaming now is free; renaming after the first publish would be a documented public-URL break.

## Files changed

- `macos/build.sh` — tarball naming uses arch-suffix convention (x86_64 unsuffixed, arm64 keeps `-arm64`)
- `Makefile` — `test-r-macos` extracts the right filename per arch
- `.github/workflows/build-macos.yml` — build-step tarball var + S3 key both updated
- `macos/README.md` — package-name and CDN-URL block
- `README.md` — install snippets

## Intentionally unchanged

- **GHA artifact folder names** stay `R-{ver}-macos-{arch}` so x86_64 and arm64 don't collide in the GHA UI; the file inside the artifact follows the new CDN naming. (Two artifacts both named `R-4.4.3-macos.tar.gz` would be confusing on the run page.)
- **User-input platform selectors** in `build.yml` (`macos-arm64`, `macos-x86_64`) drive matrix filtering for `workflow_dispatch`. They're not S3 paths — separate concern, no reason to churn them.

## Windows

Windows stays as-is for now (`/r/windows/R-{ver}-windows.zip`). When Windows arm64 R is ready, the same Linux-style suffix can be added without a path migration: `/r/windows/R-{ver}-windows-arm64.zip`.

## Test plan

- [ ] CI passes on this branch
- [ ] Manual `make build-r-macos R_VERSION=4.4.3 ARCH=arm64` produces `output/R-4.4.3-macos-arm64.tar.gz`
- [ ] Manual `make build-r-macos R_VERSION=4.4.3 ARCH=x86_64` produces `output/R-4.4.3-macos.tar.gz`
- [ ] `make test-r-macos R_VERSION=4.4.3 ARCH=arm64` extracts `R-4.4.3-macos-arm64.tar.gz`
- [ ] `make test-r-macos R_VERSION=4.4.3 ARCH=x86_64` extracts `R-4.4.3-macos.tar.gz`
- [ ] Staging publish lands artifacts at the new `/r/macos/...` prefix in the staging bucket