### PR TITLE
Fix nightly Cloudsmith publish failures (ubuntu-2604, musllinux)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,15 +385,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install cloudsmith-cli
-        run: pip install --upgrade cloudsmith-cli
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: r-${{ matrix.r_version }}-${{ matrix.platform }}-${{ matrix.arch }}
-          path: packages/
-
+      # This must run before the artifact download: portable platforms (e.g.
+      # musllinux) produce no deb/rpm, so no artifact exists for them and an
+      # unconditional download-artifact would fail the job before the skip
+      # check is ever reached.
       - name: Determine package type and Cloudsmith distro
         id: pkg-info
         env:
@@ -413,6 +408,17 @@ jobs:
             echo "pkg_type=$(echo "$info" | jq -r '.pkg_type')" >> "$GITHUB_OUTPUT"
             echo "pkg_pattern=$(echo "$info" | jq -r '.pkg_pattern')" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Install cloudsmith-cli
+        if: ${{ steps.pkg-info.outputs.skip != 'true' }}
+        run: pip install --upgrade cloudsmith-cli
+
+      - name: Download build artifacts
+        if: ${{ steps.pkg-info.outputs.skip != 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: r-${{ matrix.r_version }}-${{ matrix.platform }}-${{ matrix.arch }}
+          path: packages/
 
       - name: Find and publish package
         if: ${{ steps.pkg-info.outputs.skip != 'true' }}

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - R_VERSION=${R_VERSION}
       - R_INSTALL_PATH=${R_INSTALL_PATH:-}
       - LOCAL_STORE=/tmp/output
+      - PACKAGE_VERSION=${PACKAGE_VERSION}
     build:
       context: .
       dockerfile: Dockerfile.ubuntu-2604

--- a/test_get_matrix.py
+++ b/test_get_matrix.py
@@ -68,3 +68,43 @@ def test_cloudsmith_info_unknown_raises():
     except KeyError:
         return
     raise AssertionError("expected KeyError for unknown platform")
+
+
+def _compose_services(path='builder/docker-compose.yml'):
+    """Parse the compose file into {service_name: [lines]} using a simple
+    indentation-based scan (stdlib only, per project convention)."""
+    services = {}
+    current = None
+    with open(path) as f:
+        for line in f:
+            stripped = line.rstrip('\n')
+            # Service names sit at 2-space indent, e.g. "  ubuntu-2604:"
+            if stripped.startswith('  ') and not stripped.startswith('   ') \
+                    and stripped.endswith(':'):
+                current = stripped.strip()[:-1]
+                services[current] = []
+            elif current is not None:
+                services[current].append(stripped)
+    return services
+
+
+def test_compose_distro_services_declare_package_version():
+    """Every distro platform's compose service must pass PACKAGE_VERSION through
+    to the package script. Without it, the script defaults to version 1 and the
+    daily devel/next Cloudsmith publishes collide with the existing package@1
+    every night (this is how ubuntu-2604 broke the nightly for weeks).
+    Portable platforms are exempt: they ship version-less tarballs/apk."""
+    services = _compose_services()
+    missing = []
+    for platform in get_matrix.CLOUDSMITH_DISTROS:
+        lines = services.get(platform)
+        assert lines is not None, (
+            f"No service named '{platform}' in builder/docker-compose.yml"
+        )
+        if not any('PACKAGE_VERSION=${PACKAGE_VERSION}' in l for l in lines):
+            missing.append(platform)
+    assert not missing, (
+        f"Compose services missing PACKAGE_VERSION in environment: {missing}. "
+        f"Add '- PACKAGE_VERSION=${{PACKAGE_VERSION}}' to each service's "
+        f"environment in builder/docker-compose.yml."
+    )


### PR DESCRIPTION
## Problem

Every nightly devel/next run has failed for weeks. Breakdown of the last 14 nights' failed jobs:

| Failure | Count | Cause |
|---|---|---|
| `Cloudsmith musllinux_1_2-*` | 36 | `Artifact not found for name: r-devel-musllinux_1_2-*` |
| `Cloudsmith ubuntu-2604-*` | 32 | `r-devel@1 already exists ... "Replace Package w/ Same Version" not enabled` |
| misc (fedora-44 teething, apt flakes) | ~8 | transient |

## Root causes & fixes

**ubuntu-2604** — its `builder/docker-compose.yml` service was missing `PACKAGE_VERSION=${PACKAGE_VERSION}` (every other distro service has it), so the package script fell back to its default of `1` instead of the nightly date version. Every push after the first collided with the existing `r-devel@1`/`r-next@1`. One-line fix adding the env passthrough.

**musllinux_1_2** — portable builds produce APK/tarball, no deb/rpm, so the build job uploads no Cloudsmith artifact (`if-no-files-found: warn`). The publish job's unconditional `download-artifact` step then hard-failed *before* the portable-skip check (added in #322) ran one step later. Fix: run the skip check first, and gate the cloudsmith-cli install, artifact download, and publish steps on it. (manylinux dodged this only because its portable builds happen to emit deb/rpm.)

**Prevention** — new test in `test_get_matrix.py` asserting every `CLOUDSMITH_DISTROS` platform's compose service declares `PACKAGE_VERSION`, so this class of platform-checklist drift fails at PR time instead of silently breaking the nightly. Verified the test fails against current `main` and passes with the fix.

## Test

`make unit-test` — 8/8 in `test_get_matrix.py`; workflow + compose YAML validated.