### PR TITLE
Derive Cloudsmith distro mapping from get_matrix.py and validate it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,6 +380,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
       - name: Install cloudsmith-cli
         run: pip install --upgrade cloudsmith-cli
 
@@ -394,74 +399,23 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
         run: |
-          case "$PLATFORM" in
-            ubuntu-2004)
-              echo "distro=ubuntu/focal" >> $GITHUB_OUTPUT
-              echo "pkg_type=deb" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=r-*.deb" >> $GITHUB_OUTPUT
-              ;;
-            ubuntu-2204)
-              echo "distro=ubuntu/jammy" >> $GITHUB_OUTPUT
-              echo "pkg_type=deb" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=r-*.deb" >> $GITHUB_OUTPUT
-              ;;
-            ubuntu-2404)
-              echo "distro=ubuntu/noble" >> $GITHUB_OUTPUT
-              echo "pkg_type=deb" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=r-*.deb" >> $GITHUB_OUTPUT
-              ;;
-            debian-13)
-              echo "distro=debian/trixie" >> $GITHUB_OUTPUT
-              echo "pkg_type=deb" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=r-*.deb" >> $GITHUB_OUTPUT
-              ;;
-            centos-7)
-              echo "distro=el/7" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            centos-8)
-              echo "distro=el/8" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            rhel-9)
-              echo "distro=el/9" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            rhel-10)
-              echo "distro=el/10" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            opensuse-156)
-              echo "distro=opensuse/15.6" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            opensuse-160)
-              echo "distro=opensuse/16.0" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            fedora-42)
-              echo "distro=fedora/42" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            fedora-43)
-              echo "distro=fedora/43" >> $GITHUB_OUTPUT
-              echo "pkg_type=rpm" >> $GITHUB_OUTPUT
-              echo "pkg_pattern=R-*.rpm" >> $GITHUB_OUTPUT
-              ;;
-            *)
-              echo "::error::Unknown platform: $PLATFORM"
-              exit 1
-              ;;
-          esac
+          # Resolve the Cloudsmith distro from get_matrix.py, the single source
+          # of truth shared with the build matrix. Portable platforms return
+          # {"skip": true}; unknown platforms exit non-zero (and are caught by
+          # test_get_matrix.py before they ever reach here).
+          info=$(python get_matrix.py --cloudsmith-info "$PLATFORM")
+          if [[ "$(echo "$info" | jq -r '.skip // false')" == "true" ]]; then
+            echo "::notice::$PLATFORM is a portable build; skipping Cloudsmith publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "distro=$(echo "$info" | jq -r '.distro')" >> "$GITHUB_OUTPUT"
+            echo "pkg_type=$(echo "$info" | jq -r '.pkg_type')" >> "$GITHUB_OUTPUT"
+            echo "pkg_pattern=$(echo "$info" | jq -r '.pkg_pattern')" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Find and publish package
+        if: ${{ steps.pkg-info.outputs.skip != 'true' }}
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           PLATFORM: ${{ matrix.platform }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 R-*
 builder/integration/**
 __pycache__/
+.pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ docker-shell-r-env:
 	@cd builder && docker compose run --entrypoint /bin/bash ubuntu-2004
 
 unit-test:
+	python3 -m pytest test_get_matrix.py -v
 	cd builder/portable-r && python3 -m pytest test_delocate_r.py test_generate_sbom.py -v
 
 define GEN_TARGETS

--- a/README.md
+++ b/README.md
@@ -648,12 +648,17 @@ Update the quick install script at [`install.sh`](install.sh), if necessary, to 
 
 ### Cloudsmith distro mapping
 
-If the platform is published to Cloudsmith, add a `case` entry for it in the
-`cloudsmith-publish` job in [`.github/workflows/build.yml`](.github/workflows/build.yml).
-This maps the `platform-version` to its Cloudsmith distribution slug (e.g.
-`fedora-43` → `fedora/43`), package type (`deb`/`rpm`), and package glob. This
-list is maintained by hand, so it must be updated whenever a platform is added
-or removed.
+Classify the platform for Cloudsmith publishing in [`get_matrix.py`](get_matrix.py),
+which is the single source of truth the `cloudsmith-publish` job reads:
+
+- A distro package (deb/rpm): add it to `CLOUDSMITH_DISTROS`, mapping the
+  `platform-version` to its Cloudsmith distribution slug (e.g. `fedora-43` →
+  `fedora/43`). Package type and glob are derived from the slug.
+- A portable build (tarball, distributed via S3/CDN, not Cloudsmith): add it to
+  `PORTABLE_PLATFORMS`.
+
+`test_get_matrix.py` fails CI if any platform in `PLATFORMS` is left
+unclassified, so this can't silently drift out of sync.
 
 Once you've followed the steps above, submit a pull request.
 

--- a/get_matrix.py
+++ b/get_matrix.py
@@ -7,6 +7,7 @@ and generates the complex build matrix.
 import argparse
 import json
 import subprocess
+import sys
 
 
 # Platforms whose builds are handled by dedicated reusable workflows
@@ -14,8 +15,53 @@ import subprocess
 _NON_LINUX_PREFIXES = ('macos', 'windows')
 
 
+# Single source of truth for the cloudsmith-publish job's platform -> Cloudsmith
+# distribution mapping (consumed via `get_matrix.py --cloudsmith-info <platform>`).
+# Every distro-package platform in the Makefile's PLATFORMS must appear here or
+# in PORTABLE_PLATFORMS; test_get_matrix.py fails CI otherwise, so this can't
+# silently drift out of sync with the build matrix.
+CLOUDSMITH_DISTROS = {
+    'ubuntu-2004': 'ubuntu/focal',
+    'ubuntu-2204': 'ubuntu/jammy',
+    'ubuntu-2404': 'ubuntu/noble',
+    'ubuntu-2604': 'ubuntu/resolute',
+    'debian-13': 'debian/trixie',
+    'centos-7': 'el/7',
+    'centos-8': 'el/8',
+    'rhel-9': 'el/9',
+    'rhel-10': 'el/10',
+    'opensuse-156': 'opensuse/15.6',
+    'opensuse-160': 'opensuse/16.0',
+    'fedora-42': 'fedora/42',
+    'fedora-43': 'fedora/43',
+}
+
+# Portable builds bundle their dependencies and are distributed as relocatable
+# tarballs / packages via S3/CDN, not per-distro Cloudsmith repos. They are
+# intentionally excluded from Cloudsmith publishing.
+PORTABLE_PLATFORMS = {'manylinux_2_34', 'musllinux_1_2'}
+
+
 def _is_non_linux(platform):
     return any(platform == p or platform.startswith(p + '-') for p in _NON_LINUX_PREFIXES)
+
+
+def cloudsmith_info(platform):
+    """Cloudsmith publish info for a platform.
+
+    Returns a dict with ``distro``, ``pkg_type``, and ``pkg_pattern`` for
+    distro-package platforms, or ``None`` for portable platforms that are not
+    published to Cloudsmith. Raises ``KeyError`` for platforms that are neither
+    mapped nor declared portable.
+    """
+    if platform in PORTABLE_PLATFORMS:
+        return None
+    distro = CLOUDSMITH_DISTROS[platform]  # KeyError = unclassified platform
+    if distro.startswith(('ubuntu/', 'debian/')):
+        pkg_type, pkg_pattern = 'deb', 'r-*.deb'
+    else:
+        pkg_type, pkg_pattern = 'rpm', 'R-*.rpm'
+    return {'distro': distro, 'pkg_type': pkg_type, 'pkg_pattern': pkg_pattern}
 
 
 def main():
@@ -29,8 +75,7 @@ def main():
     parser.add_argument(
         '--versions',
         type=str,
-        required=True,
-        help='Comma-separated list of R versions.'
+        help='Comma-separated list of R versions. Required unless --cloudsmith-info is given.'
     )
     parser.add_argument(
         '--arch',
@@ -38,7 +83,29 @@ def main():
         default='amd64,arm64',
         help='Comma-separated list of architectures.'
     )
+    parser.add_argument(
+        '--cloudsmith-info',
+        type=str,
+        metavar='PLATFORM',
+        help='Print Cloudsmith publish info (JSON) for a single platform and exit. '
+             'Emits {"skip": true} for portable platforms; exits non-zero for unknown ones.'
+    )
     args = parser.parse_args()
+
+    if args.cloudsmith_info:
+        try:
+            info = cloudsmith_info(args.cloudsmith_info)
+        except KeyError:
+            sys.exit(
+                f"Unknown platform: {args.cloudsmith_info}. Add it to CLOUDSMITH_DISTROS "
+                f"or PORTABLE_PLATFORMS in get_matrix.py."
+            )
+        print(json.dumps(info if info is not None else {"skip": True}))
+        return
+
+    if not args.versions:
+        parser.error('--versions is required')
+
     # Re-set to default values if empty string/whitespace explicitly specified (""), which can happen in CI jobs
     platforms = args.platforms if args.platforms else parser.get_default('platforms')
     arch = args.arch if args.arch else parser.get_default('arch')

--- a/test_get_matrix.py
+++ b/test_get_matrix.py
@@ -1,13 +1,22 @@
 """Tests for get_matrix.py, focused on keeping the Cloudsmith platform mapping
 in sync with the build matrix's source of truth (PLATFORMS in the Makefile)."""
+import os
 import subprocess
 
 import get_matrix
 
 
 def _makefile_platforms():
-    """The authoritative platform list, straight from `make print-platforms`."""
-    out = subprocess.check_output(['make', 'print-platforms'], text=True)
+    """The authoritative platform list, straight from `make print-platforms`.
+
+    Runs with a cleared MAKEFLAGS/MAKELEVEL and --no-print-directory so that
+    invoking this while nested under `make unit-test` doesn't fold make's
+    recursive "Entering directory" chatter into the platform list.
+    """
+    env = {**os.environ, 'MAKEFLAGS': '', 'MAKELEVEL': '0'}
+    out = subprocess.check_output(
+        ['make', '--no-print-directory', 'print-platforms'], text=True, env=env,
+    )
     return set(out.split())
 
 

--- a/test_get_matrix.py
+++ b/test_get_matrix.py
@@ -1,0 +1,61 @@
+"""Tests for get_matrix.py, focused on keeping the Cloudsmith platform mapping
+in sync with the build matrix's source of truth (PLATFORMS in the Makefile)."""
+import subprocess
+
+import get_matrix
+
+
+def _makefile_platforms():
+    """The authoritative platform list, straight from `make print-platforms`."""
+    out = subprocess.check_output(['make', 'print-platforms'], text=True)
+    return set(out.split())
+
+
+def test_every_platform_is_classified():
+    """Every built platform must be mapped to a Cloudsmith distro or declared
+    portable, so the cloudsmith-publish job never hits an unknown platform."""
+    platforms = _makefile_platforms()
+    classified = set(get_matrix.CLOUDSMITH_DISTROS) | get_matrix.PORTABLE_PLATFORMS
+    missing = platforms - classified
+    assert not missing, (
+        f"Platforms not classified for Cloudsmith publishing: {sorted(missing)}. "
+        f"Add each to CLOUDSMITH_DISTROS or PORTABLE_PLATFORMS in get_matrix.py."
+    )
+
+
+def test_no_stale_mappings():
+    """Mappings must not reference platforms that were removed from PLATFORMS."""
+    platforms = _makefile_platforms()
+    classified = set(get_matrix.CLOUDSMITH_DISTROS) | get_matrix.PORTABLE_PLATFORMS
+    stale = classified - platforms
+    assert not stale, (
+        f"Cloudsmith mappings for platforms no longer in PLATFORMS: {sorted(stale)}."
+    )
+
+
+def test_distro_and_portable_are_disjoint():
+    overlap = set(get_matrix.CLOUDSMITH_DISTROS) & get_matrix.PORTABLE_PLATFORMS
+    assert not overlap, f"Platforms both mapped and marked portable: {sorted(overlap)}"
+
+
+def test_cloudsmith_info_deb_platform():
+    assert get_matrix.cloudsmith_info('ubuntu-2604') == {
+        'distro': 'ubuntu/resolute', 'pkg_type': 'deb', 'pkg_pattern': 'r-*.deb',
+    }
+
+
+def test_cloudsmith_info_rpm_platform():
+    info = get_matrix.cloudsmith_info('fedora-43')
+    assert info == {'distro': 'fedora/43', 'pkg_type': 'rpm', 'pkg_pattern': 'R-*.rpm'}
+
+
+def test_cloudsmith_info_portable_is_none():
+    assert get_matrix.cloudsmith_info('manylinux_2_34') is None
+
+
+def test_cloudsmith_info_unknown_raises():
+    try:
+        get_matrix.cloudsmith_info('does-not-exist')
+    except KeyError:
+        return
+    raise AssertionError("expected KeyError for unknown platform")


### PR DESCRIPTION
## Problem

After #270 merged, the `cloudsmith-publish` job resolved each platform's Cloudsmith distro from a hand-maintained bash `case` in `build.yml` that had no link to the build matrix's source of truth (`PLATFORMS` in the Makefile, via `get_matrix.py`). Platforms in the matrix but missing from the `case` failed publishing at runtime:

```
Error: Unknown platform: manylinux_2_34
```

`ubuntu-2604` was genuinely missing, and the portable builds (`manylinux_2_34`, `musllinux_1_2`) were being pulled into Cloudsmith publishing even though they ship as tarballs via S3/CDN and have no distro slug.

## Change

- Move the platform → Cloudsmith distro mapping into `get_matrix.py` as `CLOUDSMITH_DISTROS`, the single source of truth the job reads via `--cloudsmith-info`.
- Add `PORTABLE_PLATFORMS` for tarball builds; the job now skips them instead of erroring.
- Add `test_get_matrix.py` (runs in the existing `unit-tests` job) that **fails CI if any platform in `PLATFORMS` is left unclassified** — so the mapping can't silently drift again.
- Fixes the immediate gaps: adds `ubuntu-2604` → `ubuntu/resolute`, excludes the portable platforms.
- Updates the "Adding a new platform" README checklist to point at `get_matrix.py`.

## Test

`make unit-test` (new `test_get_matrix.py` passes; validates the mapping against `make print-platforms`).