### PR TITLE
Fix portable `Rscript --version` for R <= 3.5

### DIFF
--- a/builder/portable-r/make-relocatable.sh
+++ b/builder/portable-r/make-relocatable.sh
@@ -90,7 +90,7 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     --version)
-      exec "${R_HOME}/bin/R" --slave -e 'cat(sprintf("Rscript (R) version %s.%s (%s-%s-%s)\n", R.version$major, R.version$minor, R.version$year, R.version$month, R.version$day))'
+      exec "${R_HOME}/bin/R" --slave -e 'writeLines(sprintf("Rscript (R) version %s.%s (%s-%s-%s)", R.version$major, R.version$minor, R.version$year, R.version$month, R.version$day))'
       ;;
     --default-packages=*)
       R_DEFAULT_PACKAGES="${1#--default-packages=}"


### PR DESCRIPTION
Rebuilding the portable R builds after #310 resulted in several failures with old R <= 3.5 versions: https://github.com/rstudio/r-builds/actions/runs/26907878523/job/79378554021
```sh
++ /opt/R/3.2.4/bin/Rscript --version
+ version_out='ARGUMENT '\''",~+~R.version$major,~+~R.version$minor,~+~R.version$year,~+~R.version$month,~+~R.version$day))'\'' __ignored__

Error: unexpected end of input
Execution halted'
```

This was a bug in R <= 3.5 apparently, where `\n` newlines broke `R -e`. The workaround is to use `writeLines()` instead.
```sh
$ R -s -e 'cat("test")\n'
Error: unexpected input in "cat("test")\"
Execution halted

$ R -s -e 'writeLines("test")'
test
```

## Testing

Rebuilt the manylinux image and R from source, then ran the Rscript wrapper tests across multiple R:

- [x] R 3.0.0 -> `Rscript (R) version 3.0.0 (2013-04-03)`
- [x] R 3.5.3 -> `Rscript (R) version 3.5.3 (2019-03-11)`
- [x] R 4.0.5 -> `Rscript (R) version 4.0.5 (2021-03-31)`
- [x] R 4.5.3 -> `Rscript (R) version 4.5.3 (2026-03-11)`
- [x] R 4.6.0 -> `Rscript (R) version 4.6.0 (2026-04-24)`

I did not test musllinux since it uses the same Rscript.
