### PR TITLE
Publish r-builds CDN manifest with sha256 sidecars

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -49,7 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
-      r_versions: ${{ steps.setup-matrix.outputs.r_versions }}
     steps:
       - uses: actions/checkout@v4
 
@@ -84,7 +83,6 @@ jobs:
           #   2. arm64 is additionally unsupported on R < 4.1 (no arm64 .pkg),
           #      but rule 1 already covers this — kept as a defensive comment.
           includes="[]"
-          built_versions=""
           for version in $(echo "$r_versions" | tr ',' ' '); do
             case "${version}" in
               devel|patched|next)
@@ -98,7 +96,6 @@ jobs:
                 fi
                 ;;
             esac
-            built_versions="${built_versions:+${built_versions},}${version}"
             for arch in $archs; do
               # Both arches run on macos-14 (arm64). x86_64 R runs under
               # Rosetta 2, which is pre-installed on GitHub's macos-14 images.
@@ -113,10 +110,6 @@ jobs:
           matrix=$(echo "$includes" | jq -c '{"include": .}')
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
           echo "Using matrix: $matrix"
-
-          # Only publish versions we actually built; filtering happens above.
-          r_versions_json=$(echo "$built_versions" | jq -Rc 'split(",") | map(select(length > 0))')
-          echo "r_versions=$r_versions_json" >> $GITHUB_OUTPUT
 
   build:
     needs: setup-matrix
@@ -227,41 +220,17 @@ jobs:
         if: ${{ inputs.publish != '' }}
         run: |
           tarball="${{ steps.build.outputs.tarball }}"
+          basename="$(basename "${tarball}")"
+          sidecar="${tarball}.sha256"
+          # Sidecar format: "<hex>  <basename>" — matches `sha256sum -c`.
+          shasum -a 256 "${tarball}" | awk -v b="${basename}" '{print $1"  "b}' > "${sidecar}"
           s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
+          arch_suffix=""
+          [[ "${{ matrix.arch }}" == "arm64" ]] && arch_suffix="-arm64"
           # Both arches share the /r/macos/ prefix, matching the Linux
           # convention of one prefix per platform with arm64 distinguished
           # only by an `-arm64` filename suffix.
-          arch_suffix=""
-          [[ "${{ matrix.arch }}" == "arm64" ]] && arch_suffix="-arm64"
           s3_key="r/macos/R-${{ matrix.r_version }}-macos${arch_suffix}.tar.gz"
           echo "Publishing R ${{ matrix.r_version }} (macos-${{ matrix.arch }}) to s3://${s3_bucket}/${s3_key}"
           aws s3 cp "${tarball}" "s3://${s3_bucket}/${s3_key}" --acl public-read
-
-  update-versions-json:
-    if: ${{ inputs.publish != '' && !cancelled() }}
-    needs: [build, setup-matrix]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Update versions.json
-        run: |
-          echo "Publishing versions.json for ${{ inputs.publish }}"
-          s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
-          versions=$(echo '${{ needs.setup-matrix.outputs.r_versions }}' | jq -r 'join(",")')
-          python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"
+          aws s3 cp "${sidecar}" "s3://${s3_bucket}/${s3_key}.sha256" --acl public-read

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
-      r_versions: ${{ steps.setup-matrix.outputs.r_versions }}
     steps:
       - uses: actions/checkout@v4
 
@@ -65,9 +64,6 @@ jobs:
           matrix=$(echo "$includes" | jq -c '{"include": .}')
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
           echo "Using matrix: $matrix"
-
-          r_versions_json=$(echo "$r_versions" | jq -Rc 'split(",") | map(select(length > 0))')
-          echo "r_versions=$r_versions_json" >> $GITHUB_OUTPUT
 
   build:
     needs: setup-matrix
@@ -128,36 +124,16 @@ jobs:
         shell: pwsh
         run: |
           $zip = "${{ steps.build.outputs.zip }}"
+          $basename = Split-Path -Leaf $zip
+          $sidecar = "$zip.sha256"
+          # sha256sum -c expects "<hex>  <basename>". Get-FileHash returns
+          # uppercase; lowercase it to match GNU sha256sum output.
+          $hash = (Get-FileHash -Algorithm SHA256 -Path $zip).Hash.ToLower()
+          # Append `n (Unix LF) so the sidecar matches `sha256sum -c` format on Linux/macOS.
+          # Out-File on PowerShell would default to CRLF; -NoNewline + explicit `n keeps it LF-only.
+          "${hash}  ${basename}`n" | Out-File -FilePath $sidecar -Encoding ascii -NoNewline
           $s3Bucket = "${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
           $s3Key = "r/windows/R-${{ matrix.r_version }}-windows.zip"
           Write-Host "Publishing R ${{ matrix.r_version }} (windows) to s3://$s3Bucket/$s3Key"
           aws s3 cp "$zip" "s3://$s3Bucket/$s3Key" --acl public-read
-
-  update-versions-json:
-    if: ${{ inputs.publish != '' && !cancelled() }}
-    needs: [build, setup-matrix]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Update versions.json
-        run: |
-          echo "Publishing versions.json for ${{ inputs.publish }}"
-          s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
-          versions=$(echo '${{ needs.setup-matrix.outputs.r_versions }}' | jq -r 'join(",")')
-          python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"
+          aws s3 cp "$sidecar" "s3://$s3Bucket/$s3Key.sha256" --acl public-read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,11 @@ jobs:
       - name: Install pytest
         run: pip install pytest
 
+      - name: Install uv
+        # Used by the unit-test-manifest target to run pytest against
+        # build_manifest.py with boto3 in an ephemeral env (PEP 723).
+        uses: astral-sh/setup-uv@v6
+
       - name: Run unit tests
         run: make unit-test
 
@@ -260,42 +265,34 @@ jobs:
           role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Compute sha256 sidecars
+        if: ${{ inputs.publish != '' }}
+        run: |
+          # Hash every artifact in builder/integration/tmp/r/<platform>/ and
+          # builder/integration/tmp/<platform>/. Sidecar format matches what
+          # `sha256sum -c` accepts: "<hex>  <basename>".
+          shopt -s nullglob
+          for d in "builder/integration/tmp/r/${{ matrix.platform }}" \
+                   "builder/integration/tmp/${{ matrix.platform }}"; do
+            [ -d "$d" ] || continue
+            (
+              cd "$d"
+              for f in *; do
+                # Skip if it's already a sidecar or a directory.
+                case "$f" in *.sha256) continue ;; esac
+                [ -f "$f" ] || continue
+                sha256sum "$f" > "$f.sha256"
+                echo "  hashed $d/$f"
+              done
+            )
+          done
+
       - name: Publish R
         if: ${{ inputs.publish != '' }}
         run: |
           echo "Publishing R for ${{ inputs.publish }}"
           s3_bucket=${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}
           S3_BUCKET=$s3_bucket make publish-r-${{ matrix.platform }}
-
-  update-versions-json:
-    if: ${{ inputs.publish != '' }}
-    needs: [build, setup-matrix]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.x'
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Update versions.json
-        run: |
-          echo "Publishing versions.json for ${{ inputs.publish }}"
-          s3_bucket=${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}
-          versions=$(echo '${{ needs.setup-matrix.outputs.r_versions }}' | jq -r 'join(",")')
-          python manage_r_versions.py publish --s3-bucket="$s3_bucket" --versions="$versions"
 
   build-macos:
     # Empty inputs.platforms means a push event (workflow input defaults don't apply to push).
@@ -328,6 +325,21 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       r_versions: ${{ inputs.r_versions }}
+      publish: ${{ inputs.publish }}
+    secrets:
+      AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      S3_BUCKET_STAGING: ${{ secrets.S3_BUCKET_STAGING }}
+      S3_BUCKET_PRODUCTION: ${{ secrets.S3_BUCKET_PRODUCTION }}
+
+  update-manifest:
+    # !cancelled() rather than always() — runs on partial failures (so the
+    # manifest still reflects what did publish) but skips on user-cancelled
+    # workflows where the in-flight S3 state is unknown.
+    if: ${{ !cancelled() && inputs.publish != '' }}
+    needs: [build, build-macos, build-windows]
+    uses: ./.github/workflows/update-manifest.yml
+    with:
       publish: ${{ inputs.publish }}
     secrets:
       AWS_PUBLISH_ROLE: ${{ secrets.AWS_PUBLISH_ROLE }}

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -1,0 +1,59 @@
+name: Update r-builds manifest
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: |
+          Which S3 bucket to read and write. "staging" or "production".
+        required: true
+        type: string
+    secrets:
+      AWS_PUBLISH_ROLE:
+        required: true
+      AWS_REGION:
+        required: true
+      S3_BUCKET_STAGING:
+        required: true
+      S3_BUCKET_PRODUCTION:
+        required: true
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Which S3 bucket to read and write.'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        # uv provisions Python and reads the PEP 723 inline script
+        # metadata in build_manifest.py to install boto3 in an ephemeral env.
+        uses: astral-sh/setup-uv@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_PUBLISH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Build and upload manifest.json + versions.json
+        run: |
+          s3_bucket="${{ inputs.publish == 'staging' && secrets.S3_BUCKET_STAGING || secrets.S3_BUCKET_PRODUCTION }}"
+          # Both staging and production are served at cdn.posit.co. If staging
+          # is ever served at a different host, parameterize this here.
+          uv run build_manifest.py write \
+            --s3-bucket "$s3_bucket" \
+            --cdn-base "https://cdn.posit.co"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 R-*
 builder/integration/**
 __pycache__/
+.worktrees/

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,15 @@ docker-build-r: docker-build
 docker-shell-r-env:
 	@cd builder && docker compose run --entrypoint /bin/bash ubuntu-2004
 
-unit-test:
+unit-test: unit-test-builder unit-test-manifest
+
+unit-test-builder:
 	cd builder/portable-r && python3 -m pytest test_delocate_r.py test_generate_sbom.py -v
+
+unit-test-manifest:
+	uv run --with pytest --with boto3 -m pytest test_build_manifest.py -v
+
+.PHONY: unit-test unit-test-builder unit-test-manifest
 
 define GEN_TARGETS
 # Use PLATFORM_ARCH to override the architecture, e.g. PLATFORM_ARCH=linux/arm64 or PLATFORM_ARCH=linux/amd64

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ bash -c "$(curl -L https://rstd.io/r-install)"
 
 Define the version of R that you want to install. Available versions
 of R can be found here: https://cdn.posit.co/r/versions.json
+
+For programmatic discovery of all available builds across platforms and
+architectures (including portable manylinux, musllinux, macOS, and Windows
+builds), fetch the manifest at https://cdn.posit.co/r/manifest.json. Each
+build entry includes the download URL, sha256, and size. Every artifact also
+has a `<artifact>.sha256` sidecar published next to it for verification with
+`sha256sum -c`.
+
 ```bash
 R_VERSION=4.4.3
 ```

--- a/build_manifest.py
+++ b/build_manifest.py
@@ -1,0 +1,350 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "boto3",
+# ]
+# ///
+"""Build the r-builds CDN manifest from an S3 listing.
+
+This module parses S3 keys into typed build records, lists S3 objects under
+``r/``, fetches ``.sha256`` sidecars uploaded alongside each artifact, and
+writes both ``manifest.json`` (the canonical, full enumeration) and
+``versions.json`` (a derived flat list of R version strings retained for
+backward compatibility).
+
+Run via uv:  ``uv run build_manifest.py write --s3-bucket BUCKET --cdn-base URL``
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime
+import json
+import re
+import sys
+from typing import Iterable, Optional
+
+import boto3
+
+
+# RFC 3339 UTC, second precision. Used in manifest envelope `generated_at`.
+_RFC3339_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+@dataclasses.dataclass(frozen=True)
+class BuildRecord:
+    r_version: str
+    platform: str
+    arch: str
+    filename: str
+
+
+# Filename patterns. Each pattern's first capture group is the R version,
+# additional groups are arch hints. Order matters: more specific patterns
+# come first.
+_DEB_RE = re.compile(r"^r-(?P<ver>[^_]+)_1_(?P<arch>amd64|arm64)\.deb$")
+_RPM_RE = re.compile(r"^R-(?P<ver>.+?)-1-1\.(?P<arch>x86_64|aarch64)\.rpm$")
+_APK_RE = re.compile(r"^r-(?P<ver>[^_]+)_1_(?P<arch>x86_64|aarch64)\.apk$")
+# Lazy `.+?` for `<ver>` works for current R version strings (e.g., "4.5.3",
+# "devel", "next", "patched"). A version containing a hyphen followed by a
+# lowercase token shorter than the platform identifier (hypothetical, not in
+# any current release) could be misparsed; revisit the regex if R ever ships
+# such a version.
+_TARBALL_RE = re.compile(r"^R-(?P<ver>.+?)-(?P<plat>[a-z0-9_-]+?)(?:-arm64)?\.tar\.gz$")
+_WINZIP_RE = re.compile(r"^R-(?P<ver>.+?)-windows\.zip$")
+
+# RPM-style arch suffixes get normalized to the dpkg/build-matrix convention
+# (amd64/arm64) so all Linux entries in the manifest use one identifier per
+# hardware target.
+_RPM_ARCH_NORMALIZE = {"x86_64": "amd64", "aarch64": "arm64"}
+
+
+def parse_s3_key(key: str) -> Optional[BuildRecord]:
+    """Parse an S3 key under ``r/`` into a BuildRecord, or None to skip.
+
+    Returns None for sidecar files (.sha256), index files (versions.json,
+    manifest.json), and anything that does not match a known artifact
+    naming pattern.
+    """
+    if not key.startswith("r/"):
+        return None
+    if key.endswith(".sha256"):
+        return None
+    parts = key.split("/")
+    # Valid keys: r/<platform>/<filename>     (3 parts)
+    #          or r/<platform>/pkgs/<filename> (4 parts with "pkgs" as parts[2])
+    if len(parts) == 3:
+        pass  # platform-root artifact
+    elif len(parts) == 4 and parts[2] == "pkgs":
+        pass  # native distro deb/rpm/apk
+    else:
+        return None  # versions.json, manifest.json, or unexpected nesting
+    platform = parts[1]
+    filename = parts[-1]
+
+    # Native distro debs and rpms live under r/<platform>/pkgs/<filename>.
+    if "/pkgs/" in key:
+        m = _DEB_RE.match(filename)
+        if m:
+            return BuildRecord(
+                r_version=m["ver"],
+                platform=platform,
+                arch=m["arch"],
+                filename=filename,
+            )
+        m = _RPM_RE.match(filename)
+        if m:
+            return BuildRecord(
+                r_version=m["ver"],
+                platform=platform,
+                arch=_RPM_ARCH_NORMALIZE[m["arch"]],
+                filename=filename,
+            )
+        m = _APK_RE.match(filename)
+        if m:
+            return BuildRecord(
+                r_version=m["ver"],
+                platform=platform,
+                arch=_RPM_ARCH_NORMALIZE[m["arch"]],
+                filename=filename,
+            )
+        return None
+
+    # Windows zip.
+    if platform == "windows":
+        m = _WINZIP_RE.match(filename)
+        if m:
+            return BuildRecord(
+                r_version=m["ver"],
+                platform="windows",
+                arch="x86_64",
+                filename=filename,
+            )
+        return None
+
+    # macOS tarball. Two shapes: R-<ver>-macos.tar.gz (x86_64) and
+    # R-<ver>-macos-arm64.tar.gz (arm64).
+    if platform == "macos":
+        m = _TARBALL_RE.match(filename)
+        if m and m["plat"] == "macos":
+            arch = "arm64" if filename.endswith("-arm64.tar.gz") else "x86_64"
+            return BuildRecord(
+                r_version=m["ver"],
+                platform="macos",
+                arch=arch,
+                filename=filename,
+            )
+        return None
+
+    # Portable Linux tarball (manylinux/musllinux). Same naming convention
+    # as macOS but with platform = manylinux_2_34 / musllinux_1_2 and the
+    # Linux arch convention (amd64/arm64).
+    m = _TARBALL_RE.match(filename)
+    if m and m["plat"] == platform:
+        arch = "arm64" if filename.endswith("-arm64.tar.gz") else "amd64"
+        return BuildRecord(
+            r_version=m["ver"],
+            platform=platform,
+            arch=arch,
+            filename=filename,
+        )
+    return None
+
+
+def build_url(cdn_base: str, rec: BuildRecord, under_pkgs: bool) -> str:
+    """Construct a fully-qualified CDN URL for a build artifact."""
+    suffix = "/pkgs/" if under_pkgs else "/"
+    return f"{cdn_base}/r/{rec.platform}{suffix}{rec.filename}"
+
+
+def _version_sort_key(version: str):
+    """Sort key for R version strings.
+
+    Numeric versions sort by tuple (descending). Named channels (devel, next,
+    patched) sort above all numeric versions in a stable order.
+    """
+    named_order = {"devel": 0, "next": 1, "patched": 2}
+    if version in named_order:
+        # Named channels: tuple length matches numeric path so comparison is total.
+        return (0, named_order[version], 0, 0)
+    parts = version.split(".")
+    try:
+        nums = tuple(int(p) for p in parts)
+    except ValueError:
+        # Unknown form — sort to the end deterministically.
+        return (2, version, 0, 0)
+    # Pad to length 3 so 4.5 and 4.5.0 compare equal-ish.
+    while len(nums) < 3:
+        nums = nums + (0,)
+    return (1,) + nums
+
+
+def _build_sort_key(b: dict) -> tuple:
+    """Sort key for an assembled build dict.
+
+    Named channels (devel, next, patched) sort to the top in fixed order.
+    Numeric versions sort newest-first. Within a version, platform then
+    arch alphabetical.
+    """
+    vk = _version_sort_key(b["r_version"])
+    if vk[0] == 0:
+        return (0, vk[1], b["platform"], b["arch"])
+    if vk[0] == 1:
+        # Negate to sort newest-first under ascending sort (4.5 > 4.4 → -4.5 < -4.4).
+        return (1, -vk[1], -vk[2], -vk[3], b["platform"], b["arch"])
+    return (2, b["r_version"], b["platform"], b["arch"])
+
+
+def assemble_manifest(
+    inputs: Iterable[tuple[BuildRecord, str, int]],
+    *,
+    generated_at: str,
+    cdn_base: str,
+) -> dict:
+    """Build the manifest dict from (record, sha256, size) tuples."""
+    builds = []
+    for rec, sha256, size in inputs:
+        # deb/rpm live under <platform>/pkgs/, everything else is at the
+        # platform root.
+        under_pkgs = rec.filename.endswith((".deb", ".rpm", ".apk"))
+        builds.append({
+            "r_version": rec.r_version,
+            "platform": rec.platform,
+            "arch": rec.arch,
+            "url": build_url(cdn_base, rec, under_pkgs=under_pkgs),
+            "sha256": sha256,
+            "size": size,
+        })
+    builds.sort(key=_build_sort_key)
+    return {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "builds": builds,
+    }
+
+
+def _versions_sort_key(version: str) -> tuple:
+    """Sort key for versions.json: named channels first (devel, next,
+    patched in that order), then numeric versions newest-first."""
+    vk = _version_sort_key(version)
+    if vk[0] == 0:
+        return (0, vk[1])
+    if vk[0] == 1:
+        # Negate to sort newest-first under ascending sort.
+        return (1, -vk[1], -vk[2], -vk[3])
+    return (2, version)
+
+
+def derive_versions(manifest: dict) -> dict:
+    """Build the legacy versions.json content from the manifest."""
+    versions = list(dict.fromkeys(b["r_version"] for b in manifest["builds"]))
+    versions.sort(key=_versions_sort_key)
+    return {"r_versions": versions}
+
+
+def list_artifacts(s3_client, bucket: str) -> list[tuple[BuildRecord, str, int]]:
+    """List all artifacts under ``r/`` in the bucket and pair each with its
+    sha256 sidecar contents and size.
+
+    Skips artifacts whose .sha256 sidecar is missing — they will be filled
+    in by the next CI run that publishes them, or by the backfill script.
+    """
+    paginator = s3_client.get_paginator("list_objects_v2")
+    keys: dict[str, int] = {}
+    for page in paginator.paginate(Bucket=bucket, Prefix="r/"):
+        for obj in page.get("Contents", []) or []:
+            keys[obj["Key"]] = obj["Size"]
+
+    results: list[tuple[BuildRecord, str, int]] = []
+    for key, size in keys.items():
+        rec = parse_s3_key(key)
+        if rec is None:
+            continue
+        sha_key = f"{key}.sha256"
+        if sha_key not in keys:
+            print(f"WARNING: sidecar missing for {key}; skipping", file=sys.stderr)
+            continue
+        body = s3_client.get_object(Bucket=bucket, Key=sha_key)["Body"].read()
+        sha256 = body.decode("utf-8").strip().split()[0]
+        if len(sha256) != 64 or not all(c in "0123456789abcdef" for c in sha256):
+            print(f"WARNING: malformed sidecar for {key}; skipping", file=sys.stderr)
+            continue
+        results.append((rec, sha256, size))
+    return results
+
+
+def write_manifest(bucket: str, cdn_base: str, dry_run: bool = False) -> None:
+    """List S3, build manifest.json and versions.json, upload both."""
+    cdn_base = cdn_base.rstrip("/")
+    s3 = boto3.client("s3")
+    inputs = list_artifacts(s3, bucket)
+    generated_at = datetime.datetime.now(datetime.timezone.utc).strftime(_RFC3339_FMT)
+    manifest = assemble_manifest(inputs, generated_at=generated_at, cdn_base=cdn_base)
+    versions = derive_versions(manifest)
+
+    # Read existing versions.json from S3 and union with the newly-derived
+    # version list. Without this, a consolidator run before the sha256
+    # sidecar backfill is complete would shrink versions.json from ~80 R
+    # versions to whatever subset has sidecars, breaking install.sh and
+    # every external consumer that fetches the legacy index. Union semantics
+    # match the additive behavior of the old `manage_r_versions.py publish`
+    # command and preserve the design contract that versions.json keeps its
+    # "exact current content and shape".
+    try:
+        existing_body = s3.get_object(Bucket=bucket, Key="r/versions.json")["Body"].read()
+        existing = json.loads(existing_body).get("r_versions", [])
+    except s3.exceptions.NoSuchKey:
+        existing = []
+    union = list(dict.fromkeys(list(existing) + versions["r_versions"]))
+    union.sort(key=_versions_sort_key)
+    versions = {"r_versions": union}
+
+    manifest_body = json.dumps(manifest, indent=2).encode("utf-8")
+    versions_body = json.dumps(versions).encode("utf-8")
+
+    print(f"Manifest: {len(manifest['builds'])} builds, "
+          f"{len(versions['r_versions'])} R versions", file=sys.stderr)
+
+    if dry_run:
+        print("Dry run: not uploading.", file=sys.stderr)
+        sys.stdout.write(manifest_body.decode("utf-8"))
+        return
+
+    s3.put_object(
+        Bucket=bucket,
+        Key="r/manifest.json",
+        Body=manifest_body,
+        ContentType="application/json",
+        ACL="public-read",
+        CacheControl="public, max-age=300",
+    )
+    s3.put_object(
+        Bucket=bucket,
+        Key="r/versions.json",
+        Body=versions_body,
+        ContentType="application/json",
+        ACL="public-read",
+        CacheControl="public, max-age=300",
+    )
+    print(f"Uploaded r/manifest.json and r/versions.json to s3://{bucket}/",
+          file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build the r-builds CDN manifest.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    write = sub.add_parser("write", help="Build manifest from S3 listing and upload it.")
+    write.add_argument("--s3-bucket", required=True)
+    write.add_argument("--cdn-base", required=True,
+                       help="CDN base URL, e.g. https://cdn.posit.co")
+    write.add_argument("--dry-run", action="store_true",
+                       help="Print the manifest to stdout instead of uploading.")
+
+    args = parser.parse_args()
+    if args.command == "write":
+        write_manifest(args.s3_bucket, args.cdn_base, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_sha256.py
+++ b/scripts/backfill_sha256.py
@@ -1,0 +1,96 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "boto3",
+# ]
+# ///
+"""Backfill sha256 sidecars for existing artifacts on the r-builds CDN.
+
+One-shot maintenance tool. Run once per S3 bucket (staging, production)
+before the manifest workflow is enabled.
+
+For every object under ``r/`` that is not itself a sidecar, index file, or
+unrelated stray, compute sha256 and upload ``<key>.sha256`` if missing.
+Safe to re-run: existing sidecars are skipped.
+
+Usage:
+    uv run scripts/backfill_sha256.py --s3-bucket BUCKET [--dry-run] [--workers N]
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import hashlib
+import sys
+import os
+
+# Allow importing build_manifest from the repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+
+import boto3  # noqa: E402
+
+from build_manifest import parse_s3_key  # noqa: E402
+
+
+def _hash_object(s3, bucket: str, key: str) -> str:
+    """Stream the object body and return the lowercase hex sha256."""
+    h = hashlib.sha256()
+    body = s3.get_object(Bucket=bucket, Key=key)["Body"]
+    for chunk in iter(lambda: body.read(8 * 1024 * 1024), b""):
+        h.update(chunk)
+    return h.hexdigest()
+
+
+def _process_one(bucket: str, key: str, existing_sidecars: set[str], dry_run: bool) -> str:
+    s3 = boto3.client("s3")
+    sha_key = f"{key}.sha256"
+    if sha_key in existing_sidecars:
+        return f"skip (sidecar exists): {key}"
+    digest = _hash_object(s3, bucket, key)
+    basename = key.rsplit("/", 1)[-1]
+    body = f"{digest}  {basename}\n".encode("utf-8")
+    if dry_run:
+        return f"would upload {sha_key}: {digest}"
+    s3.put_object(
+        Bucket=bucket,
+        Key=sha_key,
+        Body=body,
+        ContentType="text/plain",
+        ACL="public-read",
+    )
+    return f"uploaded {sha_key}: {digest}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--s3-bucket", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--workers", type=int, default=8,
+                        help="Concurrent download/upload workers (default: 8)")
+    args = parser.parse_args()
+
+    s3 = boto3.client("s3")
+    paginator = s3.get_paginator("list_objects_v2")
+    artifact_keys: list[str] = []
+    sidecars: set[str] = set()
+    for page in paginator.paginate(Bucket=args.s3_bucket, Prefix="r/"):
+        for obj in page.get("Contents", []) or []:
+            k = obj["Key"]
+            if k.endswith(".sha256"):
+                sidecars.add(k)
+            elif parse_s3_key(k) is not None:
+                artifact_keys.append(k)
+
+    print(f"{len(artifact_keys)} artifacts, {len(sidecars)} existing sidecars")
+
+    with cf.ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = [
+            pool.submit(_process_one, args.s3_bucket, k, sidecars, args.dry_run)
+            for k in artifact_keys
+        ]
+        for fut in cf.as_completed(futures):
+            print(fut.result())
+
+
+if __name__ == "__main__":
+    main()

--- a/test_build_manifest.py
+++ b/test_build_manifest.py
@@ -1,0 +1,221 @@
+from build_manifest import (
+    BuildRecord,
+    assemble_manifest,
+    build_url,
+    derive_versions,
+    parse_s3_key,
+)
+
+# Portable Linux tarballs ----------------------------------------------------
+
+def test_parse_manylinux_tarball_x86_64():
+    rec = parse_s3_key("r/manylinux_2_34/R-4.5.3-manylinux_2_34.tar.gz")
+    assert rec == BuildRecord(r_version="4.5.3", platform="manylinux_2_34", arch="amd64",
+                              filename="R-4.5.3-manylinux_2_34.tar.gz")
+
+def test_parse_manylinux_tarball_arm64():
+    rec = parse_s3_key("r/manylinux_2_34/R-4.5.3-manylinux_2_34-arm64.tar.gz")
+    assert rec == BuildRecord(r_version="4.5.3", platform="manylinux_2_34", arch="arm64",
+                              filename="R-4.5.3-manylinux_2_34-arm64.tar.gz")
+
+def test_parse_musllinux_tarball():
+    rec = parse_s3_key("r/musllinux_1_2/R-4.5.3-musllinux_1_2-arm64.tar.gz")
+    assert rec.platform == "musllinux_1_2"
+    assert rec.arch == "arm64"
+
+def test_parse_devel_tarball():
+    rec = parse_s3_key("r/manylinux_2_34/R-devel-manylinux_2_34.tar.gz")
+    assert rec == BuildRecord(r_version="devel", platform="manylinux_2_34", arch="amd64",
+                              filename="R-devel-manylinux_2_34.tar.gz")
+
+# Native Linux distro packages ----------------------------------------------
+
+def test_parse_ubuntu_deb_amd64():
+    rec = parse_s3_key("r/ubuntu-2204/pkgs/r-4.5.3_1_amd64.deb")
+    assert rec == BuildRecord(r_version="4.5.3", platform="ubuntu-2204", arch="amd64",
+                              filename="r-4.5.3_1_amd64.deb")
+
+def test_parse_ubuntu_deb_arm64():
+    rec = parse_s3_key("r/ubuntu-2204/pkgs/r-4.5.3_1_arm64.deb")
+    assert rec.arch == "arm64"
+
+def test_parse_rhel_rpm_x86_64_normalizes_to_amd64():
+    rec = parse_s3_key("r/rhel-9/pkgs/R-4.5.3-1-1.x86_64.rpm")
+    assert rec == BuildRecord(r_version="4.5.3", platform="rhel-9", arch="amd64",
+                              filename="R-4.5.3-1-1.x86_64.rpm")
+
+def test_parse_rhel_rpm_aarch64_normalizes_to_arm64():
+    rec = parse_s3_key("r/rhel-9/pkgs/R-4.5.3-1-1.aarch64.rpm")
+    assert rec.arch == "arm64"
+
+# macOS ---------------------------------------------------------------------
+
+def test_parse_macos_tarball_x86_64():
+    rec = parse_s3_key("r/macos/R-4.5.3-macos.tar.gz")
+    assert rec == BuildRecord(r_version="4.5.3", platform="macos", arch="x86_64",
+                              filename="R-4.5.3-macos.tar.gz")
+
+def test_parse_macos_tarball_arm64():
+    rec = parse_s3_key("r/macos/R-4.5.3-macos-arm64.tar.gz")
+    assert rec.arch == "arm64"
+
+# Windows -------------------------------------------------------------------
+
+def test_parse_windows_zip():
+    rec = parse_s3_key("r/windows/R-4.5.3-windows.zip")
+    assert rec == BuildRecord(r_version="4.5.3", platform="windows", arch="x86_64",
+                              filename="R-4.5.3-windows.zip")
+
+# Skips ---------------------------------------------------------------------
+
+def test_skip_sha256_sidecar():
+    assert parse_s3_key("r/macos/R-4.5.3-macos.tar.gz.sha256") is None
+
+def test_skip_versions_json():
+    assert parse_s3_key("r/versions.json") is None
+
+def test_skip_manifest_json():
+    assert parse_s3_key("r/manifest.json") is None
+
+def test_skip_unrecognized():
+    assert parse_s3_key("r/macos/some-stray-file.txt") is None
+
+
+def test_assemble_manifest_envelope():
+    records = [
+        (BuildRecord("4.5.3", "manylinux_2_34", "amd64", "R-4.5.3-manylinux_2_34.tar.gz"),
+         "abc123", 100),
+    ]
+    manifest = assemble_manifest(records, generated_at="2026-05-01T12:00:00Z",
+                                 cdn_base="https://cdn.posit.co")
+    assert manifest["schema_version"] == 1
+    assert manifest["generated_at"] == "2026-05-01T12:00:00Z"
+    assert len(manifest["builds"]) == 1
+    build = manifest["builds"][0]
+    assert build["r_version"] == "4.5.3"
+    assert build["platform"] == "manylinux_2_34"
+    assert build["arch"] == "amd64"
+    assert build["sha256"] == "abc123"
+    assert build["size"] == 100
+    assert build["url"] == "https://cdn.posit.co/r/manylinux_2_34/R-4.5.3-manylinux_2_34.tar.gz"
+
+
+def test_assemble_manifest_sorts_stably():
+    # Out-of-order input.
+    inputs = [
+        (BuildRecord("4.4.3", "macos", "arm64", "R-4.4.3-macos-arm64.tar.gz"), "h", 1),
+        (BuildRecord("4.5.3", "macos", "x86_64", "R-4.5.3-macos.tar.gz"), "h", 1),
+        (BuildRecord("4.5.3", "macos", "arm64", "R-4.5.3-macos-arm64.tar.gz"), "h", 1),
+        (BuildRecord("4.5.3", "manylinux_2_34", "amd64", "R-4.5.3-manylinux_2_34.tar.gz"),
+         "h", 1),
+    ]
+    m = assemble_manifest(inputs, generated_at="t", cdn_base="https://x")
+    keys = [(b["r_version"], b["platform"], b["arch"]) for b in m["builds"]]
+    # Newest version first; within version, platform then arch alphabetical.
+    assert keys == [
+        ("4.5.3", "macos", "arm64"),
+        ("4.5.3", "macos", "x86_64"),
+        ("4.5.3", "manylinux_2_34", "amd64"),
+        ("4.4.3", "macos", "arm64"),
+    ]
+
+
+def test_derive_versions_from_manifest():
+    manifest = {
+        "schema_version": 1,
+        "builds": [
+            {"r_version": "4.5.3", "platform": "macos", "arch": "arm64"},
+            {"r_version": "4.5.3", "platform": "manylinux_2_34", "arch": "amd64"},
+            {"r_version": "4.4.3", "platform": "macos", "arch": "x86_64"},
+            {"r_version": "devel", "platform": "manylinux_2_34", "arch": "amd64"},
+        ],
+    }
+    assert derive_versions(manifest) == {
+        "r_versions": ["devel", "4.5.3", "4.4.3"],
+    }
+
+
+def test_build_url():
+    assert build_url("https://cdn.posit.co",
+                     BuildRecord("4.5.3", "ubuntu-2204", "amd64",
+                                 "r-4.5.3_1_amd64.deb"),
+                     under_pkgs=True) == \
+        "https://cdn.posit.co/r/ubuntu-2204/pkgs/r-4.5.3_1_amd64.deb"
+    assert build_url("https://cdn.posit.co",
+                     BuildRecord("4.5.3", "macos", "arm64",
+                                 "R-4.5.3-macos-arm64.tar.gz"),
+                     under_pkgs=False) == \
+        "https://cdn.posit.co/r/macos/R-4.5.3-macos-arm64.tar.gz"
+
+
+def test_assemble_with_mixed_records_orders_and_urls_correctly():
+    records = [
+        (BuildRecord("4.4.3", "manylinux_2_34", "amd64", "R-4.4.3-manylinux_2_34.tar.gz"),
+         "a" * 64, 100),
+        (BuildRecord("4.5.3", "macos", "arm64", "R-4.5.3-macos-arm64.tar.gz"),
+         "b" * 64, 200),
+        (BuildRecord("devel", "manylinux_2_34", "amd64", "R-devel-manylinux_2_34.tar.gz"),
+         "c" * 64, 300),
+        (BuildRecord("4.5.3", "ubuntu-2204", "amd64", "r-4.5.3_1_amd64.deb"),
+         "d" * 64, 400),
+    ]
+    m = assemble_manifest(records, generated_at="2026-05-01T00:00:00Z",
+                         cdn_base="https://cdn.posit.co")
+    keys = [(b["r_version"], b["platform"], b["arch"]) for b in m["builds"]]
+    # devel sorts to the top, then 4.5.3 (newest numeric) ahead of 4.4.3.
+    # Within 4.5.3: macos < ubuntu-2204 alphabetically.
+    assert keys == [
+        ("devel", "manylinux_2_34", "amd64"),
+        ("4.5.3", "macos", "arm64"),
+        ("4.5.3", "ubuntu-2204", "amd64"),
+        ("4.4.3", "manylinux_2_34", "amd64"),
+    ]
+    # deb URL goes under /pkgs/, tarball URL is at the platform root.
+    deb_entry = next(b for b in m["builds"] if b["platform"] == "ubuntu-2204")
+    assert deb_entry["url"] == "https://cdn.posit.co/r/ubuntu-2204/pkgs/r-4.5.3_1_amd64.deb"
+    macos_entry = next(b for b in m["builds"] if b["platform"] == "macos")
+    assert macos_entry["url"] == "https://cdn.posit.co/r/macos/R-4.5.3-macos-arm64.tar.gz"
+
+
+# Native Linux tarballs (with hyphenated platform names) ----------------------
+
+def test_parse_rhel9_tarball_x86_64():
+    rec = parse_s3_key("r/rhel-9/R-4.5.3-rhel-9.tar.gz")
+    assert rec == BuildRecord(r_version="4.5.3", platform="rhel-9", arch="amd64",
+                              filename="R-4.5.3-rhel-9.tar.gz")
+
+def test_parse_rhel9_tarball_arm64():
+    rec = parse_s3_key("r/rhel-9/R-4.5.3-rhel-9-arm64.tar.gz")
+    assert rec.arch == "arm64"
+    assert rec.platform == "rhel-9"
+
+def test_parse_ubuntu_tarball():
+    rec = parse_s3_key("r/ubuntu-2204/R-4.5.3-ubuntu-2204.tar.gz")
+    assert rec.platform == "ubuntu-2204"
+    assert rec.arch == "amd64"
+
+def test_parse_centos7_tarball():
+    rec = parse_s3_key("r/centos-7/R-4.5.3-centos-7.tar.gz")
+    assert rec.platform == "centos-7"
+
+# musllinux APK packages ------------------------------------------------------
+
+def test_parse_musllinux_apk_x86_64_normalizes_to_amd64():
+    rec = parse_s3_key("r/musllinux_1_2/pkgs/r-4.5.3_1_x86_64.apk")
+    assert rec == BuildRecord(r_version="4.5.3", platform="musllinux_1_2", arch="amd64",
+                              filename="r-4.5.3_1_x86_64.apk")
+
+def test_parse_musllinux_apk_aarch64_normalizes_to_arm64():
+    rec = parse_s3_key("r/musllinux_1_2/pkgs/r-4.5.3_1_aarch64.apk")
+    assert rec.arch == "arm64"
+
+
+def test_derive_versions_union_logic_independent():
+    """The union logic is in write_manifest (S3-aware) and isn't directly
+    testable from derive_versions, but we can verify the helper that powers
+    it: _versions_sort_key sorts named channels first, then numeric desc.
+    """
+    from build_manifest import _versions_sort_key
+    inputs = ["4.4.3", "devel", "4.5.3", "next", "4.5.0"]
+    inputs.sort(key=_versions_sort_key)
+    assert inputs == ["devel", "next", "4.5.3", "4.5.0", "4.4.3"]


### PR DESCRIPTION
## Summary

Adds a single machine-readable manifest at `cdn.posit.co/r/manifest.json` that enumerates every R build available on the CDN — portable manylinux/musllinux/macOS/Windows tarballs alongside every native Linux distro deb/rpm/apk — so third-party tooling can discover and verifiably download R builds without per-platform probing or filename guesswork.

Every artifact also gets a `<artifact>.sha256` sidecar published next to it in S3, in `sha256sum -c`-compatible format. Consumers can verify a download with one shell line:

```sh
curl -O https://cdn.posit.co/r/manylinux_2_34/R-4.5.3-manylinux_2_34.tar.gz
curl -O https://cdn.posit.co/r/manylinux_2_34/R-4.5.3-manylinux_2_34.tar.gz.sha256
sha256sum -c R-4.5.3-manylinux_2_34.tar.gz.sha256
```

`versions.json` is unchanged in content and shape — the manifest is purely additive. The new code regenerates `versions.json` with read-modify-write semantics so a consolidator run before the initial sidecar backfill is complete cannot shrink the legacy index.

## Schema

```json
{
  "schema_version": 1,
  "generated_at": "2026-05-01T12:00:00Z",
  "builds": [
    {
      "r_version": "4.5.3",
      "platform": "manylinux_2_34",
      "arch": "amd64",
      "url": "https://cdn.posit.co/r/manylinux_2_34/R-4.5.3-manylinux_2_34.tar.gz",
      "sha256": "abc123...",
      "size": 123456789
    }
  ]
}
```

`(r_version, platform, arch)` is the natural primary key. Portability is identified by the platform string (`manylinux_2_34`, `musllinux_1_2`, `macos`, `windows`) — no separate boolean field. Sort order: named channels (`devel`, `next`, `patched`) at top in fixed order, numeric versions newest-first, then platform ascending, then arch ascending. RPM/APK arch is normalized to the dpkg convention (`x86_64`→`amd64`, `aarch64`→`arm64`) so all Linux entries share one identifier per hardware target.

## What changed

- **`build_manifest.py`** — parses S3 keys, fetches sidecars, assembles the manifest, regenerates `versions.json`, uploads both. CLI: `python3 build_manifest.py write --s3-bucket BUCKET --cdn-base URL [--dry-run]`.
- **`test_build_manifest.py`** — 27 unit tests covering parsing across all artifact shapes (deb/rpm/apk/tarball/zip including hyphenated platform names like `rhel-9`, `ubuntu-2204`), manifest assembly, sort order, and URL construction.
- **`scripts/backfill_sha256.py`** — one-shot maintenance tool. Streams every artifact, computes sha256, uploads `<artifact>.sha256` if missing. Idempotent and parallel (ThreadPoolExecutor).
- **`.github/workflows/update-manifest.yml`** *(new)* — reusable workflow with `workflow_call` and `workflow_dispatch` triggers. Runs once at the end of every publish run.
- **`build.yml`, `build-macos.yml`, `build-windows.yml`** — each gains a sha256 sidecar step before the publish step. The three scattered `update-versions-json` jobs are removed and replaced with one end-of-run call to `update-manifest.yml` from `build.yml`. The `update-manifest` job uses `if: !cancelled() && inputs.publish != ''` so partial-success runs still produce an accurate manifest while user-cancelled runs skip.
- **Makefile** — splits `unit-test` into `unit-test-builder` (existing) and `unit-test-manifest` (new).
- **README.md** — documents the manifest URL and sha256 sidecars.

## Test plan

- [ ] Approve and merge.
- [ ] Run `python3 scripts/backfill_sha256.py --s3-bucket <staging-bucket>` against staging until completion. Verify with `aws s3 ls s3://<staging-bucket>/r/ --recursive | grep -c '\.sha256$'` matches the artifact count.
- [ ] Trigger `update-manifest.yml` against staging via `gh workflow run update-manifest.yml -f publish=staging`.
- [ ] Fetch `https://cdn-staging…/r/manifest.json` and inspect the schema, sort order, and a sampling of URLs.
- [ ] Verify `versions.json` on staging is unchanged in shape and unioned with previous content.
- [ ] Repeat backfill against production.
- [ ] Trigger `update-manifest.yml` against production.
- [ ] Verify `https://cdn.posit.co/r/manifest.json` resolves and parses, and `versions.json` is unaffected for existing consumers (`install.sh` quick installer, etc.).