### PR TITLE
Fix Windows R-next build by resolving R-patched filename dynamically

### DIFF
--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -26,9 +26,24 @@ if (Test-Path $InstallerPath) {
     #   current       — cloud.r-project.org/bin/windows/base/R-$Version-win.exe
     #   main archive  — cloud.r-project.org/bin/windows/base/old/$Version/...
     #   cran-archive  — cran-archive.r-project.org/bin/windows/base/old/$Version/...
-    # devel uses its own stable URL; all other versions walk the list.
+    # devel uses its own stable URL; "next" (R-patched, matching the
+    # base-prerelease/R-patched.tar.gz source used by the Linux build) needs
+    # the current release filename resolved from rpatched.html because the
+    # filename embeds the current major.minor.patch (e.g. R-4.6.0patched-win.exe)
+    # and changes with each release. All other versions walk the candidate list.
     if ($Version -eq "devel") {
         $candidates = @("https://cloud.r-project.org/bin/windows/base/R-devel-win.exe")
+    } elseif ($Version -eq "next") {
+        $rpatchedUrl = "https://cloud.r-project.org/bin/windows/base/rpatched.html"
+        Write-Host "  Resolving R-patched installer filename from $rpatchedUrl"
+        $resp = Invoke-WebRequest -Uri $rpatchedUrl -UseBasicParsing
+        $match = [regex]::Match($resp.Content, 'href="(R-[^"]+patched-win\.exe)"')
+        if (-not $match.Success) {
+            throw "Could not find patched installer link in $rpatchedUrl"
+        }
+        $patchedFile = $match.Groups[1].Value
+        Write-Host "  Resolved: $patchedFile"
+        $candidates = @("https://cloud.r-project.org/bin/windows/base/$patchedFile")
     } else {
         $candidates = @(
             "https://cloud.r-project.org/bin/windows/base/R-$Version-win.exe",


### PR DESCRIPTION
## Summary
- The daily R-next Windows job has been failing because `windows/build.ps1` tried to download `R-next-win.exe` — a filename CRAN never publishes.
- In r-builds, `next` semantically means R-patched (see `builder/build.sh:47-48`, which pulls `base-prerelease/R-patched.tar.gz` for Linux). CRAN's Windows patched build is named `R-{current-release}patched-win.exe` (e.g. `R-4.6.0patched-win.exe` today), and the filename rolls forward with each release — hardcoding it would just defer the same breakage.
- Add a `next` branch in the URL-resolver that fetches `rpatched.html` and regex-extracts the current installer filename, mirroring macOS's dynamic per-branch nightly resolution. All downstream stages (extraction, staging-dir flattening, zip naming, the test step) are version-agnostic and need no changes.

Failing run for reference: https://github.com/rstudio/r-builds/actions/runs/26143347109/job/76893319563

## Test plan
- [ ] Manually trigger the `Daily R-devel and R-next builds` workflow and confirm the `build-windows / windows (R next)` job succeeds and uploads `R-next-windows.zip`.
- [ ] Confirm `build-windows / windows (R devel)` still succeeds (devel branch of the URL resolver is unchanged).
- [ ] Spot-check the extracted artifact reports the expected patched version via `R --version`.