### PR TITLE
Properly acknowledge portable-r in macOS and Windows READMEs

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -270,7 +270,9 @@ The Makefile's `build-r-macos` target also extracts the tarball before running t
 
 **`bin/R` works but the IDE can't find R** — verify `bin/R` still contains a static `R_HOME_DIR=...` line. If it was overwritten (e.g. by an extra sed pass), the IDE's text parser can't extract a path. The runtime override should be *inserted before* the static line, not replace it.
 
-## Related projects
+## Acknowledgements
 
-- **[portable-r/portable-r-macos](https://github.com/portable-r/portable-r-macos)** — independent prototype of the same approach. Used as a reference; this pipeline shares its core idea (CRAN .pkg + post-process) but adds CI integration, Developer ID signing, the version-aware Rscript wrapper, and the base-Rprofile hook design.
-- **[builder/portable-r/](../builder/portable-r/README.md)** — the Linux portable builds. Different mechanism (compile from source + bundle libs via `delocate_r.py`) but the same goal of relocatable, distribution-independent R.
+This pipeline is based on [portable-r/portable-r-macos](https://github.com/portable-r/portable-r-macos) by James Balamuta. The approach of producing a portable macOS R from the official
+CRAN `.pkg`, the Mach-O install-name rewriting that replaces
+`/Library/Frameworks/R.framework/...` paths with `@rpath`, `@loader_path`, and
+`@executable_path` references, and the `Rprofile` hook installs a `.portable` R environment wrapping `install.packages()` to patch CRAN binary packages after install, all originated in that project. The techniques in this directory are adapted from that work.

--- a/windows/README.md
+++ b/windows/README.md
@@ -165,8 +165,11 @@ The Makefile's `build-r-windows` target also extracts the zip before running tes
 
 **Build is extremely slow on PowerShell 5.1** — `$ProgressPreference = 'SilentlyContinue'` is set in `build.ps1`, but if you're invoking the script with `-NoProfile` and overriding the variable, restore it. The PS 5.1 progress bar is a known bottleneck for `Invoke-WebRequest` and `Expand-Archive`.
 
-## Related projects
+## Acknowledgements
 
-- **[portable-r/portable-r-windows](https://github.com/portable-r/portable-r-windows)** — independent prototype of the same approach. Used as a reference; this pipeline shares its core idea (CRAN .exe extraction + minimal post-process) but adds CI integration, the innoextract+silent-install fallback chain, and the base-Rprofile hook design.
-- **[`macos/README.md`](../macos/README.md)** — companion macOS portable builds. Same goals, much heavier post-processing because CRAN macOS binaries embed framework paths.
-- **[`builder/portable-r/`](../builder/portable-r/README.md)** — the Linux portable builds. Different mechanism (compile from source + bundle libs via `delocate_r.py`) but the same goal of relocatable, distribution-independent R.
+This pipeline is based on [portable-r/portable-r-windows](https://github.com/portable-r/portable-r-windows)
+by James Balamuta. The approach of producing a portable Windows R from the
+official CRAN Inno Setup installer (extracting it with innoextract, falling
+back to a silent install), and configuring a portable site-library and CRAN
+mirror via an `Rprofile` hook, originated in that project. The techniques in
+this directory are adapted from that work.


### PR DESCRIPTION
The portable macOS and Windows pipelines in this repo are adapted from
portable-r/portable-r-macos and portable-r/portable-r-windows by James
Balamuta. Add the proper Acknowledgements sections that credit the author
by name and describe the techniques that originated upstream.

Ref https://github.com/rstudio/r-builds/issues/299