### PR TITLE
Fix R 4.2.2 build on Fedora 44

### DIFF
--- a/builder/Dockerfile.fedora-44
+++ b/builder/Dockerfile.fedora-44
@@ -35,7 +35,7 @@ RUN dnf -y upgrade \
     tex \
     texinfo-tex \
     texlive-collection-latexrecommended \
-    texlive-rsfs \
+    texlive-rsfs `# Only R 4.2.2 needs this to build an .Rnw` \
     tk-devel \
     unzip \
     valgrind-devel \

--- a/builder/Dockerfile.fedora-44
+++ b/builder/Dockerfile.fedora-44
@@ -35,6 +35,7 @@ RUN dnf -y upgrade \
     tex \
     texinfo-tex \
     texlive-collection-latexrecommended \
+    texlive-rsfs \
     tk-devel \
     unzip \
     valgrind-devel \


### PR DESCRIPTION
Apparently, this R version on this Fedora version needs an extra (la)tex package. I tested this locally.