### PR TITLE
Allow RHEL RPMs to work on UBI 9/10: make flexiblas-devel a weak dependency

### DIFF
--- a/builder/package.rhel-10
+++ b/builder/package.rhel-10
@@ -52,7 +52,7 @@ depends:
 - libXt
 ${zstd_libs}
 - make
-- flexiblas-devel
+- flexiblas-netlib
 - pango
 - pcre2-devel
 - tcl
@@ -62,6 +62,22 @@ ${zstd_libs}
 - xz-devel
 - zip
 - zlib-devel
+# For RHEL 9/10, flexiblas-devel is a weak (Recommends) dependency for UBI 9/10
+# support. UBI 9/10's CRB repos do not provide flexiblas-devel, so we let the
+# RPM install without the optional -devel package.
+#
+# r-builds installs the BLAS development headers by convention, since many R
+# packages need them to compile from source. They are not actually required to
+# run R (only the runtime BLAS library is: flexiblas-netlib, which provides
+# libflexiblas.so.3), so excluding -devel on UBI 9/10 is acceptable. On full
+# RHEL/Rocky, dnf still auto-installs it from CRB.
+#
+# See RHEL-5411: it requested flexiblas-devel in the UBI CRB and was closed as
+# fixed, but the package was never actually shipped (verified absent in UBI 9/10
+# images).
+# https://issues.redhat.com/browse/RHEL-5411
+recommends:
+- flexiblas-devel
 contents:
 - src: ${R_INSTALL_PATH}
   dst: ${R_INSTALL_PATH}

--- a/builder/package.rhel-9
+++ b/builder/package.rhel-9
@@ -31,8 +31,25 @@ fi
 # for portability.
 #
 # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Shared-BLAS
+recommends=''
 if [[ "$("${R_INSTALL_PATH}/bin/R" CMD config BLAS_LIBS)" == "-lflexiblas" ]]; then
-  blas_lib='flexiblas-devel'
+  # For RHEL 9/10, flexiblas-devel is a weak (Recommends) dependency for UBI 9/10
+  # support. UBI 9/10's CRB repos do not provide flexiblas-devel, so we let the
+  # RPM install without the optional -devel package.
+  #
+  # r-builds installs the BLAS development headers by convention, since many R
+  # packages need them to compile from source. They are not actually required to
+  # run R (only the runtime BLAS library is: flexiblas-netlib, which provides
+  # libflexiblas.so.3), so excluding -devel on UBI 9/10 is acceptable. On full
+  # RHEL/Rocky, dnf still auto-installs it from CRB.
+  #
+  # See RHEL-5411: it requested flexiblas-devel in the UBI CRB and was closed as
+  # fixed, but the package was never actually shipped (verified absent in UBI 9/10
+  # images).
+  # https://issues.redhat.com/browse/RHEL-5411
+  blas_lib='flexiblas-netlib'
+  recommends='recommends:
+- flexiblas-devel'
 
   # Create postremove script to remove empty directories, as nFPM doesn't include them in the RPM files.
   cat <<EOF >> /after-remove.sh
@@ -106,6 +123,7 @@ ${pcre_libs}
 - xz-devel
 - zip
 - zlib-devel
+${recommends}
 contents:
 - src: ${R_INSTALL_PATH}
   dst: ${R_INSTALL_PATH}

--- a/test/test-yum.sh
+++ b/test/test-yum.sh
@@ -30,3 +30,50 @@ if [ -d "/opt/R/${R_VERSION}" ]; then
     echo "Failed to uninstall completely"
     exit 1
 fi
+
+# flexiblas-devel is a weak Recommends on RHEL 9/10 because it is absent from the
+# UBI CodeReady Builder subset (RHEL-5411, closed as fixed but never shipped).
+# Reproduce UBI by installing with weak deps disabled: the RPM must still install,
+# the runtime (flexiblas-netlib) must be present, flexiblas-devel must be skipped,
+# and R must run BLAS at runtime. Guards against regressing flexiblas-devel to a
+# hard dependency, which would break UBI installs.
+case "${OS_IDENTIFIER}" in
+  rhel-9|rhel-10)
+    pkg_file=$(ls ${SCRIPT_DIR}/../builder/integration/tmp/${OS_IDENTIFIER}/R-${R_VERSION}*.rpm 2>/dev/null | head -1)
+    if [ -n "${pkg_file}" ] && rpm -qp --requires "${pkg_file}" | grep -q '^flexiblas'; then
+        # The RPM must declare flexiblas-devel as a weak Recommends so full
+        # RHEL/Rocky still auto-installs it; a dropped Recommends would otherwise
+        # pass the checks below (devel simply absent) while breaking source builds.
+        rpm -qp --recommends "${pkg_file}" | grep -q '^flexiblas-devel'
+
+        $YUM -y remove flexiblas-devel > /dev/null 2>&1 || true
+        $YUM install -y --setopt=install_weak_deps=False "${pkg_file}"
+
+        # libflexiblas.so.3 (what R loads) comes from flexiblas-netlib, not the
+        # flexiblas front-end, so check the SONAME provider directly.
+        rpm -q flexiblas
+        rpm -q flexiblas-netlib
+
+        # flexiblas-devel (weak dependency) must be skipped, not pulled in.
+        if rpm -q flexiblas-devel > /dev/null 2>&1; then
+            echo "flexiblas-devel was installed with weak dependencies disabled; it may have regressed to a hard dependency"
+            exit 1
+        fi
+
+        # R and runtime BLAS must work without flexiblas-devel. (Only source
+        # compilation of BLAS-linked packages needs it, so test-r.sh, which
+        # builds testpkg against -lflexiblas, is intentionally not run here.)
+        R_HOME="/opt/R/${R_VERSION}/lib/R"
+        "${R_HOME}/bin/R" --version
+        "${R_HOME}/bin/Rscript" -e 'x <- matrix(rnorm(100), 10); stopifnot(is.matrix(crossprod(x))); cat("runtime BLAS OK\n")'
+
+        $YUM -y remove "R-${R_VERSION}"
+        if [ -d "/opt/R/${R_VERSION}" ]; then
+            echo "Failed to uninstall completely"
+            exit 1
+        fi
+    else
+        echo "Skipping flexiblas-devel weak-dependency check: no locally built ${OS_IDENTIFIER} RPM linking flexiblas found"
+    fi
+    ;;
+esac


### PR DESCRIPTION
Closes #212

UBI 9/10 never added flexiblas-devel to CRB even though our bug tracker issues were closed. Since BLAS development headers are optional for R, only included in our builds because a lot of R packages need it to compile from source, we can switch the `flexiblas-devel` package to a weak RPM dependency so R at least installs.

Tests added here, and I also verified in `rockylinux:9` and `registry.access.redhat.com/ubi9/ubi` images that the new R RPM installs fine in both, and that the RHEL 9 installation includes flexiblas-devel:
```
Installing weak dependencies:
 flexiblas-devel                                                 x86_64                                     3.0.4-9.el9                                                 appstream                                         98 k
```

```sh
# Rocky Linux 9 - rockylinux:9
dnf install ./rhel-9/R-4.6.1-1-1.x86_64.rpm 
Extra Packages for Enterprise Linux 9 - x86_64                                                                                                                                                 6.2 MB/s |  21 MB     00:03    
Extra Packages for Enterprise Linux 9 openh264 (From Cisco) - x86_64                                                                                                                           3.4 kB/s | 2.5 kB     00:00    
Rocky Linux 9 - BaseOS                                                                                                                                                                          14 kB/s | 3.9 kB     00:00    
Rocky Linux 9 - BaseOS                                                                                                                                                                         9.9 MB/s | 6.7 MB     00:00    
Rocky Linux 9 - AppStream                                                                                                                                                                       14 kB/s | 4.3 kB     00:00    
Rocky Linux 9 - CRB                                                                                                                                                                            3.7 MB/s | 4.0 MB     00:01    
Dependencies resolved.
===============================================================================================================================================================================================================================
 Package                                                         Architecture                               Version                                                     Repository                                        Size
===============================================================================================================================================================================================================================
Installing:
 R-4.6.1                                                         x86_64                                     1-1                                                         @commandline                                      69 M
...
Installing dependencies:
 bzip2-devel                                                     x86_64                                     1.0.8-11.el9                                                appstream                                        213 k
 cairo                                                           x86_64                                     1.17.4-7.el9                                                appstream                                        659 k
 cpp                                                             x86_64                                     11.5.0-14.el9                                               appstream                                         11 M
 dejavu-sans-fonts                                               noarch                                     2.37-18.el9                                                 baseos                                           1.3 M
 flexiblas                                                       x86_64                                     3.0.4-9.el9                                                 appstream                                         30 k
 flexiblas-netlib                                                x86_64                                     3.0.4-9.el9                                                 appstream                                        3.0 M
 flexiblas-netlib64                                              x86_64                                     3.0.4-9.el9                                                 appstream                                        2.9 M
 flexiblas-openblas-openmp                                       x86_64                                     3.0.4-9.el9                                                 appstream                                         15 k
 flexiblas-openblas-openmp64                                     x86_64                                     3.0.4-9.el9                                                 appstream                                         15 k
...
 zip                                                             x86_64                                     3.0-35.el9                                                  baseos                                           263 k
 zlib-devel                                                      x86_64                                     1.2.11-40.el9                                               appstream                                         44 k
Installing weak dependencies:
 flexiblas-devel                                                 x86_64                                     3.0.4-9.el9                                                 appstream                                         98 k

# Checking that flexiblas-devel is installed
ld -lflexiblas
# ld: warning: cannot find entry symbol _start; not setting start address

# UBI 9 - registry.access.redhat.com/ubi9/ubi
dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
crb enable
dnf install ./rhel-9/R-4.6.1-1-1.x86_64.rpm
```

**Note** that I didn't do anything about `openblas-devel` which we use in R <= 4.2 on RHEL 9 for legacy compatibility reasons. We could if needed, but R 4.2 is EOL in like 9 months, so I didn't think it was worth it.