### PR TITLE
Parse trailing args correctly in portable `Rscript`

### DIFF
--- a/builder/portable-r/make-relocatable.sh
+++ b/builder/portable-r/make-relocatable.sh
@@ -123,7 +123,9 @@ elif [ "$1" = "-e" ]; then
   # We can have multiple -e args, but once we have a trailing arg, all subsequent args are also trailing
   is_e=0
   is_trailing=0
+  # Cycle through "$@", dropping each arg from the front and replacing appropriately at the back
   for arg in "$@"; do
+    shift
     if [ $is_trailing = 1 ]; then
       set -- "$@" "$arg"
     elif [ "$arg" = "-e" ]; then
@@ -135,7 +137,6 @@ elif [ "$1" = "-e" ]; then
       set -- "$@" "--args" "$arg"
       is_trailing=1
     fi
-    shift
   done
   exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "$@"
 else

--- a/builder/portable-r/make-relocatable.sh
+++ b/builder/portable-r/make-relocatable.sh
@@ -113,13 +113,30 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# $@ now contains: [-e expr ...] or [file [args...]] or nothing
+# $@ now contains: [-e expr [-e expr] [args...]] or [file [args...]] or nothing
 # r_opts contains collected --options (no spaces in individual options)
 if [ $# -eq 0 ]; then
   # No file or -e: just R options
   exec "${R_HOME}/bin/R" --slave --no-restore $r_opts
 elif [ "$1" = "-e" ]; then
-  # -e expressions: pass through directly (preserves quoting via "$@")
+  # At least one -e arg before any trailing args - pass these, plus trailing args, to R using "$@" to preserve quoting
+  # We can have multiple -e args, but once we have a trailing arg, all subsequent args are also trailing
+  is_e=0
+  is_trailing=0
+  for arg in "$@"; do
+    if [ $is_trailing = 1 ]; then
+      set -- "$@" "$arg"
+    elif [ "$arg" = "-e" ]; then
+      is_e=1
+    elif [ $is_e = 1 ]; then
+      set -- "$@" "-e" "$arg"
+      is_e=0
+    else
+      set -- "$@" "--args" "$arg"
+      is_trailing=1
+    fi
+    shift
+  done
   exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "$@"
 else
   # File argument: convert to --file=, remaining args become --args

--- a/builder/portable-r/test-manylinux.sh
+++ b/builder/portable-r/test-manylinux.sh
@@ -210,7 +210,7 @@ result=$("$RSCRIPT" -e 'cat("a")' -e 'cat("b")')
 echo "  Rscript -e -e: OK"
 
 # -e expressions with trailing arguments (regression test for #311)
-result=$("RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
+result=$("$RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
 [ "$result" = "one/two three/ARG1 ARG2" ] || { echo "FAIL: Rscript -e ARGS"; exit 1; }
 echo "  Rscript -e ARGS: OK"
 

--- a/builder/portable-r/test-manylinux.sh
+++ b/builder/portable-r/test-manylinux.sh
@@ -209,6 +209,11 @@ result=$("$RSCRIPT" -e 'cat("a")' -e 'cat("b")')
 [ "$result" = "ab" ] || { echo "FAIL: Rscript -e -e"; exit 1; }
 echo "  Rscript -e -e: OK"
 
+# -e expressions with trailing arguments (regression test for #311)
+result=$("RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
+[ "$result" = "one/two three/ARG1 ARG2" ] || { echo "FAIL: Rscript -e ARGS"; exit 1; }
+echo "  Rscript -e ARGS: OK"
+
 # File execution with arguments
 tmpscript=$(mktemp /tmp/test_rscript_XXXXXX.R)
 echo 'args <- commandArgs(trailingOnly=TRUE); cat(paste(args, collapse=","))' > "$tmpscript"

--- a/builder/portable-r/test-musllinux.sh
+++ b/builder/portable-r/test-musllinux.sh
@@ -176,7 +176,7 @@ result=$("$RSCRIPT" -e 'cat("a")' -e 'cat("b")')
 echo "  Rscript -e -e: OK"
 
 # -e expressions with trailing arguments (regression test for #311)
-result=$("RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
+result=$("$RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
 [ "$result" = "one/two three/ARG1 ARG2" ] || { echo "FAIL: Rscript -e ARGS"; exit 1; }
 echo "  Rscript -e ARGS: OK"
 

--- a/builder/portable-r/test-musllinux.sh
+++ b/builder/portable-r/test-musllinux.sh
@@ -175,6 +175,11 @@ result=$("$RSCRIPT" -e 'cat("a")' -e 'cat("b")')
 [ "$result" = "ab" ] || { echo "FAIL: Rscript -e -e"; exit 1; }
 echo "  Rscript -e -e: OK"
 
+# -e expressions with trailing arguments (regression test for #311)
+result=$("RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
+[ "$result" = "one/two three/ARG1 ARG2" ] || { echo "FAIL: Rscript -e ARGS"; exit 1; }
+echo "  Rscript -e ARGS: OK"
+
 # File execution with arguments
 tmpscript=$(mktemp /tmp/test_rscript_XXXXXX.R)
 echo 'args <- commandArgs(trailingOnly=TRUE); cat(paste(args, collapse=","))' > "$tmpscript"


### PR DESCRIPTION
Fixes #311, effectively by inserting `--args` into the list of variables `$@` which are subsequently passed to R.

---

Supersedes previous attempt in #312, which depended on bash arrays - I think this solution is shell-agnostic (and somewhat neater!).