### PR TITLE
Parse trailing args correctly in portable `Rscript`

### DIFF
--- a/builder/portable-r/make-relocatable.sh
+++ b/builder/portable-r/make-relocatable.sh
@@ -87,39 +87,54 @@ r_opts=( "--slave" "--no-restore" )
 r_file=""
 r_args=()
 while [ $# -gt 0 ]; do
-  case "$1" in
-    --help|-h)
-      echo "Usage: Rscript [options] [-e expr [-e expr2 ...] | file] [args]"
-      exit 0
-      ;;
-    --version)
-      exec "${R_HOME}/bin/R" --slave -e 'cat(sprintf("Rscript (R) version %s.%s (%s)\n", R.version$major, R.version$minor, R.version$date))'
-      ;;
-    --default-packages=*)
-      R_DEFAULT_PACKAGES="${1#--default-packages=}"
-      export R_DEFAULT_PACKAGES
-      shift
-      ;;
-    -e)
-      # Collect R expressions - each -e is followed by an expression
+  if [ -n "$r_file" ]; then
+    # Everything after the filename is a trailing arg
+    r_args+=( "$1" )
+    shift
+  elif [ "${#r_exprs[@]}" -gt 0 ]; then
+    # Everything after the first -e arg, except for other -e args, is a trailing arg
+    if [ "$1" = "-e" ]; then
       r_exprs+=( "$1" "$2" )
       shift 2
-      ;;
-    --*)
-      # Collect R options (--verbose, --vanilla, --no-environ, etc.)
-      r_opts+=( "$1" )
+    else
+      r_args+=( "$1" )
       shift
-      ;;
-    *)
-      # Positional args - first one is the file to execute iff we don't have any -e expressions yet
-      if [ -z "$r_file" -a "${#r_exprs[@]}" -eq 0 ]; then
-        r_file="$1"
-      else
-        r_args+=( "$1" )
-      fi
-      shift
-      ;;
-  esac
+    fi
+  else
+    case "$1" in
+      --help|-h)
+        echo "Usage: Rscript [options] [-e expr [-e expr2 ...] | file] [args]"
+        exit 0
+        ;;
+      --version)
+        exec "${R_HOME}/bin/R" --slave -e 'cat(sprintf("Rscript (R) version %s.%s (%s)\n", R.version$major, R.version$minor, R.version$date))'
+        ;;
+      --default-packages=*)
+        R_DEFAULT_PACKAGES="${1#--default-packages=}"
+        export R_DEFAULT_PACKAGES
+        shift
+        ;;
+      -e)
+        # Collect R expressions - each -e is followed by an expression
+        r_exprs+=( "$1" "$2" )
+        shift 2
+        ;;
+      --*)
+        # Collect R options (--verbose, --vanilla, --no-environ, etc.)
+        r_opts+=( "$1" )
+        shift
+        ;;
+      *)
+        # Positional args - first one is the file to execute iff we don't have any -e expressions yet
+        if [ -z "$r_file" -a "${#r_exprs[@]}" -eq 0 ]; then
+          r_file="$1"
+        else
+          r_args+=( "$1" )
+        fi
+        shift
+        ;;
+    esac
+  fi
 done
 
 # Start composing the command to execute

--- a/builder/portable-r/make-relocatable.sh
+++ b/builder/portable-r/make-relocatable.sh
@@ -82,7 +82,7 @@ export R_HOME
 # R understands --verbose, --vanilla, --no-environ, --no-site-file, etc.
 # directly, so we only need to handle --default-packages (env var conversion)
 # and file argument conversion (first positional arg -> --file=).
-r_exprs=""
+r_exprs=()
 r_opts=( "--slave" "--no-restore" )
 r_file=""
 r_args=()
@@ -102,12 +102,7 @@ while [ $# -gt 0 ]; do
       ;;
     -e)
       # Collect R expressions - each -e is followed by an expression
-      # Note that bin/R only accepts one -e arg, whereas Rscript accepts multiple; so we have to concatenate into a single expression
-      if [ -z "$r_exprs" ]; then
-        r_exprs="$2"
-      else
-        r_exprs="$r_exprs; $2"
-      fi
+      r_exprs+=( "$1" "$2" )
       shift 2
       ;;
     --*)
@@ -116,8 +111,8 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     *)
-      # Positional args - first one is the file to execute iff we don't have any -e expressions
-      if [ -z "$r_file" -a -z "$r_exprs" ]; then
+      # Positional args - first one is the file to execute iff we don't have any -e expressions yet
+      if [ -z "$r_file" -a "${#r_exprs[@]}" -eq 0 ]; then
         r_file="$1"
       else
         r_args+=( "$1" )
@@ -135,9 +130,9 @@ if [ "${#r_opts[@]}" -gt 0 ]; then
   r_cmd+=( "${r_opts[@]}" )
 fi
 
-# r_exprs is, after earlier concatenation, a single R expression
-if [ -n "$r_exprs" ]; then
-  r_cmd+=( "-e" "$r_exprs" )
+# r_exprs contains collected R expressions
+if [ "${#r_exprs[@]}" -gt 0  ]; then
+  r_cmd+=( "${r_exprs[@]}" )
 elif [ -n "$r_file" ]; then
   # If we didn't have any -e expressions, but we did have positional args, then we assumed the first arg was the file to execute
   r_cmd+=( "--file=$r_file" )

--- a/builder/portable-r/make-relocatable.sh
+++ b/builder/portable-r/make-relocatable.sh
@@ -82,7 +82,10 @@ export R_HOME
 # R understands --verbose, --vanilla, --no-environ, --no-site-file, etc.
 # directly, so we only need to handle --default-packages (env var conversion)
 # and file argument conversion (first positional arg -> --file=).
-r_opts=""
+r_exprs=""
+r_opts=( "--slave" "--no-restore" )
+r_file=""
+r_args=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --help|-h)
@@ -98,39 +101,54 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     -e)
-      # -e starts expressions -- stop processing options, pass rest to R
-      break
+      # Collect R expressions - each -e is followed by an expression
+      # Note that bin/R only accepts one -e arg, whereas Rscript accepts multiple; so we have to concatenate into a single expression
+      if [ -z "$r_exprs" ]; then
+        r_exprs="$2"
+      else
+        r_exprs="$r_exprs; $2"
+      fi
+      shift 2
       ;;
     --*)
       # Collect R options (--verbose, --vanilla, --no-environ, etc.)
-      r_opts="$r_opts $1"
+      r_opts+=( "$1" )
       shift
       ;;
     *)
-      # First positional arg is the script file
-      break
+      # Positional args - first one is the file to execute iff we don't have any -e expressions
+      if [ -z "$r_file" -a -z "$r_exprs" ]; then
+        r_file="$1"
+      else
+        r_args+=( "$1" )
+      fi
+      shift
       ;;
   esac
 done
 
-# $@ now contains: [-e expr ...] or [file [args...]] or nothing
+# Start composing the command to execute
+r_cmd=("${R_HOME}/bin/R")
+
 # r_opts contains collected --options (no spaces in individual options)
-if [ $# -eq 0 ]; then
-  # No file or -e: just R options
-  exec "${R_HOME}/bin/R" --slave --no-restore $r_opts
-elif [ "$1" = "-e" ]; then
-  # -e expressions: pass through directly (preserves quoting via "$@")
-  exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "$@"
-else
-  # File argument: convert to --file=, remaining args become --args
-  file="$1"
-  shift
-  if [ $# -gt 0 ]; then
-    exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "--file=$file" --args "$@"
-  else
-    exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "--file=$file"
-  fi
+if [ "${#r_opts[@]}" -gt 0 ]; then
+  r_cmd+=( "${r_opts[@]}" )
 fi
+
+# r_exprs is, after earlier concatenation, a single R expression
+if [ -n "$r_exprs" ]; then
+  r_cmd+=( "-e" "$r_exprs" )
+elif [ -n "$r_file" ]; then
+  # If we didn't have any -e expressions, but we did have positional args, then we assumed the first arg was the file to execute
+  r_cmd+=( "--file=$r_file" )
+fi
+
+# r_args contains [args...] - note that for bin/R these follow --args, whereas for Rscript they just trail
+if [ "${#r_args[@]}" -gt 0 ]; then
+  r_cmd+=( "--args" "${r_args[@]}" )
+fi
+
+exec "${r_cmd[@]}"
 RSCRIPT_EOF
   chmod +x "$rscript"
   echo "  Replaced $(basename "$(dirname "$rscript")")/Rscript with relocatable wrapper"


### PR DESCRIPTION
Fixes #311.

Instead of passing all args following `-e` directly to R, we instead "collect" `-e` arguments and trailing args, similarly to how we are already collecting `--options`. Then all the collected arguments are used to construct the command which is ultimately executed.

Because we can't now use the "easy" option of `"$@"`, it becomes awkward to make sure all arguments are quoted correctly. I _think_ this implementation using bash arrays is behaving well, but I'd love to know if it could be improved!

---

I _think_ this implementation also now aligns better with how the compiled `Rscript` handles argument order. From [the docs](https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html):

> The prescribed order of arguments is important: e.g. `--verbose` specified after `-e` will be part of `args` and passed to the expression; the same will happen to `-e` specified after `file`.

To me, there's some slight ambiguity about what to do if there are multiple `-e` args _interspersed_ with trailing args. This seems like an unlikely situation to come across in real life, but you never know... for now, I've opted to collect _all_ `-e` args first, and then to collect anything else as a trailing arg. This could easily be adjusted though.