### PR TITLE
Fix Docker Compose and Dockerfile lint warnings

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -1,6 +1,6 @@
 FROM centos:centos7
 
-ENV OS_IDENTIFIER centos-7
+ENV OS_IDENTIFIER=centos-7
 
 # Use vault.centos.org since CentOS 7 is EOL and the official mirrors are no longer available
 RUN sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*

--- a/builder/Dockerfile.centos-8
+++ b/builder/Dockerfile.centos-8
@@ -1,6 +1,6 @@
 FROM rockylinux:8
 
-ENV OS_IDENTIFIER centos-8
+ENV OS_IDENTIFIER=centos-8
 
 RUN dnf -y upgrade \
     && dnf -y install dnf-plugins-core \

--- a/builder/Dockerfile.debian-12
+++ b/builder/Dockerfile.debian-12
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-ENV OS_IDENTIFIER debian-12
+ENV OS_IDENTIFIER=debian-12
 
 RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
@@ -17,7 +17,7 @@ RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_
     rm "nfpm_$(dpkg --print-architecture).deb"
 
 # Override the default pager used by R
-ENV PAGER /usr/bin/pager
+ENV PAGER=/usr/bin/pager
 
 # R 3.x requires PCRE2 for Pango support on Debian 12
 ENV INCLUDE_PCRE2_IN_R_3 yes

--- a/builder/Dockerfile.debian-13
+++ b/builder/Dockerfile.debian-13
@@ -1,6 +1,6 @@
 FROM debian:trixie
 
-ENV OS_IDENTIFIER debian-13
+ENV OS_IDENTIFIER=debian-13
 
 RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
@@ -22,7 +22,7 @@ RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_
     rm "nfpm_$(dpkg --print-architecture).deb"
 
 # Override the default pager used by R
-ENV PAGER /usr/bin/pager
+ENV PAGER=/usr/bin/pager
 
 # R 3.x requires PCRE2 for Pango support on Debian 13
 ENV INCLUDE_PCRE2_IN_R_3 yes

--- a/builder/Dockerfile.fedora-42
+++ b/builder/Dockerfile.fedora-42
@@ -1,6 +1,6 @@
 FROM fedora:42
 
-ENV OS_IDENTIFIER fedora-42
+ENV OS_IDENTIFIER=fedora-42
 
 RUN dnf -y upgrade \
     && dnf -y install dnf-plugins-core \

--- a/builder/Dockerfile.fedora-43
+++ b/builder/Dockerfile.fedora-43
@@ -1,6 +1,6 @@
 FROM fedora:43
 
-ENV OS_IDENTIFIER fedora-43
+ENV OS_IDENTIFIER=fedora-43
 
 RUN dnf -y upgrade \
     && dnf -y install dnf-plugins-core \

--- a/builder/Dockerfile.manylinux_2_34
+++ b/builder/Dockerfile.manylinux_2_34
@@ -1,6 +1,6 @@
 FROM rockylinux:9
 
-ENV OS_IDENTIFIER manylinux_2_34
+ENV OS_IDENTIFIER=manylinux_2_34
 
 RUN dnf -y upgrade \
     && dnf -y install dnf-plugins-core \

--- a/builder/Dockerfile.musllinux_1_2
+++ b/builder/Dockerfile.musllinux_1_2
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-ENV OS_IDENTIFIER musllinux_1_2
+ENV OS_IDENTIFIER=musllinux_1_2
 
 RUN apk update && apk add --no-cache \
     autoconf \

--- a/builder/Dockerfile.opensuse-156
+++ b/builder/Dockerfile.opensuse-156
@@ -1,6 +1,6 @@
 FROM opensuse/leap:15.6
 
-ENV OS_IDENTIFIER opensuse-156
+ENV OS_IDENTIFIER=opensuse-156
 
 # Most of these packages, and also the configure options that follow were determined
 # by reviewing "R-base.spec" from the following OpenSUSE RPM:

--- a/builder/Dockerfile.opensuse-160
+++ b/builder/Dockerfile.opensuse-160
@@ -1,6 +1,6 @@
 FROM opensuse/leap:16.0
 
-ENV OS_IDENTIFIER opensuse-160
+ENV OS_IDENTIFIER=opensuse-160
 
 # Most of these packages, and also the configure options that follow were determined
 # by reviewing "R-base.spec" from the following OpenSUSE RPM:

--- a/builder/Dockerfile.rhel-10
+++ b/builder/Dockerfile.rhel-10
@@ -1,6 +1,6 @@
 FROM rockylinux/rockylinux:10
 
-ENV OS_IDENTIFIER rhel-10
+ENV OS_IDENTIFIER=rhel-10
 
 RUN dnf -y upgrade \
     && dnf -y install dnf-plugins-core \

--- a/builder/Dockerfile.rhel-9
+++ b/builder/Dockerfile.rhel-9
@@ -1,6 +1,6 @@
 FROM rockylinux:9
 
-ENV OS_IDENTIFIER rhel-9
+ENV OS_IDENTIFIER=rhel-9
 
 RUN dnf -y upgrade \
     && dnf -y install dnf-plugins-core \

--- a/builder/Dockerfile.ubuntu-2004
+++ b/builder/Dockerfile.ubuntu-2004
@@ -1,6 +1,6 @@
 FROM ubuntu:focal
 
-ENV OS_IDENTIFIER ubuntu-2004
+ENV OS_IDENTIFIER=ubuntu-2004
 
 RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
@@ -16,7 +16,7 @@ RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_
 RUN chmod 0777 /opt
 
 # Override the default pager used by R
-ENV PAGER /usr/bin/pager
+ENV PAGER=/usr/bin/pager
 
 COPY package.ubuntu-2004 /package.sh
 COPY build.sh .

--- a/builder/Dockerfile.ubuntu-2204
+++ b/builder/Dockerfile.ubuntu-2204
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-ENV OS_IDENTIFIER ubuntu-2204
+ENV OS_IDENTIFIER=ubuntu-2204
 
 RUN set -x \
   && sed -i "s|# deb-src|deb-src|g" /etc/apt/sources.list \
@@ -16,10 +16,10 @@ RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_
 RUN chmod 0777 /opt
 
 # Override the default pager used by R
-ENV PAGER /usr/bin/pager
+ENV PAGER=/usr/bin/pager
 
 # R 3.x requires PCRE2 for Pango support on Ubuntu 22
-ENV INCLUDE_PCRE2_IN_R_3 yes
+ENV INCLUDE_PCRE2_IN_R_3=yes
 
 COPY package.ubuntu-2204 /package.sh
 COPY build.sh .

--- a/builder/Dockerfile.ubuntu-2404
+++ b/builder/Dockerfile.ubuntu-2404
@@ -1,6 +1,6 @@
 FROM ubuntu:noble
 
-ENV OS_IDENTIFIER ubuntu-2404
+ENV OS_IDENTIFIER=ubuntu-2404
 
 RUN set -x \
   && sed -i "s|Types: deb|Types: deb deb-src|g" /etc/apt/sources.list.d/ubuntu.sources \
@@ -23,7 +23,7 @@ RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_
 RUN chmod 0777 /opt
 
 # Override the default pager used by R
-ENV PAGER /usr/bin/pager
+ENV PAGER=/usr/bin/pager
 
 # R 3.x requires PCRE2 for Pango support on Ubuntu 24
 ENV INCLUDE_PCRE2_IN_R_3 yes

--- a/builder/Dockerfile.ubuntu-2604
+++ b/builder/Dockerfile.ubuntu-2604
@@ -1,6 +1,6 @@
 FROM ubuntu:resolute
 
-ENV OS_IDENTIFIER ubuntu-2604
+ENV OS_IDENTIFIER=ubuntu-2604
 
 RUN set -x \
   && sed -i "s|Types: deb|Types: deb deb-src|g" /etc/apt/sources.list.d/ubuntu.sources \
@@ -23,7 +23,7 @@ RUN curl -LO "https://github.com/goreleaser/nfpm/releases/download/v2.46.1/nfpm_
 RUN chmod 0777 /opt
 
 # Override the default pager used by R
-ENV PAGER /usr/bin/pager
+ENV PAGER=/usr/bin/pager
 
 # Note: Ubuntu 26 does not have PCRE1 (libpcre3), so R 3.x is not supported
 

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -16,7 +16,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -29,7 +29,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -42,7 +42,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -55,7 +55,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -68,7 +68,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -81,7 +81,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -94,7 +94,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -107,7 +107,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -120,7 +120,7 @@ services:
     command: bash ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -133,7 +133,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -146,7 +146,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -159,7 +159,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -172,7 +172,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -185,7 +185,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .
@@ -198,7 +198,7 @@ services:
     command: ./build.sh
     environment:
       - R_VERSION=${R_VERSION}
-      - R_INSTALL_PATH=${R_INSTALL_PATH}
+      - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
     build:
       context: .


### PR DESCRIPTION
## Summary                                                                                                                                                                                          
                                                                                                                                                                                                      
- Fix `LegacyKeyValueFormat` Dockerfile lint warnings by updating all `ENV key value` statements to `ENV key=value` format across 16 Dockerfiles                                                    
- Fix Docker Compose warnings about unset `R_INSTALL_PATH` variable by providing explicit empty default (`${R_INSTALL_PATH:-}`)                                                                     
