### PR TITLE
Remove deprecated 'install' input from setup-buildx-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,8 +179,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          install: true
 
       # Enable Docker layer caching without having to push to a registry.
       # https://docs.docker.com/build/ci/github-actions/examples/#local-cache
@@ -227,8 +225,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          install: true
 
       - name: Restore cached Docker layers
         uses: actions/cache@v5


### PR DESCRIPTION
Fixing GHA warning:
```
Warning: Unexpected input(s) 'install', valid inputs are ['version', 'driver', 'driver-opts', 'buildkitd-flags', 'buildkitd-config', 'buildkitd-config-inline', 'use', 'name', 'endpoint', 'platforms', 'append', 'keep-state', 'cache-binary', 'cleanup']
```
https://github.com/rstudio/r-builds/actions/runs/25843407005


The `install: true` input was removed in docker/setup-buildx-action@v4. Buildx is now installed by default, making this option unnecessary and causing workflow warnings.