### PR TITLE
Handle arm64 architecture in the quick install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ docker-shell-r-env:
 	@cd builder && docker compose run --entrypoint /bin/bash ubuntu-2004
 
 unit-test:
+	bash test/test-install-unit.sh
 	python3 -m pytest test_get_matrix.py test_prune_cloudsmith.py -v
 	cd builder/portable-r && python3 -m pytest test_delocate_r.py test_generate_sbom.py -v
 

--- a/install.sh
+++ b/install.sh
@@ -1,30 +1,13 @@
 #!/bin/bash
-THIS_VERSION="1.2.0"
+THIS_VERSION="1.3.0"
 
 # Call with:
 #   bash -c "$(curl -L https://rstd.io/r-install)"
-
-SCRIPT_ACTION=$1
-SCRIPT_ACTION=${SCRIPT_ACTION:-install}
-
-# Set to the full version to install. Must be either available on S3 or in the working directory
-R_VERSION=${R_VERSION:-}
-# The version may optionally be provided as a second argument
-if [[ "$2" != "" ]]; then
-  R_VERSION=$2
-fi
-
-# Run unattended; show no questions, assume default answers.
-# May also be set by the '-y'/'yes' options on the install action.
-RUN_UNATTENDED=${RUN_UNATTENDED:-0}
-if [[ "$3" == "-y" || "$3" == "yes" ]]; then
-  RUN_UNATTENDED=1
-fi
-
-SUDO=
-if [[ $(id -u) != "0" ]]; then
-  SUDO=sudo
-fi
+#
+# Arguments and environment variables are parsed by main() at the bottom of
+# this file. The script may also be sourced to load its functions without
+# running the installer, which the unit tests rely on; see
+# test/test-install-unit.sh.
 
 # The root of the S3 URL for downloads
 CDN_URL='https://cdn.posit.co/r'
@@ -32,17 +15,21 @@ CDN_URL='https://cdn.posit.co/r'
 # The URL for listing available R versions
 VERSIONS_URL="${CDN_URL}/versions.json"
 
-R_VERSIONS=$(curl -s ${VERSIONS_URL} |
-  # Matches the JSON line that contains the r versions
-  grep r_versions |
-  # Gets the value of the `r_version` property (e.g., "[ 3.0.0, 3.0.3, ... ]")
-  cut -f2 -d ":" |
-  # Removes the opening and closing brackets of the array
-  cut -f2 -d "[" | cut -f1 -d "]" |
-  # Removes the quotes and commas from the values
-  sed -e 's/\"//g' | sed -e 's/\,//g' |
-  # Convert to newlines and sort in descending order, with devel/next at the bottom
-  tr ' ' '\n' | sort --numeric-sort --reverse)
+# Fetches and parses the list of available R versions from versions.json,
+# newest first (with devel/next sorted to the bottom).
+load_r_versions () {
+  curl -s ${VERSIONS_URL} |
+    # Matches the JSON line that contains the r versions
+    grep r_versions |
+    # Gets the value of the `r_version` property (e.g., "[ 3.0.0, 3.0.3, ... ]")
+    cut -f2 -d ":" |
+    # Removes the opening and closing brackets of the array
+    cut -f2 -d "[" | cut -f1 -d "]" |
+    # Removes the quotes and commas from the values
+    sed -e 's/\"//g' | sed -e 's/\,//g' |
+    # Convert to newlines and sort in descending order, with devel/next at the bottom
+    tr ' ' '\n' | sort --numeric-sort --reverse
+}
 
 # Returns the OS
 detect_os () {
@@ -163,9 +150,16 @@ download_name () {
       rpm_arch="x86_64"
       deb_arch="amd64"
       ;;
-    "aarch64")
+    # Linux reports 64-bit ARM as "aarch64"; "arm64" is accepted as an alias
+    # (e.g., dpkg's architecture name) so the mapping never silently misses.
+    "aarch64" | "arm64")
       rpm_arch="aarch64"
       deb_arch="arm64"
+      ;;
+    *)
+      # Unsupported architecture. Emit nothing and signal failure so the caller
+      # can report a clear error instead of building a bogus download URL.
+      return 1
       ;;
   esac
   case $os in
@@ -260,7 +254,6 @@ valid_version () {
 }
 
 # Prompts for the version until a valid version is entered.
-SELECTED_VERSION=${R_VERSION}
 prompt_version () {
   while [ "$SELECTED_VERSION" = "" ]; do
     echo "Available Versions"
@@ -522,8 +515,18 @@ do_install () {
 
   arch=$(uname -m)
 
-  # Get the name of the installer to use
-  installer_file_name=$(download_name "${os}" "${SELECTED_VERSION}" "${arch}")
+  # Get the name of the installer to use. download_name returns non-zero for an
+  # unsupported architecture and empty output for an unsupported OS; report each
+  # clearly instead of attempting to download a bogus URL.
+  if ! installer_file_name=$(download_name "${os}" "${SELECTED_VERSION}" "${arch}"); then
+    echo "Unsupported architecture '${arch}' for ${os}."
+    echo "Supported architectures are x86_64/amd64 and aarch64/arm64."
+    exit 1
+  fi
+  if [ -z "${installer_file_name}" ]; then
+    echo "No R package is available for ${os} on ${arch}."
+    exit 1
+  fi
 
   # Get the URL to download from. If the installer already exists in the current
   # directory, this will return a blank string.
@@ -555,18 +558,56 @@ do_show_usage() {
   echo "'-h' or 'help' show this info"
 }
 
-# Choose a command to perform
-case ${SCRIPT_ACTION} in
-  "-i"|"install")
-    do_install
-    ;;
-  "-r"|"rversions")
-    do_show_versions
-    ;;
-  "-v"|"version")
-    echo "r-builds quick install version ${THIS_VERSION}"
-    ;;
-  "-h"|"help"|*)
-    do_show_usage
-    ;;
-esac
+# Parses arguments and the environment, loads the available R versions, and
+# dispatches to the requested action.
+main () {
+  # The action to perform; defaults to "install".
+  SCRIPT_ACTION=${1:-install}
+
+  # The full version to install. May come from the environment or, optionally,
+  # the second argument. Must be available on the CDN or in the working directory.
+  R_VERSION=${R_VERSION:-}
+  if [[ "$2" != "" ]]; then
+    R_VERSION=$2
+  fi
+
+  # Run unattended; show no questions, assume default answers. May be set via
+  # the environment or the '-y'/'yes' third argument on the install action.
+  RUN_UNATTENDED=${RUN_UNATTENDED:-0}
+  if [[ "$3" == "-y" || "$3" == "yes" ]]; then
+    RUN_UNATTENDED=1
+  fi
+
+  SUDO=
+  if [[ $(id -u) != "0" ]]; then
+    SUDO=sudo
+  fi
+
+  # The list of available R versions, used to validate and select a version.
+  R_VERSIONS=$(load_r_versions)
+
+  # The version to install; prompt_version may override this.
+  SELECTED_VERSION=${R_VERSION}
+
+  # Choose a command to perform
+  case ${SCRIPT_ACTION} in
+    "-i"|"install")
+      do_install
+      ;;
+    "-r"|"rversions")
+      do_show_versions
+      ;;
+    "-v"|"version")
+      echo "r-builds quick install version ${THIS_VERSION}"
+      ;;
+    "-h"|"help"|*)
+      do_show_usage
+      ;;
+  esac
+}
+
+# Run the installer unless this script is being sourced (for example by the
+# unit tests), in which case only the function definitions above are loaded.
+if ! (return 0 2>/dev/null); then
+  main "$@"
+fi

--- a/test/test-install-unit.sh
+++ b/test/test-install-unit.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Unit tests for the quick install script (install.sh).
+#
+# These source install.sh to load its functions and exercise the pure
+# detection / name / URL-building logic. No network calls or installs happen,
+# so the tests run anywhere (including CI runners without an arm64 host). The
+# end-to-end install path is covered separately by test/test-apt.sh,
+# test/test-yum.sh, and test/test-zypper.sh under Docker.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Sourcing install.sh loads its functions without running main() (see the guard
+# at the bottom of install.sh). Run from a temporary directory so download_url's
+# "installer already present" short-circuit never triggers on a stray file.
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_TEST}"' EXIT
+cd "${TMPDIR_TEST}"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../install.sh"
+
+# A fixed version list so valid_version / get_version don't depend on the CDN.
+# Mirrors load_r_versions output: newest numeric first, devel/next at the end.
+R_VERSIONS=$'4.6.1\n4.6.0\n4.5.3\ndevel\nnext'
+
+fail=0
+pass=0
+
+# assert_eq <description> <expected> <actual>
+assert_eq () {
+  local desc=$1 expected=$2 actual=$3
+  if [[ "${expected}" == "${actual}" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: ${desc}"
+    echo "        expected: [${expected}]"
+    echo "        actual:   [${actual}]"
+  fi
+}
+
+# assert_arch_unsupported <description> <os> <version> <arch>
+# download_name must exit non-zero and print nothing for architectures we
+# don't publish packages for.
+assert_arch_unsupported () {
+  local desc=$1 os=$2 version=$3 arch=$4 out rc
+  out=$(download_name "${os}" "${version}" "${arch}")
+  rc=$?
+  if [[ "${rc}" -ne 0 && -z "${out}" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: ${desc}"
+    echo "        expected: non-zero exit and empty output"
+    echo "        actual:   rc=${rc} out=[${out}]"
+  fi
+}
+
+# assert_do_install_error <description> <os> <arch> <expected message substring>
+# Drives do_install with its side-effectful steps stubbed so only the arch/OS
+# guards run, and checks it exits 1 with the expected message. The stubs live in
+# the command-substitution subshell, so they don't leak into other tests.
+assert_do_install_error () {
+  local desc=$1 fake_os=$2 fake_arch=$3 want=$4 out rc
+  out=$(
+    check_commands () { :; }
+    detect_os () { echo "${fake_os}"; }
+    detect_os_version () { echo "9"; }
+    prompt_version () { :; }
+    uname () { echo "${fake_arch}"; }
+    SELECTED_VERSION=4.6.1
+    do_install 2>&1
+  )
+  rc=$?
+  if [[ "${rc}" -eq 1 && "${out}" == *"${want}"* ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: ${desc}"
+    echo "        expected: exit 1 with substring [${want}]"
+    echo "        actual:   rc=${rc} out=[${out}]"
+  fi
+}
+
+echo "== sourcing guard: main() does not run when sourced =="
+# main() is the only place that sets SCRIPT_ACTION. If the source guard in
+# install.sh regressed, sourcing would run the installer (network fetch, prompt,
+# or a real package install) instead of just loading functions.
+assert_eq "SCRIPT_ACTION unset after sourcing" "" "${SCRIPT_ACTION:-}"
+
+echo "== detect_installer_type =="
+assert_eq "ubuntu -> deb"   "deb" "$(detect_installer_type Ubuntu)"
+assert_eq "debian -> deb"   "deb" "$(detect_installer_type Debian)"
+assert_eq "redhat -> rpm"   "rpm" "$(detect_installer_type RedHat)"
+assert_eq "fedora -> rpm"   "rpm" "$(detect_installer_type Fedora)"
+assert_eq "centos -> rpm"   "rpm" "$(detect_installer_type CentOS)"
+assert_eq "alma -> rpm"     "rpm" "$(detect_installer_type Alma)"
+assert_eq "rocky -> rpm"    "rpm" "$(detect_installer_type Rocky)"
+assert_eq "oracle -> rpm"   "rpm" "$(detect_installer_type Oracle)"
+assert_eq "amazon -> rpm"   "rpm" "$(detect_installer_type Amazon)"
+assert_eq "sles12 -> rpm"   "rpm" "$(detect_installer_type SLES12)"
+assert_eq "sles1x -> rpm"   "rpm" "$(detect_installer_type SLES1X)"
+assert_eq "leap12 -> rpm"   "rpm" "$(detect_installer_type LEAP12)"
+assert_eq "leap1x -> rpm"   "rpm" "$(detect_installer_type LEAP1X)"
+
+echo "== download_name: deb (Ubuntu/Debian) =="
+assert_eq "ubuntu aarch64 -> arm64 deb" "r-4.6.1_1_arm64.deb" "$(download_name Ubuntu 4.6.1 aarch64)"
+assert_eq "ubuntu arm64   -> arm64 deb" "r-4.6.1_1_arm64.deb" "$(download_name Ubuntu 4.6.1 arm64)"
+assert_eq "ubuntu x86_64  -> amd64 deb" "r-4.6.1_1_amd64.deb" "$(download_name Ubuntu 4.6.1 x86_64)"
+assert_eq "ubuntu amd64   -> amd64 deb" "r-4.6.1_1_amd64.deb" "$(download_name Ubuntu 4.6.1 amd64)"
+assert_eq "debian aarch64 -> arm64 deb" "r-4.6.1_1_arm64.deb" "$(download_name Debian 4.6.1 aarch64)"
+assert_eq "debian arm64   -> arm64 deb" "r-4.6.1_1_arm64.deb" "$(download_name Debian 4.6.1 arm64)"
+
+echo "== download_name: rpm (RedHat family / SUSE) =="
+assert_eq "redhat aarch64 -> aarch64 rpm" "R-4.6.1-1-1.aarch64.rpm" "$(download_name RedHat 4.6.1 aarch64)"
+assert_eq "redhat arm64   -> aarch64 rpm" "R-4.6.1-1-1.aarch64.rpm" "$(download_name RedHat 4.6.1 arm64)"
+assert_eq "redhat x86_64  -> x86_64 rpm"  "R-4.6.1-1-1.x86_64.rpm"  "$(download_name RedHat 4.6.1 x86_64)"
+assert_eq "rocky aarch64  -> aarch64 rpm" "R-4.6.1-1-1.aarch64.rpm" "$(download_name Rocky 4.6.1 aarch64)"
+assert_eq "fedora arm64   -> aarch64 rpm" "R-4.6.1-1-1.aarch64.rpm" "$(download_name Fedora 4.6.1 arm64)"
+assert_eq "oracle aarch64 -> aarch64 rpm" "R-4.6.1-1-1.aarch64.rpm" "$(download_name Oracle 4.6.1 aarch64)"
+assert_eq "sles1x aarch64 -> aarch64 rpm" "R-4.6.1-1-1.aarch64.rpm" "$(download_name SLES1X 4.6.1 aarch64)"
+assert_eq "sles12 x86_64  -> x86_64 rpm"  "R-4.6.1-1-1.x86_64.rpm"  "$(download_name SLES12 4.6.1 x86_64)"
+
+echo "== download_name: unsupported architectures fail cleanly =="
+assert_arch_unsupported "ubuntu i386"    Ubuntu 4.6.1 i386
+assert_arch_unsupported "ubuntu riscv64" Ubuntu 4.6.1 riscv64
+assert_arch_unsupported "redhat ppc64le" RedHat 4.6.1 ppc64le
+assert_arch_unsupported "ubuntu empty"   Ubuntu 4.6.1 ""
+
+echo "== do_install: fail-fast messages =="
+assert_do_install_error "unsupported arch -> arch message" RedHat ppc64le \
+  "Unsupported architecture 'ppc64le'"
+# A distro detect_os can name but download_name has no case for (e.g. an Ubuntu
+# derivative) is an unsupported OS, not an unsupported arch.
+assert_do_install_error "unsupported os -> os message" LinuxMint x86_64 \
+  "No R package is available for LinuxMint"
+
+echo "== download_url =="
+assert_eq "ubuntu 2404 arm64" \
+  "https://cdn.posit.co/r/ubuntu-2404/pkgs/r-4.6.1_1_arm64.deb" \
+  "$(download_url Ubuntu r-4.6.1_1_arm64.deb 2404)"
+assert_eq "ubuntu 2404 amd64" \
+  "https://cdn.posit.co/r/ubuntu-2404/pkgs/r-4.6.1_1_amd64.deb" \
+  "$(download_url Ubuntu r-4.6.1_1_amd64.deb 2404)"
+assert_eq "debian 13 arm64" \
+  "https://cdn.posit.co/r/debian-13/pkgs/r-4.6.1_1_arm64.deb" \
+  "$(download_url Debian r-4.6.1_1_arm64.deb 13)"
+assert_eq "rhel 9 aarch64" \
+  "https://cdn.posit.co/r/rhel-9/pkgs/R-4.6.1-1-1.aarch64.rpm" \
+  "$(download_url RedHat R-4.6.1-1-1.aarch64.rpm 9)"
+assert_eq "rhel 10 aarch64" \
+  "https://cdn.posit.co/r/rhel-10/pkgs/R-4.6.1-1-1.aarch64.rpm" \
+  "$(download_url RedHat R-4.6.1-1-1.aarch64.rpm 10)"
+assert_eq "el 8 -> centos-8" \
+  "https://cdn.posit.co/r/centos-8/pkgs/R-4.6.1-1-1.aarch64.rpm" \
+  "$(download_url RedHat R-4.6.1-1-1.aarch64.rpm 8)"
+assert_eq "rocky 9 aarch64" \
+  "https://cdn.posit.co/r/rhel-9/pkgs/R-4.6.1-1-1.aarch64.rpm" \
+  "$(download_url Rocky R-4.6.1-1-1.aarch64.rpm 9)"
+assert_eq "fedora 42 aarch64" \
+  "https://cdn.posit.co/r/fedora-42/pkgs/R-4.6.1-1-1.aarch64.rpm" \
+  "$(download_url Fedora R-4.6.1-1-1.aarch64.rpm 42)"
+assert_eq "opensuse 156 aarch64" \
+  "https://cdn.posit.co/r/opensuse-156/pkgs/R-4.6.1-1-1.aarch64.rpm" \
+  "$(download_url SLES1X R-4.6.1-1-1.aarch64.rpm 156)"
+assert_eq "opensuse 160 aarch64" \
+  "https://cdn.posit.co/r/opensuse-160/pkgs/R-4.6.1-1-1.aarch64.rpm" \
+  "$(download_url SLES1X R-4.6.1-1-1.aarch64.rpm 160)"
+
+echo "== download_url: local file short-circuits download =="
+touch r-4.6.1_1_arm64.deb
+assert_eq "existing installer -> empty url" "" "$(download_url Ubuntu r-4.6.1_1_arm64.deb 2404)"
+rm -f r-4.6.1_1_arm64.deb
+
+echo "== valid_version / get_version =="
+assert_eq "valid_version present"    "4.6.1" "$(valid_version 4.6.1)"
+assert_eq "valid_version absent"     ""      "$(valid_version 9.9.9)"
+assert_eq "get_version latest"       "4.6.1" "$(get_version latest)"
+assert_eq "get_version exact"        "4.5.3" "$(get_version 4.5.3)"
+assert_eq "get_version unknown"      ""      "$(get_version 1.0.0)"
+
+echo
+echo "install.sh unit tests: ${pass} passed, ${fail} failed"
+if [[ "${fail}" -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
`download_name` only recognized `aarch64`, so an `arm64` arch string (or any unknown arch) built a bad package URL that 404s instead of failing with a clear error. This maps `arm64` to the same packages, fails fast on anything unsupported, and adds offline unit tests so the arch logic is covered in CI without an arm64 host.

Fixes an issue reported by @bschwedler about arm64 PPM images failing to install R properly via the quick install script.

---

## Changes

- Map `arm64` as an alias for `aarch64`, covering both the deb and rpm package names.
- Fail fast when there's nothing to install, reporting an unsupported architecture and an unsupported OS (e.g. an Ubuntu derivative) separately instead of building a 404 URL.
- Make `install.sh` sourceable: move arg/env parsing and dispatch into `main()`, the `versions.json` fetch into `load_r_versions()`, and guard execution so curl-pipe, piped, and direct runs are unchanged while sourcing loads only the functions.
- Add `test/test-install-unit.sh`: 50 offline assertions (both arches, both package types, the failure paths, and the source guard), wired into `make unit-test`.
- Bump the script version to 1.3.0.

## Testing

- `make unit-test`: 50 passed.
- End-to-end on emulated arm64 via the curl-pipe form: Ubuntu 24.04 installs the arm64 deb, Rocky 9 installs the aarch64 rpm, R 4.6.1 runs in both (exit 0).
- arm64 packages confirmed on the CDN for ubuntu-2404 (deb) and rhel-9/10, opensuse-156, fedora-42, centos-7 (rpm).
