### PR TITLE
Disable Cloudsmith publishing for the daily devel/next builds

### DIFF
--- a/.github/workflows/devel-daily.yml
+++ b/.github/workflows/devel-daily.yml
@@ -44,7 +44,12 @@ jobs:
       r_versions: 'devel,next'
       publish: production
       package_version: ${{ needs.generate-version.outputs.package_version }}
-      publish_cloudsmith: ${{ inputs.publish_cloudsmith || 'posit/open' }}
+      # Cloudsmith publishing is temporarily disabled for the scheduled run to
+      # stop the daily devel/next uploads from consuming Cloudsmith artifact
+      # storage. The daily S3/CDN builds continue. Manual workflow_dispatch runs
+      # can still publish to Cloudsmith (defaulting to posit/open). Re-enable by
+      # dropping the `github.event_name == 'schedule'` guard below.
+      publish_cloudsmith: ${{ github.event_name == 'schedule' && '' || (inputs.publish_cloudsmith || 'posit/open') }}
       cloudsmith_dry_run: ${{ inputs.cloudsmith_dry_run || false }}
     secrets: inherit
 


### PR DESCRIPTION
## Why

We're over our Cloudsmith artifact-storage allowance. The daily devel/next workflow uploads a new date-versioned `R-next`/`R-devel` package for every platform × architecture each night (~50/day), which is the main source of growth in `posit/open`.

## Change

Skip Cloudsmith publishing on the **scheduled** run by passing an empty `publish_cloudsmith`, while keeping the daily **S3/CDN** builds intact (people rely on daily R-devel there). Manual `workflow_dispatch` runs can still publish to Cloudsmith (default `posit/open`).

```yaml
publish_cloudsmith: ${{ github.event_name == 'schedule' && '' || (inputs.publish_cloudsmith || 'posit/open') }}
```

Re-enable later by dropping the `github.event_name == 'schedule'` guard.

## Notes

- This is a stopgap for the storage overage. The retention work in #327 is the longer-term fix (prune old nightlies); this PR just stops adding to the pile now. If both land, #327's prune step becomes a no-op for scheduled runs until Cloudsmith publishing is re-enabled — worth reconciling the `prune-cloudsmith` job's `if:` guard there.
- Existing accumulated `R-next`/`R-devel` versions in `posit/open` are not removed by this PR; that's either #327 (once re-enabled) or a manual prune.