### PR TITLE
Portable Linux: replace `Rscript` shell script with a native `Rscript` wrapper using `RHOME`

### DIFF
--- a/builder/portable-r/make-relocatable.sh
+++ b/builder/portable-r/make-relocatable.sh
@@ -55,101 +55,42 @@ R_HOME_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")"
   echo "  Patched lib/R/bin/R"
 fi
 
-echo ">>> Replace Rscript with relocatable wrapper"
-# Replace compiled Rscript binary with a relocatable shell wrapper.
-# The compiled Rscript has R_HOME hardcoded at compile time and doesn't check
-# the R_HOME env var, so it can't find bin/R after relocation.
-# The wrapper replicates Rscript's argument handling: options like --verbose,
-# --default-packages are processed; -e expressions pass through; the first
-# positional arg becomes --file=arg; remaining positional args use --args.
+echo ">>> Make Rscript relocatable (preserve binary, wrap with RHOME)"
+# The compiled Rscript binary has R_HOME baked in at compile time, so after
+# relocation it would exec the wrong (build-time) bin/R.
+#
+# But Rscript reads the RHOME environment variable and, when set, execs
+# "${RHOME}/bin/R" instead of the compiled-in path. This has held for every R
+# version we support (3.0+). See getenv("RHOME") in R's src/unix/Rscript.c:
+# https://github.com/wch/r-source/blob/tags/R-4-6-0/src/unix/Rscript.c#L230-L280
+#
+# So we preserve the original binary as Rscript.bin and install a thin wrapper
+# that sets RHOME from its own location and execs the real binary.
+#
+# Rscript depends only on libc + ld (no bundled libs), so the preserved binary
+# needs no RPATH/patchelf handling.
 for rscript in "${R_INSTALL_PATH}/bin/Rscript" "${R_INSTALL_PATH}/lib/R/bin/Rscript"; do
   [ -f "$rscript" ] || continue
-  # Determine R_HOME formula based on location (same logic as bin/R vs lib/R/bin/R)
+  # RHOME must be R_HOME (<prefix>/lib/R). Formula depends on the script's depth,
+  # same logic as the bin/R vs lib/R/bin/R distinction above.
+  #   bin/Rscript        is at <prefix>/bin/Rscript        -> RHOME=<prefix>/lib/R
+  #   lib/R/bin/Rscript  is at <R_HOME>/bin/Rscript        -> RHOME=<R_HOME>
   if [[ "$rscript" == */lib/R/bin/Rscript ]]; then
-    r_home_formula='R_HOME="$(dirname "$(dirname "$(readlink -f "$0")")")"'
+    rhome_formula='RHOME="$(dirname "$(dirname "$(readlink -f "$0")")")"'
   else
-    r_home_formula='R_HOME="$(dirname "$(dirname "$(readlink -f "$0")")")/lib/R"'
+    rhome_formula='RHOME="$(dirname "$(dirname "$(readlink -f "$0")")")/lib/R"'
   fi
-  cat > "$rscript" <<'RSCRIPT_OUTER'
+  mv "$rscript" "${rscript}.bin"
+  cat > "$rscript" <<'RSCRIPT_HEAD'
 #!/bin/sh
-# Relocatable Rscript wrapper (replaces compiled binary for portability)
-RSCRIPT_OUTER
-  echo "${r_home_formula}" >> "$rscript"
-  cat >> "$rscript" <<'RSCRIPT_EOF'
-export R_HOME
-
-# Process Rscript-specific options, collect pass-through R options.
-# R understands --verbose, --vanilla, --no-environ, --no-site-file, etc.
-# directly, so we only need to handle --default-packages (env var conversion)
-# and file argument conversion (first positional arg -> --file=).
-r_opts=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --help|-h)
-      echo "Usage: Rscript [options] [-e expr [-e expr2 ...] | file] [args]"
-      exit 0
-      ;;
-    --version)
-      exec "${R_HOME}/bin/R" --slave -e 'cat(sprintf("Rscript (R) version %s.%s (%s-%s-%s)\n", R.version$major, R.version$minor, R.version$year, R.version$month, R.version$day))'
-      ;;
-    --default-packages=*)
-      R_DEFAULT_PACKAGES="${1#--default-packages=}"
-      export R_DEFAULT_PACKAGES
-      shift
-      ;;
-    -e)
-      # -e starts expressions -- stop processing options, pass rest to R
-      break
-      ;;
-    --*)
-      # Collect R options (--verbose, --vanilla, --no-environ, etc.)
-      r_opts="$r_opts $1"
-      shift
-      ;;
-    *)
-      # First positional arg is the script file
-      break
-      ;;
-  esac
-done
-
-# $@ now contains: [-e expr [-e expr] [args...]] or [file [args...]] or nothing
-# r_opts contains collected --options (no spaces in individual options)
-if [ $# -eq 0 ]; then
-  # No file or -e: just R options
-  exec "${R_HOME}/bin/R" --slave --no-restore $r_opts
-elif [ "$1" = "-e" ]; then
-  # At least one -e arg before any trailing args - pass these, plus trailing args, to R using "$@" to preserve quoting
-  # We can have multiple -e args, but once we have a trailing arg, all subsequent args are also trailing
-  is_e=0
-  is_trailing=0
-  # Cycle through "$@", dropping each arg from the front and replacing appropriately at the back
-  for arg in "$@"; do
-    shift
-    if [ $is_trailing = 1 ]; then
-      set -- "$@" "$arg"
-    elif [ "$arg" = "-e" ]; then
-      is_e=1
-    elif [ $is_e = 1 ]; then
-      set -- "$@" "-e" "$arg"
-      is_e=0
-    else
-      set -- "$@" "--args" "$arg"
-      is_trailing=1
-    fi
-  done
-  exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "$@"
-else
-  # File argument: convert to --file=, remaining args become --args
-  file="$1"
-  shift
-  if [ $# -gt 0 ]; then
-    exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "--file=$file" --args "$@"
-  else
-    exec "${R_HOME}/bin/R" --slave --no-restore $r_opts "--file=$file"
-  fi
-fi
-RSCRIPT_EOF
+# Relocatable Rscript wrapper: set RHOME from our own location, then exec the
+# preserved native binary, which reads RHOME and execs "${RHOME}/bin/R".
+RSCRIPT_HEAD
+  echo "${rhome_formula}" >> "$rscript"
+  cat >> "$rscript" <<'RSCRIPT_TAIL'
+export RHOME
+exec "$(dirname "$(readlink -f "$0")")/Rscript.bin" "$@"
+RSCRIPT_TAIL
   chmod +x "$rscript"
-  echo "  Replaced $(basename "$(dirname "$rscript")")/Rscript with relocatable wrapper"
+  echo "  Wrapped $(basename "$(dirname "$rscript")")/Rscript (preserved as Rscript.bin)"
 done

--- a/builder/portable-r/test-manylinux.sh
+++ b/builder/portable-r/test-manylinux.sh
@@ -190,51 +190,39 @@ if [ -n "$TESTPKG_SO" ]; then
 fi
 
 echo "=== Rscript wrapper tests ==="
-# Test key usage patterns of the relocatable Rscript shell wrapper to catch
-# regressions if upstream Rscript changes its CLI interface.
+# Portable Rscript preserves the native compiled binary as Rscript.bin and wraps
+# it with a thin script that sets RHOME and execs the binary. Argument parsing,
+# --version, etc. are the native binary's job (upstream R) and need no coverage
+# here. We test only what the wrapper owns:
+#   1. the native binary is preserved (the wrapper execs it)
+#   2. RHOME resolution reaches a working R and "$@" is forwarded intact
+#   3. no args exits non-interactively (does not start an interactive session)
 RSCRIPT="${R_PREFIX}/bin/Rscript"
 
-# --version should output a version string (regression test for #309)
-version_out=$("$RSCRIPT" --version 2>&1)
-echo "$version_out" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+' || { echo "FAIL: Rscript --version produced no version number: '$version_out'"; exit 1; }
-echo "  Rscript --version: OK ($version_out)"
+# 1. The wrapper execs the preserved native binary, so Rscript.bin must exist
+# and be the real ELF binary.
+[ -f "${R_PREFIX}/bin/Rscript.bin" ] || { echo "FAIL: Rscript.bin (preserved native binary) is missing"; exit 1; }
+head -c 4 "${R_PREFIX}/bin/Rscript.bin" | grep -q ELF || { echo "FAIL: Rscript.bin is not an ELF binary"; exit 1; }
+echo "  Rscript.bin preserved (native binary): OK"
 
-# -e expression
-result=$("$RSCRIPT" -e 'cat("hello")')
-[ "$result" = "hello" ] || { echo "FAIL: Rscript -e"; exit 1; }
-echo "  Rscript -e: OK"
-
-# Multiple -e expressions
-result=$("$RSCRIPT" -e 'cat("a")' -e 'cat("b")')
-[ "$result" = "ab" ] || { echo "FAIL: Rscript -e -e"; exit 1; }
-echo "  Rscript -e -e: OK"
-
-# -e expressions with trailing arguments (regression test for #311)
-result=$("$RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
-[ "$result" = "one/two three/ARG1 ARG2" ] || { echo "FAIL: Rscript -e ARGS"; exit 1; }
-echo "  Rscript -e ARGS: OK"
-
-# File execution with arguments
+# 2. RHOME resolution + faithful "$@" forwarding: run a script file with trailing
+# args (one containing a space). commandArgs must round-trip exactly. This fails
+# if the wrapper points RHOME at the wrong R or mangles argument quoting.
 tmpscript=$(mktemp /tmp/test_rscript_XXXXXX.R)
-echo 'args <- commandArgs(trailingOnly=TRUE); cat(paste(args, collapse=","))' > "$tmpscript"
-result=$("$RSCRIPT" "$tmpscript" arg1 arg2 arg3)
-[ "$result" = "arg1,arg2,arg3" ] || { echo "FAIL: Rscript file args: got '$result'"; exit 1; }
-echo "  Rscript file.R arg1 arg2 arg3: OK"
-
-# --default-packages
-result=$("$RSCRIPT" --default-packages=base -e 'cat(paste(.packages(), collapse=","))')
-echo "$result" | grep -q "base" || { echo "FAIL: --default-packages: got '$result'"; exit 1; }
-echo "  Rscript --default-packages=base: OK"
-
-# --vanilla pass-through
-result=$("$RSCRIPT" --vanilla -e 'cat("vanilla")')
-[ "$result" = "vanilla" ] || { echo "FAIL: Rscript --vanilla"; exit 1; }
-echo "  Rscript --vanilla: OK"
-
-# Rscript with no args should not hang (runs R --slave --no-restore, which exits)
-timeout 10 "$RSCRIPT" < /dev/null > /dev/null 2>&1 || { echo "FAIL: Rscript with no args hung or failed"; exit 1; }
-echo "  Rscript (no args): OK"
-
+echo 'cat(commandArgs(trailingOnly=TRUE), sep="|")' > "$tmpscript"
+result=$("$RSCRIPT" "$tmpscript" arg1 "two words" arg3)
+[ "$result" = "arg1|two words|arg3" ] || { echo "FAIL: Rscript arg forwarding: got '$result'"; exit 1; }
 rm -f "$tmpscript"
+echo "  Rscript file + args (RHOME + \"\$@\" forwarding): OK"
+
+# 3. No args must exit 1 (non-interactive), not start an interactive session.
+# Exact usage wording is upstream R's and varies by version, so we assert only
+# the exit code plus a loose usage match.
+set +e
+noargs_out=$(timeout 10 "$RSCRIPT" < /dev/null 2>&1); noargs_code=$?
+set -e
+[ "$noargs_code" = "1" ] || { echo "FAIL: Rscript no-args exit code: got $noargs_code, want 1"; exit 1; }
+echo "$noargs_out" | grep -qi "usage" || { echo "FAIL: Rscript no-args did not print usage: '$noargs_out'"; exit 1; }
+echo "  Rscript (no args): exit 1 non-interactive: OK"
 
 echo "=== All manylinux tests passed ==="

--- a/builder/portable-r/test-musllinux.sh
+++ b/builder/portable-r/test-musllinux.sh
@@ -156,51 +156,39 @@ fi
 echo "  libRblas.so not in .libs/ (OK)"
 
 echo "=== Rscript wrapper tests ==="
-# Test key usage patterns of the relocatable Rscript shell wrapper to catch
-# regressions if upstream Rscript changes its CLI interface.
+# Portable Rscript preserves the native compiled binary as Rscript.bin and wraps
+# it with a thin script that sets RHOME and execs the binary. Argument parsing,
+# --version, etc. are the native binary's job (upstream R) and need no coverage
+# here. We test only what the wrapper owns:
+#   1. the native binary is preserved (the wrapper execs it)
+#   2. RHOME resolution reaches a working R and "$@" is forwarded intact
+#   3. no args exits non-interactively (does not start an interactive session)
 RSCRIPT="${R_PREFIX}/bin/Rscript"
 
-# --version should output a version string (regression test for #309)
-version_out=$("$RSCRIPT" --version 2>&1)
-echo "$version_out" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+' || { echo "FAIL: Rscript --version produced no version number: '$version_out'"; exit 1; }
-echo "  Rscript --version: OK ($version_out)"
+# 1. The wrapper execs the preserved native binary, so Rscript.bin must exist
+# and be the real ELF binary.
+[ -f "${R_PREFIX}/bin/Rscript.bin" ] || { echo "FAIL: Rscript.bin (preserved native binary) is missing"; exit 1; }
+head -c 4 "${R_PREFIX}/bin/Rscript.bin" | grep -q ELF || { echo "FAIL: Rscript.bin is not an ELF binary"; exit 1; }
+echo "  Rscript.bin preserved (native binary): OK"
 
-# -e expression
-result=$("$RSCRIPT" -e 'cat("hello")')
-[ "$result" = "hello" ] || { echo "FAIL: Rscript -e"; exit 1; }
-echo "  Rscript -e: OK"
-
-# Multiple -e expressions
-result=$("$RSCRIPT" -e 'cat("a")' -e 'cat("b")')
-[ "$result" = "ab" ] || { echo "FAIL: Rscript -e -e"; exit 1; }
-echo "  Rscript -e -e: OK"
-
-# -e expressions with trailing arguments (regression test for #311)
-result=$("$RSCRIPT" -e 'cat("one/"); cat("two three/")' -e 'cat(commandArgs(trailingOnly = TRUE), sep = " ")' ARG1 ARG2)
-[ "$result" = "one/two three/ARG1 ARG2" ] || { echo "FAIL: Rscript -e ARGS"; exit 1; }
-echo "  Rscript -e ARGS: OK"
-
-# File execution with arguments
+# 2. RHOME resolution + faithful "$@" forwarding: run a script file with trailing
+# args (one containing a space). commandArgs must round-trip exactly. This fails
+# if the wrapper points RHOME at the wrong R or mangles argument quoting.
 tmpscript=$(mktemp /tmp/test_rscript_XXXXXX.R)
-echo 'args <- commandArgs(trailingOnly=TRUE); cat(paste(args, collapse=","))' > "$tmpscript"
-result=$("$RSCRIPT" "$tmpscript" arg1 arg2 arg3)
-[ "$result" = "arg1,arg2,arg3" ] || { echo "FAIL: Rscript file args: got '$result'"; exit 1; }
-echo "  Rscript file.R arg1 arg2 arg3: OK"
-
-# --default-packages
-result=$("$RSCRIPT" --default-packages=base -e 'cat(paste(.packages(), collapse=","))')
-echo "$result" | grep -q "base" || { echo "FAIL: --default-packages: got '$result'"; exit 1; }
-echo "  Rscript --default-packages=base: OK"
-
-# --vanilla pass-through
-result=$("$RSCRIPT" --vanilla -e 'cat("vanilla")')
-[ "$result" = "vanilla" ] || { echo "FAIL: Rscript --vanilla"; exit 1; }
-echo "  Rscript --vanilla: OK"
-
-# Rscript with no args should not hang (runs R --slave --no-restore, which exits)
-timeout 10 "$RSCRIPT" < /dev/null > /dev/null 2>&1 || { echo "FAIL: Rscript with no args hung or failed"; exit 1; }
-echo "  Rscript (no args): OK"
-
+echo 'cat(commandArgs(trailingOnly=TRUE), sep="|")' > "$tmpscript"
+result=$("$RSCRIPT" "$tmpscript" arg1 "two words" arg3)
+[ "$result" = "arg1|two words|arg3" ] || { echo "FAIL: Rscript arg forwarding: got '$result'"; exit 1; }
 rm -f "$tmpscript"
+echo "  Rscript file + args (RHOME + \"\$@\" forwarding): OK"
+
+# 3. No args must exit 1 (non-interactive), not start an interactive session.
+# Exact usage wording is upstream R's and varies by version, so we assert only
+# the exit code plus a loose usage match.
+set +e
+noargs_out=$(timeout 10 "$RSCRIPT" < /dev/null 2>&1); noargs_code=$?
+set -e
+[ "$noargs_code" = "1" ] || { echo "FAIL: Rscript no-args exit code: got $noargs_code, want 1"; exit 1; }
+echo "$noargs_out" | grep -qi "usage" || { echo "FAIL: Rscript no-args did not print usage: '$noargs_out'"; exit 1; }
+echo "  Rscript (no args): exit 1 non-interactive: OK"
 
 echo "=== All musllinux_1_2 tests passed ==="


### PR DESCRIPTION
Closes #315 

@gaborcsardi pointed out that the native `Rscript` reads an `RHOME` env var that we can just set in a wrapper script. It's much simpler than reimplementing Rscript, especially with all the small bugs we've had to fix so far. The portable macOS R build also does this same thing.

I couldn't find a good reason for reimplementing `Rscript` in the original work besides just not knowing that `RHOME` was configurable. It's even in the Rscript docs:
> Normally the version of R is determined at installation, but this can be overridden by setting the environment variable RHOME.
> https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html

I tested this on various distros and R versions going back to 3.0.0 and it seems to work perfectly fine. The `Rscript` wrapper scripts look like this (`Rscript.bin` is the original `Rscript` moved):

```sh
$ cat /opt/R/4.6.0/bin/Rscript
#!/bin/sh
# Relocatable Rscript wrapper: set RHOME from our own location, then exec the
# preserved native binary, which reads RHOME and execs "${RHOME}/bin/R".
RHOME="$(dirname "$(dirname "$(readlink -f "$0")")")/lib/R"
export RHOME
exec "$(dirname "$(readlink -f "$0")")/Rscript.bin" "$@"

$ cat /opt/R/4.6.0/lib/R/bin/Rscript
#!/bin/sh
# Relocatable Rscript wrapper: set RHOME from our own location, then exec the
# preserved native binary, which reads RHOME and execs "${RHOME}/bin/R".
RHOME="$(dirname "$(dirname "$(readlink -f "$0")")")"
export RHOME
exec "$(dirname "$(readlink -f "$0")")/Rscript.bin" "$@"
```