### PR TITLE
Load methods in older Rscript, to match R

### DIFF
--- a/test/test.R
+++ b/test/test.R
@@ -1,3 +1,6 @@
+# Older Rscript did not load the methods package by default
+library(methods)
+
 # HTTP mirror to support R 3.1
 options(repos = c("https://cloud.r-project.org", "http://cloud.r-project.org"))
 

--- a/test/test.R
+++ b/test/test.R
@@ -1,4 +1,6 @@
 # Older Rscript did not load the methods package by default
+# This fixes a crash on musllinux 1.2 & R 3.4.x:
+# https://github.com/rstudio/r-builds/pull/317#issuecomment-4749554642
 library(methods)
 
 # HTTP mirror to support R 3.1


### PR DESCRIPTION
Fixes tests on musllinux-1.2 on R 3.4.x.
See https://github.com/rstudio/r-builds/pull/317#issuecomment-4749554642